### PR TITLE
utf-8 encoding

### DIFF
--- a/torchtext/data.py
+++ b/torchtext/data.py
@@ -415,7 +415,7 @@ class TabularDataset(Dataset):
             'tsv': Example.fromTSV, 'csv': Example.fromCSV}[format.lower()]
 
         with open(os.path.expanduser(path)) as f:
-            examples = [make_example(line, fields) for line in f]
+            examples = [make_example(line.decode('utf-8'), fields) for line in f]
 
         if make_example in (Example.fromdict, Example.fromJSON):
             fields, field_dict = [], fields


### PR DESCRIPTION
For python 2.*, if the dataset contains special tokens, there are encoding errors to read the files.

A better way to fix this problem is to add an argument to indicate the encoding of the input file.