### PR TITLE
Batch should be sorted by decreasing size.

### DIFF
--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -157,8 +157,10 @@ class Iterator(object):
                     continue
                 self.iterations += 1
                 self._iterations_this_epoch += 1
-                # NOTE: Find out more here for why we reverse: https://github.com/pytorch/text/pull/95
-                yield Batch(minibatch.reverse(), self.dataset, self.device,
+                # NOTE: `rnn.pack_padded_sequence` requires that a minibatch be sorted by decreasing order,
+                # which requires reversing relative to typical sort keys
+                minibatch.reverse()
+                yield Batch(minibatch, self.dataset, self.device,
                             self.train)
             if not self.repeat:
                 raise StopIteration

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -157,8 +157,8 @@ class Iterator(object):
                     continue
                 self.iterations += 1
                 self._iterations_this_epoch += 1
-                minibatch_decreasing_size = sorted(minibatch, key=lambda x: -self.sort_key(x))
-                yield Batch(minibatch_decreasing_size, self.dataset, self.device,
+                # NOTE: Find out more here for why we reverse: https://github.com/pytorch/text/pull/95
+                yield Batch(minibatch.reverse(), self.dataset, self.device,
                             self.train)
             if not self.repeat:
                 raise StopIteration

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -157,8 +157,8 @@ class Iterator(object):
                     continue
                 self.iterations += 1
                 self._iterations_this_epoch += 1
-                # NOTE: `rnn.pack_padded_sequence` requires that a minibatch be sorted by decreasing order,
-                # which requires reversing relative to typical sort keys
+                # NOTE: `rnn.pack_padded_sequence` requires that a minibatch be sorted by
+                # decreasing order, which requires reversing relative to typical sort keys
                 minibatch.reverse()
                 yield Batch(minibatch, self.dataset, self.device,
                             self.train)

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -157,7 +157,8 @@ class Iterator(object):
                     continue
                 self.iterations += 1
                 self._iterations_this_epoch += 1
-                yield Batch(minibatch, self.dataset, self.device,
+                minibatch_decreasing_size = sorted(minibatch, key=lambda x: -self.sort_key(x))
+                yield Batch(minibatch_decreasing_size, self.dataset, self.device,
                             self.train)
             if not self.repeat:
                 raise StopIteration


### PR DESCRIPTION
**Intended effect:**
- `rnn.pack_padded_sequence` requires that a minibatch be sorted by decreasing order.
- Curriculum learning requires that the batches are sorted in increasing order.

**Proposed Solution:**
Flip the sign of the `self.sort_key(x)` when creating the Batch.