### PR TITLE
Ignore tests directory in codecov statistics

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,5 @@ coverage:
         threshold: 1%
     changes: false
 comment: false
+ignore:
+  - "test/"


### PR DESCRIPTION
I noticed that codecov is considering the `test/` directory in coverage statistics since there's a bit of source code in there --- this tells codecov to ignore the folder.