### PR TITLE
Fix Field.preprocess for LM dataset

### DIFF
--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -87,7 +87,7 @@ class Field(object):
         `preprocessing` Pipeline."""
         if six.PY2 and isinstance(x, six.string_types):
             x = Pipeline(lambda s: unicode(s, encoding='utf-8'))(x)
-        if self.sequential:
+        if self.sequential and isinstance(x, six.text_type):
             x = self.tokenize(x)
         if self.lower:
             x = Pipeline(six.text_type.lower)(x)


### PR DESCRIPTION
This should fix #64 -- the LM dataset calls `Example.fromlist` on data that's already tokenized, so `Field.preprocess` needs to skip tokenization.