### PR TITLE
Finish tests for Field class

### DIFF
--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -65,3 +65,36 @@ class TorchtextTestCase(TestCase):
             test_numerical_features_dataset_file.write("0.2\t0\tteststring3\n")
             test_numerical_features_dataset_file.write("0.4\t12\tteststring4\n")
             test_numerical_features_dataset_file.write("0.9\t9\tteststring5\n")
+
+def verify_numericalized_example(field, test_example_data,
+                                 test_example_numericalized,
+                                 test_example_lengths=None,
+                                 batch_first=False, train=True):
+    """
+    Function to verify that numericalized example is correct
+    with respect to the Field's Vocab.
+    """
+    if isinstance(test_example_numericalized, tuple):
+        test_example_numericalized, lengths = test_example_numericalized
+        assert test_example_lengths == lengths.tolist()
+    if batch_first:
+        test_example_numericalized.data.t_()
+    # Transpose numericalized example so we can compare over batches
+    for example_idx, numericalized_single_example in enumerate(
+            test_example_numericalized.t()):
+        assert len(test_example_data[example_idx]) == len(numericalized_single_example)
+        assert numericalized_single_example.volatile is not train
+        for token_idx, numericalized_token in enumerate(
+                numericalized_single_example):
+            # Convert from Variable to int
+            numericalized_token = numericalized_token.data[0]
+            test_example_token = test_example_data[example_idx][token_idx]
+            # Check if the numericalized example is correct, taking into
+            # account unknown tokens.
+            if field.vocab.stoi[test_example_token] != 0:
+                # token is in-vocabulary
+                assert (field.vocab.itos[numericalized_token] ==
+                        test_example_token)
+            else:
+                # token is OOV and <unk> always has an index of 0
+                assert numericalized_token == 0

--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -66,6 +66,7 @@ class TorchtextTestCase(TestCase):
             test_numerical_features_dataset_file.write("0.4\t12\tteststring4\n")
             test_numerical_features_dataset_file.write("0.9\t9\tteststring5\n")
 
+
 def verify_numericalized_example(field, test_example_data,
                                  test_example_numericalized,
                                  test_example_lengths=None,

--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -20,6 +20,8 @@ class TorchtextTestCase(TestCase):
             os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir)))
         self.test_dir = tempfile.mkdtemp()
         self.test_ppid_dataset_path = os.path.join(self.test_dir, "test_ppid_dataset")
+        self.test_numerical_features_dataset_path = os.path.join(
+            self.test_dir, "test_numerical_features_dataset")
 
     def tearDown(self):
         try:
@@ -54,3 +56,12 @@ class TorchtextTestCase(TestCase):
                                     example["question2"], example["label"]])))
                 else:
                     raise ValueError("Invalid format {}".format(data_format))
+
+    def write_test_numerical_features_dataset(self):
+        with open(self.test_numerical_features_dataset_path,
+                  "w") as test_numerical_features_dataset_file:
+            test_numerical_features_dataset_file.write("0.1\t1\tteststring1\n")
+            test_numerical_features_dataset_file.write("0.5\t12\tteststring2\n")
+            test_numerical_features_dataset_file.write("0.2\t0\tteststring3\n")
+            test_numerical_features_dataset_file.write("0.4\t12\tteststring4\n")
+            test_numerical_features_dataset_file.write("0.9\t9\tteststring5\n")

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -211,19 +211,16 @@ class TestField(TorchtextTestCase):
                               "<pad>", "<pad>", "<pad>"],
                              ["Here", "is", "a", "sentence", "with",
                               "some", "oovs", "<pad>"]]
-        test_example_lengths = [8, 3, 7]
 
         # Test default
         default_numericalized = question_field.numericalize(
             test_example_data, device=-1)
         verify_numericalized_example(question_field, test_example_data,
-                                     test_example_lengths,
                                      default_numericalized)
         # Test with train=False
         volatile_numericalized = question_field.numericalize(
             test_example_data, device=-1, train=False)
         verify_numericalized_example(question_field, test_example_data,
-                                     test_example_lengths,
                                      volatile_numericalized, train=False)
 
     def test_numericalize_include_lengths(self):
@@ -249,8 +246,8 @@ class TestField(TorchtextTestCase):
             (test_example_data, test_example_lengths), device=-1)
         verify_numericalized_example(question_field,
                                      test_example_data,
-                                     test_example_lengths,
-                                     include_lengths_numericalized)
+                                     include_lengths_numericalized,
+                                     test_example_lengths)
 
     def test_numericalize_batch_first(self):
         self.write_test_ppid_dataset(data_format="tsv")
@@ -268,21 +265,19 @@ class TestField(TorchtextTestCase):
                               "<pad>", "<pad>", "<pad>"],
                              ["Here", "is", "a", "sentence", "with",
                               "some", "oovs", "<pad>"]]
-        test_example_lengths = [8, 3, 7]
 
         # Test with batch_first
         include_lengths_numericalized = question_field.numericalize(
-            (test_example_data, test_example_lengths), device=-1)
+            test_example_data, device=-1)
         verify_numericalized_example(question_field,
                                      test_example_data,
-                                     test_example_lengths,
                                      include_lengths_numericalized,
                                      batch_first=True)
 
 
 def verify_numericalized_example(field, test_example_data,
-                                 test_example_lengths,
                                  test_example_numericalized,
+                                 test_example_lengths=None,
                                  batch_first=False, train=True):
     """
     Function to verify that numericalized example is correct

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -29,7 +29,7 @@ class TestField(TorchtextTestCase):
         # Non-regression test that we do not try to decode unicode strings to unicode
         field_not_sequential = data.Field(sequential=False, lower=True,
                                           preprocessing=preprocess_pipeline)
-        assert field_not_sequential.preprocess("ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T") == "ᑌᑎiᑕoᗪᕮ_tᕮ᙭t"
+        assert field_not_sequential.preprocess("ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T") == "ᑌᑎiᑕoᗪᕮ_tᕮ᙭t!"
 
     def test_pad(self):
         # Default case.

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import torchtext.data as data
 
 from ..common.torchtext_test_case import TorchtextTestCase
@@ -27,7 +29,7 @@ class TestField(TorchtextTestCase):
         # Non-regression test that we do not try to decode unicode strings to unicode
         field_not_sequential = data.Field(sequential=False, lower=True,
                                           preprocessing=preprocess_pipeline)
-        assert field_not_sequential.preprocess(u"Test string.") == "test string.!"
+        assert field_not_sequential.preprocess("ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T") == "ᑌᑎiᑕoᗪᕮ_tᕮ᙭t"
 
     def test_pad(self):
         # Default case.

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -305,6 +305,27 @@ class TestField(TorchtextTestCase):
                                      reversed_test_example_data,
                                      postprocessed_numericalized)
 
+    def test_errors(self):
+        # Test that passing a non-tuple (of data and length) to numericalize
+        # with Field.include_lengths = True raises an error.
+        with self.assertRaises(ValueError):
+            self.write_test_ppid_dataset(data_format="tsv")
+            question_field = data.Field(sequential=True, include_lengths=True)
+            tsv_fields = [("id", None), ("q1", question_field),
+                          ("q2", question_field), ("label", None)]
+            tsv_dataset = data.TabularDataset(
+                path=self.test_ppid_dataset_path, format="tsv",
+                fields=tsv_fields)
+            question_field.build_vocab(tsv_dataset)
+            test_example_data = [["When", "do", "you", "use", "シ",
+                                  "instead", "of", "し?"],
+                                 ["What", "is", "2+2", "<pad>", "<pad>",
+                                  "<pad>", "<pad>", "<pad>"],
+                                 ["Here", "is", "a", "sentence", "with",
+                                  "some", "oovs", "<pad>"]]
+            question_field.numericalize(
+                test_example_data, device=-1)
+
 
 def verify_numericalized_example(field, test_example_data,
                                  test_example_numericalized,

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -79,7 +79,6 @@ class Field(object):
         torch.cuda.LongTensor: int
     }
 
-
     def __init__(
             self, sequential=True, use_vocab=True, init_token=None,
             eos_token=None, fix_length=None, tensor_type=torch.LongTensor,

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -103,7 +103,8 @@ class Field(object):
         the longest example in the batch. Prepends self.init_token and appends
         self.eos_token if those attributes are not None. Returns a tuple of the
         padded list and a list containing lengths of each example if
-        `self.include_lengths` is `True`, else just returns the padded list.
+        `self.include_lengths` is `True` and `self.sequential` is `True`, else just
+        returns the padded list. If `self.sequential` is `False`, no padding is applied.
         """
         minibatch = list(minibatch)
         if not self.sequential:


### PR DESCRIPTION
This PR is a continuation of #47 and finishes testing the various functions for the field class (`build_vocab` and `numericalize`).

I also wanted to fix #78 and add a test for it, but I'm unsure how to properly do this. One way would be to simply convert the numerical features to python ints dictated by the input `tensor_type` member (e.g. `int` for `LongTensor`, `float` for `FloatTensor`, etc). This feels pretty brittle, does anyone else have any other suggestions?