### PR TITLE
Make travis slow python3 environment sudo-required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - env: PYTHON_VERSION="2.7.9" RUN_SLOW="true" COVERAGE="true"
       sudo: required
     - env: PYTHON_VERSION="3.6" RUN_SLOW="true" COVERAGE="true"
+      sudo: required
   allow_failures:
     - env: PYTHON_VERSION="2.7.9" RUN_SLOW="true" COVERAGE="true"
     - env: PYTHON_VERSION="3.6" RUN_SLOW="true" COVERAGE="true"


### PR DESCRIPTION
I've noticed that the builds have been failing due to memory issues. As a result, I'm making the python 3 slow test environment non-container-based for more memory (it now matches the slow python 2 tests).