### PR TITLE
fix bug in preprocess field

### DIFF
--- a/torchtext/data.py
+++ b/torchtext/data.py
@@ -135,7 +135,9 @@ class Field(object):
         if self.sequential and isinstance(x, six.string_types):
             x = self.tokenize(x)
         if self.lower:
-            x = Pipeline(six.text_type.lower)(six.text_type(x))
+            pipeline = Pipeline(six.text_type)
+            pipeline.add_after(six.text_type.lower)
+            x = pipeline(x)
         return self.preprocessing(x)
 
     def pad(self, minibatch):


### PR DESCRIPTION
Fix bug when `six.text_type` converts a list into a string.