### PR TITLE
fix and improve dynamic batching support

### DIFF
--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -13,12 +13,12 @@ class Iterator(object):
     Attributes:
         dataset: The Dataset object to load Examples from.
         batch_size: Batch size.
-        batch_size_fn: Function of three arguments (new example to add, example
-            index, and current effective batch size) that returns the new
-            effective batch size resulting from adding that example to a batch.
-            This is useful for dynamic batching, where this function would add
-            to the current effective batch size the number of tokens in the new
-            example.
+        batch_size_fn: Function of three arguments (new example to add, current
+            count of examples in the batch, and current effective batch size)
+            that returns the new effective batch size resulting from adding
+            that example to a batch. This is useful for dynamic batching, where
+            this function would add to the current effective batch size the
+            number of tokens in the new example.
         sort_key: A key to use for sorting examples in order to batch together
             examples with similar lengths and minimize padding. The sort_key
             provided to the Iterator constructor overrides the sort_key
@@ -34,7 +34,7 @@ class Iterator(object):
     """
 
     def __init__(self, dataset, batch_size, sort_key=None, device=None,
-                 batch_size_fn=lambda new, i, sofar: i + 1, train=True,
+                 batch_size_fn=lambda new, count, sofar: count, train=True,
                  repeat=None, shuffle=None, sort=None):
         self.batch_size, self.train, self.dataset = batch_size, train, dataset
         self.batch_size_fn = batch_size_fn
@@ -178,15 +178,18 @@ class BucketIterator(Iterator):
             self.iterations = 0
 
 
-def batch(data, batch_size, batch_size_fn=lambda new, i, sofar: i + 1):
+def batch(data, batch_size, batch_size_fn=lambda new, count, sofar: count):
     """Yield elements from data in chunks of batch_size."""
     minibatch, size_so_far = [], 0
     for ex in data:
         minibatch.append(ex)
-        size_so_far = batch_size_fn(ex, size_so_far)
-        if size_so_far >= batch_size:
+        size_so_far = batch_size_fn(ex, len(minibatch), size_so_far)
+        if size_so_far == batch_size:
             yield minibatch
             minibatch, size_so_far = [], 0
+        elif size_so_far > batch_size:
+            yield minibatch[:-1]
+            minibatch, size_so_far = minibatch[:-1], batch_size_fn(ex, 1, 0)
     if minibatch:
         yield minibatch
 
@@ -197,7 +200,7 @@ def shuffled(data):
     return data
 
 
-def pool(data, batch_size, key, batch_size_fn=lambda new, i, sofar: i + 1):
+def pool(data, batch_size, key, batch_size_fn=lambda new, count, sofar: count):
     """Sort within buckets, then batch, then shuffle batches.
 
     Partitions data into chunks of size 100*batch_size, sorts examples within

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -13,11 +13,12 @@ class Iterator(object):
     Attributes:
         dataset: The Dataset object to load Examples from.
         batch_size: Batch size.
-        batch_size_fn: Function of two arguments (new example to add and
-            current effective batch size) that returns the new effective batch
-            size resulting from adding that example to a batch. This is useful
-            for dynamic batching, where this function would add to the current
-            effective batch size the number of tokens in the new example.
+        batch_size_fn: Function of three arguments (new example to add, example
+            index, and current effective batch size) that returns the new
+            effective batch size resulting from adding that example to a batch.
+            This is useful for dynamic batching, where this function would add
+            to the current effective batch size the number of tokens in the new
+            example.
         sort_key: A key to use for sorting examples in order to batch together
             examples with similar lengths and minimize padding. The sort_key
             provided to the Iterator constructor overrides the sort_key
@@ -33,7 +34,7 @@ class Iterator(object):
     """
 
     def __init__(self, dataset, batch_size, sort_key=None, device=None,
-                 batch_size_fn=lambda new, sofar: sofar + 1, train=True,
+                 batch_size_fn=lambda new, i, sofar: i + 1, train=True,
                  repeat=None, shuffle=None, sort=None):
         self.batch_size, self.train, self.dataset = batch_size, train, dataset
         self.batch_size_fn = batch_size_fn
@@ -177,7 +178,7 @@ class BucketIterator(Iterator):
             self.iterations = 0
 
 
-def batch(data, batch_size, batch_size_fn=lambda new, sofar: sofar + 1):
+def batch(data, batch_size, batch_size_fn=lambda new, i, sofar: i + 1):
     """Yield elements from data in chunks of batch_size."""
     minibatch, size_so_far = [], 0
     for ex in data:
@@ -196,7 +197,7 @@ def shuffled(data):
     return data
 
 
-def pool(data, batch_size, key, batch_size_fn=lambda new, sofar: sofar + 1):
+def pool(data, batch_size, key, batch_size_fn=lambda new, i, sofar: i + 1):
     """Sort within buckets, then batch, then shuffle batches.
 
     Partitions data into chunks of size 100*batch_size, sorts examples within


### PR DESCRIPTION
In one place I left an old (and now wrong) default for `batch_size_fn`; this PR fixes that.
It also changes the `batch_size_fn` API to take three arguments rather than one. This is intended to support the ability to use the total number of tokens in a batch (`max_len * num_examples`) as an effective batch size in addition to the number of non-padding tokens `sum(len(ex) for ex in batch)` (in some cases the former is the relevant quantity when it comes to memory use, in some cases it's the latter). I strongly suspect no one else is using that API right now, but this is slightly breaking if they are.