### PR TITLE
Trees and fixes for SNLI

### DIFF
--- a/torchtext/data.py
+++ b/torchtext/data.py
@@ -234,11 +234,13 @@ class Example(object):
     @classmethod
     def fromdict(cls, data, fields):
         ex = cls()
-        for key, val in data.items():
-            if key in fields:
-                name, field = fields[key]
-                if field is not None:
-                    setattr(ex, name, field.preprocess(val))
+        for key, vals in fields.items():
+            if key in data and vals is not None:
+                if not isinstance(vals, list):
+                    vals = [vals]
+                for val in vals:
+                    name, field = val
+                    setattr(ex, name, field.preprocess(data[key]))
         return ex
 
     @classmethod
@@ -371,7 +373,6 @@ class ZipDataset(Dataset):
         return os.path.join(path, '')
 
 
-
 class TabularDataset(Dataset):
     """Defines a Dataset of columns stored in CSV, TSV, or JSON format."""
 
@@ -398,7 +399,12 @@ class TabularDataset(Dataset):
             examples = [make_example(line, fields) for line in f]
 
         if make_example in (Example.fromdict, Example.fromJSON):
-            fields = fields.values()
+            fields, field_dict = [], fields
+            for field in field_dict.values():
+                if isinstance(field, list):
+                    fields.extend(field)
+                else:
+                    fields.append(field)
 
         super(TabularDataset, self).__init__(examples, fields, **kwargs)
 

--- a/torchtext/datasets/snli.py
+++ b/torchtext/datasets/snli.py
@@ -3,34 +3,25 @@ import os
 from .. import data
 
 
-def transitions(parse):
-    return ['reduce' if t == ')' else 'shift' for t in parse if t != '(']
-
-
-def tokens(parse):
-    return [t for t in parse if t not in ('(', ')')]
-
-
 class ShiftReduceField(data.Field):
 
-    def __init__(self, init_token=None, eos_token=None, fix_length=None,
-                 lower=False):
+    def __init__(self):
 
-        super(ShiftReduceField, self).__init__(
-            init_token=init_token, eos_token=eos_token, fix_length=fix_length,
-            lower=lower, preprocessing=transitions)
+        super(ShiftReduceField, self).__init__(preprocessing=lambda parse: [
+            'reduce' if t == ')' else 'shift' for t in parse if t != '('])
 
-        self.build_vocab([['shift'], ['reduce']])
+        self.build_vocab([['reduce'], ['shift']])
 
 
 class ParsedTextField(data.Field):
 
-    def __init__(self, init_token=None, eos_token=None, fix_length=None,
-                 lower=False):
+    def __init__(self, eos_token='<pad>', lower=False):
 
         super(ParsedTextField, self).__init__(
-            init_token=init_token, eos_token=eos_token, fix_length=fix_length,
-            lower=lower, preprocessing=tokens)
+            eos_token=eos_token, lower=lower, preprocessing=lambda parse: [
+                t for t in parse if t not in ('(', ')')],
+            postprocessing=lambda parse, _, __: [
+                list(reversed(p)) for p in parse])
 
 
 class SNLI(data.ZipDataset, data.TabularDataset):

--- a/torchtext/datasets/snli.py
+++ b/torchtext/datasets/snli.py
@@ -2,6 +2,37 @@ import os
 
 from .. import data
 
+
+def transitions(parse):
+    return ['reduce' if t == ')' else 'shift' for t in parse if t != '(']
+
+
+def tokens(parse):
+    return [t for t in parse if t not in ('(', ')')]
+
+
+class ShiftReduceField(data.Field):
+
+    def __init__(self, init_token=None, eos_token=None, fix_length=None,
+                 lower=False):
+
+        super(ShiftReduceField, self).__init__(
+            init_token=init_token, eos_token=eos_token, fix_length=fix_length,
+            lower=lower, preprocessing=transitions)
+
+        self.build_vocab([['shift'], ['reduce']])
+
+
+class ParsedTextField(data.Field):
+
+    def __init__(self, init_token=None, eos_token=None, fix_length=None,
+                 lower=False):
+
+        super(ParsedTextField, self).__init__(
+            init_token=init_token, eos_token=eos_token, fix_length=fix_length,
+            lower=lower, preprocessing=tokens)
+
+
 class SNLI(data.ZipDataset, data.TabularDataset):
 
     url = 'http://nlp.stanford.edu/projects/snli/snli_1.0.zip'
@@ -14,7 +45,7 @@ class SNLI(data.ZipDataset, data.TabularDataset):
             len(ex.premise), len(ex.hypothesis))
 
     @classmethod
-    def splits(cls, text_field, label_field, root='.', trees=False,
+    def splits(cls, text_field, label_field, parse_field=None, root='.',
                train='train.jsonl', validation='dev.jsonl', test='test.jsonl'):
         """Create dataset objects for splits of the SNLI dataset.
 
@@ -24,8 +55,8 @@ class SNLI(data.ZipDataset, data.TabularDataset):
             text_field: The field that will be used for premise and hypothesis
                 data.
             label_field: The field that will be used for label data.
-            trees: Whether to include the parse trees provided with the SNLI
-                dataset (not implemented).
+            parse_field: The field that will be used for shift-reduce parser
+                transitions, or None to not include them.
             root: The root directory that the dataset's zip archive will be
                 expanded into; therefore the directory in whose snli_1.0
                 subdirectory the data files will be stored.
@@ -35,20 +66,28 @@ class SNLI(data.ZipDataset, data.TabularDataset):
             test: The filename of the test data, or None to not load the test
                 set. Default: 'test.jsonl'.
         """
-        if trees:
-            # TODO
-            raise NotImplementedError
         path = cls.download_or_unzip(root)
+        if parse_field is None:
+            return super(SNLI, cls).splits(
+                os.path.join(path, 'snli_1.0_'), train, validation, test,
+                format='json', fields={'sentence1': ('premise', text_field),
+                                       'sentence2': ('hypothesis', text_field),
+                                       'gold_label': ('label', label_field)},
+                filter_pred=lambda ex: ex.label != '-')
         return super(SNLI, cls).splits(
             os.path.join(path, 'snli_1.0_'), train, validation, test,
-            format='json', fields={'sentence1': ('premise', text_field),
-                                   'sentence2': ('hypothesis', text_field),
+            format='json', fields={'sentence1_binary_parse':
+                                   [('premise', text_field),
+                                    ('premise_transitions', parse_field)],
+                                   'sentence2_binary_parse':
+                                   [('hypothesis', text_field),
+                                    ('hypothesis_transitions', parse_field)],
                                    'gold_label': ('label', label_field)},
             filter_pred=lambda ex: ex.label != '-')
 
     @classmethod
     def iters(cls, batch_size=32, device=0, root='.', wv_dir='.',
-              wv_type=None, wv_dim='300d', **kwargs):
+              wv_type=None, wv_dim='300d', trees=False, **kwargs):
         """Create iterator objects for splits of the SNLI dataset.
 
         This is the simplest way to use the dataset, and assumes common
@@ -64,12 +103,20 @@ class SNLI(data.ZipDataset, data.TabularDataset):
             wv_dir, wv_type, wv_dim: Passed to the Vocab constructor for the
                 text field. The word vectors are accessible as
                 train.dataset.fields['text'].vocab.vectors.
+            trees: Whether to include shift-reduce parser transitions.
+                Default: False.
             Remaining keyword arguments: Passed to the splits method.
         """
-        TEXT = data.Field(tokenize='spacy')
+        if trees:
+            TEXT = ParsedTextField()
+            TRANSITIONS = ShiftReduceField()
+        else:
+            TEXT = data.Field(tokenize='spacy')
+            TRANSITIONS = None
         LABEL = data.Field(sequential=False)
 
-        train, val, test = cls.splits(TEXT, LABEL, root=root, **kwargs)
+        train, val, test = cls.splits(
+            TEXT, LABEL, TRANSITIONS, root=root, **kwargs)
 
         TEXT.build_vocab(train, wv_dir=wv_dir, wv_type=wv_type, wv_dim=wv_dim)
         LABEL.build_vocab(train)


### PR DESCRIPTION
Adds the functionality I use in https://github.com/jekbradbury/examples/blob/spinn/snli/spinn.py, which creates shift+reduce parser transitions from the parse trees provided by SNLI. Also fixes #13.