### PR TITLE
Add tests for simple Field methods

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -50,7 +50,10 @@ source activate testenv
 # Install requirements via pip in our conda environment
 pip install -r requirements.txt
 
-# Install PyTorch if we are running tests
+# Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
+    # SpaCy English models
+    python -m spacy download en
+    # PyTorch
     conda install --yes pytorch torchvision -c soumith
 fi

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -18,3 +18,63 @@ class TestField(TestCase):
         field_not_sequential = data.Field(sequential=False, lower=True,
                                           preprocessing=preprocess_pipeline)
         assert field_not_sequential.preprocess("Test string.") == "test string.!"
+
+    def test_pad(self):
+        field = data.Field()
+        minibatch = [["a", "sentence", "of", "data", "."],
+                     ["yet", "another"],
+                     ["one", "last", "sent"]]
+        expected_padded_minibatch = [["a", "sentence", "of", "data", "."],
+                                     ["yet", "another", "<pad>", "<pad>", "<pad>"],
+                                     ["one", "last", "sent", "<pad>", "<pad>"]]
+        expected_lengths = [5, 2, 3]
+
+        assert field.pad(minibatch) == expected_padded_minibatch
+        field = data.Field(include_lengths=True)
+        assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
+
+        field = data.Field(fix_length=3)
+        minibatch = [["a", "sentence", "of", "data", "."],
+                     ["yet", "another"],
+                     ["one", "last", "sent"]]
+        expected_padded_minibatch = [["a", "sentence", "of"],
+                                     ["yet", "another", "<pad>"],
+                                     ["one", "last", "sent"]]
+        expected_lengths = [3, 2, 3]
+        assert field.pad(minibatch) == expected_padded_minibatch
+        field = data.Field(fix_length=3, include_lengths=True)
+        assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
+
+        field = data.Field(fix_length=4, init_token="<bos>")
+        minibatch = [["a", "sentence", "of", "data", "."],
+                     ["yet", "another"],
+                     ["one", "last", "sent"]]
+        expected_padded_minibatch = [["<bos>", "a", "sentence", "of"],
+                                     ["<bos>", "yet", "another", "<pad>"],
+                                     ["<bos>", "one", "last", "sent"]]
+        expected_lengths = [4, 3, 4]
+        assert field.pad(minibatch) == expected_padded_minibatch
+        field = data.Field(fix_length=4, init_token="<bos>", include_lengths=True)
+        assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
+
+        field = data.Field(init_token="<bos>", eos_token="<eos>")
+        minibatch = [["a", "sentence", "of", "data", "."],
+                     ["yet", "another"],
+                     ["one", "last", "sent"]]
+        expected_padded_minibatch = [
+            ["<bos>", "a", "sentence", "of", "data", ".", "<eos>"],
+            ["<bos>", "yet", "another", "<eos>", "<pad>", "<pad>", "<pad>"],
+            ["<bos>", "one", "last", "sent", "<eos>", "<pad>", "<pad>"]]
+        expected_lengths = [7, 4, 5]
+        assert field.pad(minibatch) == expected_padded_minibatch
+        field = data.Field(init_token="<bos>", eos_token="<eos>", include_lengths=True)
+        assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
+
+        field = data.Field(init_token="<bos>", eos_token="<eos>", sequential=False)
+        minibatch = [["contradiction"],
+                     ["neutral"],
+                     ["entailment"]]
+        assert field.pad(minibatch) == minibatch
+        field = data.Field(init_token="<bos>", eos_token="<eos>",
+                           sequential=False, include_lengths=True)
+        assert field.pad(minibatch) == minibatch

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -2,8 +2,8 @@ from unittest import TestCase
 import torchtext.data as data
 
 
-class TestData(TestCase):
-    def test_field_preprocess(self):
+class TestField(TestCase):
+    def test_preprocess(self):
         field = data.Field()
         assert field.preprocess("Test string.") == ["Test", "string."]
 

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -1,4 +1,6 @@
 from unittest import TestCase
+
+import six
 import torchtext.data as data
 
 
@@ -94,7 +96,7 @@ class TestField(TestCase):
         assert data.get_tokenizer(str.split)(test_str) == str.split(test_str)
 
         # Test SpaCy option, and verify it properly handles punctuation.
-        assert data.get_tokenizer("spacy")(test_str) == [
+        assert data.get_tokenizer("spacy")(six.text_type(test_str)) == [
             "A", "string", ",", "particularly", "one", "with", "slightly",
             "complex", "punctuation", "."]
 

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -4,22 +4,27 @@ import torchtext.data as data
 
 class TestField(TestCase):
     def test_preprocess(self):
+        # Default case.
         field = data.Field()
         assert field.preprocess("Test string.") == ["Test", "string."]
 
+        # Test that lowercase is properly applied.
         field_lower = data.Field(lower=True)
         assert field_lower.preprocess("Test string.") == ["test", "string."]
 
+        # Test that custom preprocessing pipelines are properly applied.
         preprocess_pipeline = data.Pipeline(lambda x: x + "!")
         field_preprocessing = data.Field(preprocessing=preprocess_pipeline,
                                          lower=True)
         assert field_preprocessing.preprocess("Test string.") == ["test!", "string.!"]
 
+        # Test that non-sequential data is properly handled.
         field_not_sequential = data.Field(sequential=False, lower=True,
                                           preprocessing=preprocess_pipeline)
         assert field_not_sequential.preprocess("Test string.") == "test string.!"
 
     def test_pad(self):
+        # Default case.
         field = data.Field()
         minibatch = [["a", "sentence", "of", "data", "."],
                      ["yet", "another"],
@@ -28,11 +33,11 @@ class TestField(TestCase):
                                      ["yet", "another", "<pad>", "<pad>", "<pad>"],
                                      ["one", "last", "sent", "<pad>", "<pad>"]]
         expected_lengths = [5, 2, 3]
-
         assert field.pad(minibatch) == expected_padded_minibatch
         field = data.Field(include_lengths=True)
         assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
 
+        # Test fix_length properly truncates and pads.
         field = data.Field(fix_length=3)
         minibatch = [["a", "sentence", "of", "data", "."],
                      ["yet", "another"],
@@ -45,6 +50,7 @@ class TestField(TestCase):
         field = data.Field(fix_length=3, include_lengths=True)
         assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
 
+        # Test init_token is properly handled.
         field = data.Field(fix_length=4, init_token="<bos>")
         minibatch = [["a", "sentence", "of", "data", "."],
                      ["yet", "another"],
@@ -57,6 +63,7 @@ class TestField(TestCase):
         field = data.Field(fix_length=4, init_token="<bos>", include_lengths=True)
         assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
 
+        # Test init_token and eos_token are properly handled.
         field = data.Field(init_token="<bos>", eos_token="<eos>")
         minibatch = [["a", "sentence", "of", "data", "."],
                      ["yet", "another"],
@@ -70,6 +77,7 @@ class TestField(TestCase):
         field = data.Field(init_token="<bos>", eos_token="<eos>", include_lengths=True)
         assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
 
+        # Test that non-sequential data is properly handled.
         field = data.Field(init_token="<bos>", eos_token="<eos>", sequential=False)
         minibatch = [["contradiction"],
                      ["neutral"],

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -86,3 +86,20 @@ class TestField(TestCase):
         field = data.Field(init_token="<bos>", eos_token="<eos>",
                            sequential=False, include_lengths=True)
         assert field.pad(minibatch) == minibatch
+
+    def test_get_tokenizer(self):
+        # Test the default case with str.split
+        assert data.get_tokenizer(str.split) == str.split
+        test_str = "A string, particularly one with slightly complex punctuation."
+        assert data.get_tokenizer(str.split)(test_str) == str.split(test_str)
+
+        # Test SpaCy option, and verify it properly handles punctuation.
+        assert data.get_tokenizer("spacy")(test_str) == [
+            "A", "string", ",", "particularly", "one", "with", "slightly",
+            "complex", "punctuation", "."]
+
+        # Test that errors are raised for invalid input arguments.
+        with self.assertRaises(ValueError):
+            data.get_tokenizer(1)
+        with self.assertRaises(ValueError):
+            data.get_tokenizer("some other string")

--- a/torchtext/data/__init__.py
+++ b/torchtext/data/__init__.py
@@ -1,17 +1,17 @@
 from .batch import Batch
 from .dataset import Dataset, TabularDataset, ZipDataset
 from .example import Example
-from .field import Field, get_tokenizer
+from .field import Field
 from .iterator import (batch, BucketIterator, Iterator, BPTTIterator,
                        pool, shuffled)
 from .pipeline import Pipeline
-from .utils import interleave_keys
+from .utils import get_tokenizer, interleave_keys
 
 __all__ = ["Batch",
            "Dataset", "TabularDataset", "ZipDataset",
            "Example",
-           "Field", "get_tokenizer",
+           "Field",
            "batch", "BucketIterator", "Iterator", "BPTTIterator",
            "pool", "shuffled",
            "Pipeline",
-           "interleave_keys"]
+           "get_tokenizer", "interleave_keys"]

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -189,7 +189,7 @@ class Field(object):
 
 
 def get_tokenizer(tokenizer):
-    if not isinstance(tokenizer, six.string_types):
+    if callable(tokenizer):
         return tokenizer
     if tokenizer == 'spacy':
         try:
@@ -204,3 +204,7 @@ def get_tokenizer(tokenizer):
             print("Please install SpaCy and the SpaCy English tokenizer. "
                   "See the docs at https://spacy.io for more information.")
             raise
+    raise ValueError("Requested tokenizer {}, valid choices are a "
+                     "callable that takes a single string as input "
+                     "and \"spacy\" for the SpaCy English "
+                     "tokenizer.".format(tokenizer))

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -5,6 +5,7 @@ from torch.autograd import Variable
 
 from .dataset import Dataset
 from .pipeline import Pipeline
+from .utils import get_tokenizer
 from ..vocab import Vocab
 
 
@@ -186,25 +187,3 @@ class Field(object):
         if self.include_lengths:
             return Variable(arr, volatile=not train), lengths
         return Variable(arr, volatile=not train)
-
-
-def get_tokenizer(tokenizer):
-    if callable(tokenizer):
-        return tokenizer
-    if tokenizer == 'spacy':
-        try:
-            import spacy
-            spacy_en = spacy.load('en')
-            return lambda s: [tok.text for tok in spacy_en.tokenizer(s)]
-        except ImportError:
-            print("Please install SpaCy and the SpaCy English tokenizer. "
-                  "See the docs at https://spacy.io for more information.")
-            raise
-        except AttributeError:
-            print("Please install SpaCy and the SpaCy English tokenizer. "
-                  "See the docs at https://spacy.io for more information.")
-            raise
-    raise ValueError("Requested tokenizer {}, valid choices are a "
-                     "callable that takes a single string as input "
-                     "and \"spacy\" for the SpaCy English "
-                     "tokenizer.".format(tokenizer))

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -1,3 +1,25 @@
+def get_tokenizer(tokenizer):
+    if callable(tokenizer):
+        return tokenizer
+    if tokenizer == 'spacy':
+        try:
+            import spacy
+            spacy_en = spacy.load('en')
+            return lambda s: [tok.text for tok in spacy_en.tokenizer(s)]
+        except ImportError:
+            print("Please install SpaCy and the SpaCy English tokenizer. "
+                  "See the docs at https://spacy.io for more information.")
+            raise
+        except AttributeError:
+            print("Please install SpaCy and the SpaCy English tokenizer. "
+                  "See the docs at https://spacy.io for more information.")
+            raise
+    raise ValueError("Requested tokenizer {}, valid choices are a "
+                     "callable that takes a single string as input "
+                     "and \"spacy\" for the SpaCy English "
+                     "tokenizer.".format(tokenizer))
+
+
 def interleave_keys(a, b):
     """Interleave bits from two sort keys to form a joint sort key.
 


### PR DESCRIPTION
This PR adds tests for the relatively simple `Field` methods  `Field.pad` and `Field.preprocess` -- the others are a bit more involved (you'd need to create `Dataset`s to properly test them), so I think I want to go "from the ground up" and write the tests for `Dataset` / other things that this uses before coming back to finish it.

This PR also adds some input validation to `get_tokenizer` and moves the get_tokenizer function into `data.utils` (though its still accessible from `data.get_tokenizer`, so nothing should break)

In general, let me know if there are datatypes that these methods should accept but I do not test; it's a bit hard to infer at times what the intended input is.