### PR TITLE
Savable iterator

### DIFF
--- a/torchtext/data/__init__.py
+++ b/torchtext/data/__init__.py
@@ -3,7 +3,7 @@ from .dataset import Dataset, TabularDataset, ZipDataset
 from .example import Example
 from .field import Field
 from .iterator import (batch, BucketIterator, Iterator, BPTTIterator,
-                       pool, shuffled)
+                       pool)
 from .pipeline import Pipeline
 from .utils import get_tokenizer, interleave_keys
 
@@ -12,6 +12,6 @@ __all__ = ["Batch",
            "Example",
            "Field",
            "batch", "BucketIterator", "Iterator", "BPTTIterator",
-           "pool", "shuffled",
+           "pool",
            "Pipeline",
            "get_tokenizer", "interleave_keys"]

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -114,12 +114,14 @@ class Iterator(object):
 
         if self._restored_from_state:
             self.random_shuffler.random_state = self._random_state_this_epoch
-            self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
-            self._restored_from_state = False
-
         else:
             self._random_state_this_epoch = deepcopy(self.random_shuffler.random_state)
-            self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
+
+        self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
+
+        if self._restored_from_state:
+            self._restored_from_state = False
+        else:
             self._iterations_this_epoch = 0
 
         if not self.repeat:

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -135,9 +135,7 @@ class Iterator(object):
     def __iter__(self):
         while True:
             self.init_epoch()
-            fast_forward = self._iterations_this_epoch
             for idx, minibatch in enumerate(self.batches):
-
                 # fast-forward if loaded from state
                 if self._iterations_this_epoch > idx:
                     continue

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -27,8 +27,7 @@ class RandomShuffler(object):
     def __call__(self, data):
         """Shuffle and return a new list."""
         with self.use_internal_state():
-            list_data = list(data)
-            return random.sample(list_data, len(list_data))
+            return random.sample(data, len(data))
 
 class Iterator(object):
     """Defines an iterator that loads batches of data from a Dataset.
@@ -274,5 +273,5 @@ def pool(data, batch_size, key, batch_size_fn=lambda new, count, sofar: count,
     if random_shuffler is None:
         random_shuffler = random.shuffle
     for p in batch(data, batch_size * 100, batch_size_fn):
-        for b in random_shuffler(batch(sorted(p, key=key), batch_size, batch_size_fn)):
+        for b in random_shuffler(list(batch(sorted(p, key=key), batch_size, batch_size_fn))):
             yield b

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -3,8 +3,6 @@ import random
 from contextlib import contextmanager
 from copy import deepcopy
 
-import torch
-
 from .batch import Batch
 from .dataset import Dataset
 

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from .batch import Batch
 from .dataset import Dataset
 
+
 class RandomShuffler(object):
     """Use random functions while keeping track of the random state to make it
     reproducible and deterministic."""
@@ -36,6 +37,7 @@ class RandomShuffler(object):
         """Shuffle and return a new list."""
         with self.use_internal_state():
             return random.sample(data, len(data))
+
 
 class Iterator(object):
     """Defines an iterator that loads batches of data from a Dataset.
@@ -170,6 +172,7 @@ class Iterator(object):
         self._random_state_this_epoch = state_dict["random_state_this_epoch"]
         self._restored_from_state = True
 
+
 class BPTTIterator(Iterator):
     """Defines an iterator for language modeling tasks that use BPTT.
 
@@ -271,5 +274,7 @@ def pool(data, batch_size, key, batch_size_fn=lambda new, count, sofar: count,
     if random_shuffler is None:
         random_shuffler = random.shuffle
     for p in batch(data, batch_size * 100, batch_size_fn):
-        for b in random_shuffler(list(batch(sorted(p, key=key), batch_size, batch_size_fn))):
+        shuffled = random_shuffler(list(batch(
+                sorted(p, key=key), batch_size, batch_size_fn)))
+        for b in shuffled:
             yield b

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -1,11 +1,34 @@
 import math
 import random
+from contextlib import contextmanager
+from copy import deepcopy
 
 import torch
 
 from .batch import Batch
 from .dataset import Dataset
 
+class RandomShuffler(object):
+    """Use random functions while keeping track of the random state to make it
+    reproducible and deterministic."""
+
+    def __init__(self, random_state=None):
+        self.random_state = random_state
+        if self.random_state is None:
+            self.random_state = random.getstate()
+
+    @contextmanager
+    def use_internal_state(self):
+        """Use a specific RNG state."""
+        old_state = random.getstate()
+        random.setstate(self.random_state)
+        yield
+        self.random_state = random.getstate()
+        random.setstate(old_state)
+
+    def shuffle(self, data):
+        with self.use_internal_state():
+            random.shuffle(data)
 
 class Iterator(object):
     """Defines an iterator that loads batches of data from a Dataset.
@@ -48,6 +71,13 @@ class Iterator(object):
             self.sort_key = sort_key
         self.device = device
 
+        self.random_shuffler = RandomShuffler()
+
+        # For state loading/saving only
+        self._iterations_this_epoch = 0
+        self._random_state_this_epoch = None
+        self._restored_from_state = False
+
     @classmethod
     def splits(cls, datasets, batch_sizes=None, **kwargs):
         """Create Iterator objects for multiple splits of a dataset.
@@ -72,7 +102,9 @@ class Iterator(object):
     def data(self):
         """Return the examples in the dataset in order, sorted, or shuffled."""
         if self.shuffle:
-            xs = [self.dataset[i] for i in torch.randperm(len(self.dataset))]
+            randperm = list(range(len(self.dataset)))
+            self.random_shuffler.shuffle(randperm)
+            xs = [self.dataset[i] for i in randperm]
         elif self.sort:
             xs = sorted(self.dataset, key=self.sort_key)
         else:
@@ -81,7 +113,17 @@ class Iterator(object):
 
     def init_epoch(self):
         """Set up the batch generator for a new epoch."""
-        self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
+
+        if self._restored_from_state:
+            self.random_shuffler.random_state = self._random_state_this_epoch
+            self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
+            self._restored_from_state = False
+
+        else:
+            self._random_state_this_epoch = deepcopy(self.random_shuffler.random_state)
+            self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
+            self._iterations_this_epoch = 0
+
         if not self.repeat:
             self.iterations = 0
 
@@ -95,13 +137,30 @@ class Iterator(object):
     def __iter__(self):
         while True:
             self.init_epoch()
-            for minibatch in self.batches:
+            fast_forward = self._iterations_this_epoch
+            for idx, minibatch in enumerate(self.batches):
+
+                # fast-forward if loaded from state
+                if self._iterations_this_epoch > idx:
+                    continue
                 self.iterations += 1
+                self._iterations_this_epoch += 1
                 yield Batch(minibatch, self.dataset, self.device,
                             self.train)
             if not self.repeat:
                 raise StopIteration
 
+    def state_dict(self):
+        return {
+            "iterations": self.iterations,
+            "iterations_this_epoch": self._iterations_this_epoch,
+            "random_state_this_epoch": self._random_state_this_epoch}
+
+    def load_state_dict(self, state_dict):
+        self.iterations = state_dict["iterations"]
+        self._iterations_this_epoch = state_dict["iterations_this_epoch"]
+        self._random_state_this_epoch = state_dict["random_state_this_epoch"]
+        self._restored_from_state = True
 
 class BPTTIterator(Iterator):
     """Defines an iterator for language modeling tasks that use BPTT.
@@ -168,12 +227,24 @@ class BucketIterator(Iterator):
     """
 
     def init_epoch(self):
+        if self._restored_from_state:
+            self.random_shuffler.random_state = self._random_state_this_epoch
+        else:
+            self._random_state_this_epoch = deepcopy(self.random_shuffler.random_state)
+
         if self.sort:
             self.batches = batch(self.data(), self.batch_size,
                                  self.batch_size_fn)
         else:
             self.batches = pool(self.data(), self.batch_size,
-                                self.sort_key, self.batch_size_fn)
+                                self.sort_key, self.batch_size_fn,
+                                random_shuffler=self.random_shuffler)
+
+        if self._restored_from_state:
+            self._restored_from_state = False
+        else:
+            self._iterations_this_epoch = 0
+
         if not self.repeat:
             self.iterations = 0
 
@@ -194,19 +265,22 @@ def batch(data, batch_size, batch_size_fn=lambda new, count, sofar: count):
         yield minibatch
 
 
-def shuffled(data):
+def shuffled(data, random_shuffler):
     data = list(data)
-    random.shuffle(data)
+    random_shuffler.shuffle(data)
     return data
 
 
-def pool(data, batch_size, key, batch_size_fn=lambda new, count, sofar: count):
+def pool(data, batch_size, key, batch_size_fn=lambda new, count, sofar: count,
+         random_shuffler=None):
     """Sort within buckets, then batch, then shuffle batches.
 
     Partitions data into chunks of size 100*batch_size, sorts examples within
     each chunk using sort_key, then batch these examples and shuffle the
     batches.
     """
+    if random_shuffler is None:
+        random_shuffler = random
     for p in batch(data, batch_size * 100, batch_size_fn):
-        for b in shuffled(batch(sorted(p, key=key), batch_size, batch_size_fn)):
+        for b in shuffled(batch(sorted(p, key=key), batch_size, batch_size_fn), random_shuffler):
             yield b

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -274,7 +274,6 @@ def pool(data, batch_size, key, batch_size_fn=lambda new, count, sofar: count,
     if random_shuffler is None:
         random_shuffler = random.shuffle
     for p in batch(data, batch_size * 100, batch_size_fn):
-        shuffled = random_shuffler(list(batch(
-                sorted(p, key=key), batch_size, batch_size_fn)))
-        for b in shuffled:
+        p_batch = batch(sorted(p, key=key), batch_size, batch_size_fn)
+        for b in random_shuffler(list(p_batch)):
             yield b

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -124,7 +124,7 @@ class Iterator(object):
         else:
             self._random_state_this_epoch = self.random_shuffler.random_state
 
-        self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
+        self.create_batches()
 
         if self._restored_from_state:
             self._restored_from_state = False
@@ -133,6 +133,9 @@ class Iterator(object):
 
         if not self.repeat:
             self.iterations = 0
+
+    def create_batches(self):
+        self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
 
     @property
     def epoch(self):
@@ -231,12 +234,7 @@ class BucketIterator(Iterator):
     batches for each new epoch. See pool for the bucketing procedure used.
     """
 
-    def init_epoch(self):
-        if self._restored_from_state:
-            self.random_shuffler.random_state = self._random_state_this_epoch
-        else:
-            self._random_state_this_epoch = self.random_shuffler.random_state
-
+    def create_batches(self):
         if self.sort:
             self.batches = batch(self.data(), self.batch_size,
                                  self.batch_size_fn)
@@ -244,14 +242,6 @@ class BucketIterator(Iterator):
             self.batches = pool(self.data(), self.batch_size,
                                 self.sort_key, self.batch_size_fn,
                                 random_shuffler=self.random_shuffler)
-
-        if self._restored_from_state:
-            self._restored_from_state = False
-        else:
-            self._iterations_this_epoch = 0
-
-        if not self.repeat:
-            self.iterations = 0
 
 
 def batch(data, batch_size, batch_size_fn=lambda new, count, sofar: count):

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -11,18 +11,26 @@ class RandomShuffler(object):
     reproducible and deterministic."""
 
     def __init__(self, random_state=None):
-        self.random_state = random_state
-        if self.random_state is None:
-            self.random_state = random.getstate()
+        self._random_state = random_state
+        if self._random_state is None:
+            self._random_state = random.getstate()
 
     @contextmanager
     def use_internal_state(self):
         """Use a specific RNG state."""
         old_state = random.getstate()
-        random.setstate(self.random_state)
+        random.setstate(self._random_state)
         yield
-        self.random_state = random.getstate()
+        self._random_state = random.getstate()
         random.setstate(old_state)
+
+    @property
+    def random_state(self):
+        return deepcopy(self._random_state)
+
+    @random_state.setter
+    def random_state(self, s):
+        self._random_state = s
 
     def __call__(self, data):
         """Shuffle and return a new list."""
@@ -114,7 +122,7 @@ class Iterator(object):
         if self._restored_from_state:
             self.random_shuffler.random_state = self._random_state_this_epoch
         else:
-            self._random_state_this_epoch = deepcopy(self.random_shuffler.random_state)
+            self._random_state_this_epoch = self.random_shuffler.random_state
 
         self.batches = batch(self.data(), self.batch_size, self.batch_size_fn)
 
@@ -227,7 +235,7 @@ class BucketIterator(Iterator):
         if self._restored_from_state:
             self.random_shuffler.random_state = self._random_state_this_epoch
         else:
-            self._random_state_this_epoch = deepcopy(self.random_shuffler.random_state)
+            self._random_state_this_epoch = self.random_shuffler.random_state
 
         if self.sort:
             self.batches = batch(self.data(), self.batch_size,


### PR DESCRIPTION
Implements `state_dict` and `load_state_dict` methods on `Iterator` instances in order to load/save checkpoints that maintain the shuffling order, including with `BucketIterator`. This required a more deterministic way to keep track of RNG states and reproduce them with the `RandomShuffler` class.