### PR TITLE
Document spacy tokenization in Field tokenize argument

### DIFF
--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -47,7 +47,8 @@ class Field(object):
             into a Tensor. Default: None.
         lower: Whether to lowercase the text in this field. Default: False.
         tokenize: The function used to tokenize strings using this field into
-            sequential examples. Default: str.split.
+            sequential examples. If "spacy", the SpaCy English tokenizer is
+            used. Default: str.split.
         include_lengths: Whether to return a tuple of a padded minibatch and
             a list containing the lengths of each examples, or just a padded
             minibatch. Default: False.


### PR DESCRIPTION
The `Field`'s `tokenize` argument takes a function to tokenize a string with. However, we also allow the user to pass in the string `spacy` to use the SpaCy english tokenizer. This wasn't mentioned in the docstring, so I added it.