### PR TITLE
Run linter on python 3 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - env: PYTHON_VERSION="3.5" COVERAGE="true"
     - env: PYTHON_VERSION="3.6" COVERAGE="true"
     - env: PYTHON_VERSION="2.7" RUN_FLAKE8="true" SKIP_TESTS="true"
-
+    - env: PYTHON_VERSION="3.6" RUN_FLAKE8="true" SKIP_TESTS="true"
 notifications:
   email: false
 

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -84,8 +84,8 @@ class Field(object):
         will be optionally lowercased and passed to the user-provided
         `preprocessing` Pipeline."""
         if (six.PY2 and isinstance(x, six.string_types) and not
-                isinstance(x, unicode)):
-            x = Pipeline(lambda s: unicode(s, encoding='utf-8'))(x)
+                isinstance(x, six.text_type)):
+            x = Pipeline(lambda s: six.text_type(s, encoding='utf-8'))(x)
         if self.sequential and isinstance(x, six.text_type):
             x = self.tokenize(x)
         if self.lower:


### PR DESCRIPTION
This PR adds Python 3 linting to the test matrix, and fixes an infraction (`unicode` type doesn't exist in python 3).