### PR TITLE
Update CI matrix to use Python 2.7.9 from 2.7.8 (parity with PyTorch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ cache:
   - /home/travis/.cache/pip
 
 # This matrix tests that the code works on Python 2.7,
-# 2.7.8, 3.5, 3.6, and passes lint.
+# 2.7.9, 3.5, 3.6 (same versions as PyTorch CI), and passes lint.
 matrix:
   fast_finish: true
   include:
     - env: PYTHON_VERSION="2.7" COVERAGE="true"
-    - env: PYTHON_VERSION="2.7.8" COVERAGE="true"
+    - env: PYTHON_VERSION="2.7.9" COVERAGE="true"
     - env: PYTHON_VERSION="3.5" COVERAGE="true"
     - env: PYTHON_VERSION="3.6" COVERAGE="true"
     - env: PYTHON_VERSION="2.7" RUN_FLAKE8="true" SKIP_TESTS="true"


### PR DESCRIPTION
When i set up the matrix initially, it was my intention to mirror the versions used in the PyTorch repo.  Looks like PyTorch is now testing on Python 2.7.9 instead of Python 2.7.8 (https://github.com/pytorch/pytorch/pull/2214), so making the same change here.