### PR TITLE
Add `nltk` and `requests` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+nltk
+requests
 spacy


### PR DESCRIPTION
`test/snli.py` uses both `nltk` and `requests` but neither are in `requirements.txt`. Most importantly, `requests` is core to retrieving many of the datasets. Without these in `requirements.txt` users will experience ModuleNotFoundError errors.