### PR TITLE
bug fix: snli data loader

### DIFF
--- a/torchtext/datasets/snli.py
+++ b/torchtext/datasets/snli.py
@@ -1,5 +1,3 @@
-import os
-
 from .. import data
 
 

--- a/torchtext/datasets/snli.py
+++ b/torchtext/datasets/snli.py
@@ -37,7 +37,7 @@ class SNLI(data.TabularDataset):
 
     @classmethod
     def splits(cls, text_field, label_field, parse_field=None, root='.data',
-               train='train.jsonl', validation='dev.jsonl', test='test.jsonl'):
+               train='snli_1.0_train.jsonl', validation='snli_1.0_dev.jsonl', test='snli_1.0_test.jsonl'):
         """Create dataset objects for splits of the SNLI dataset.
 
         This is the most flexible way to use the dataset.
@@ -61,13 +61,13 @@ class SNLI(data.TabularDataset):
 
         if parse_field is None:
             return super(SNLI, cls).splits(
-                os.path.join(path, 'snli_1.0_'), train, validation, test,
+                path, root, train, validation, test,
                 format='json', fields={'sentence1': ('premise', text_field),
                                        'sentence2': ('hypothesis', text_field),
                                        'gold_label': ('label', label_field)},
                 filter_pred=lambda ex: ex.label != '-')
         return super(SNLI, cls).splits(
-            os.path.join(path, 'snli_1.0_'), train, validation, test,
+            path, root, train, validation, test,
             format='json', fields={'sentence1_binary_parse':
                                    [('premise', text_field),
                                     ('premise_transitions', parse_field)],

--- a/torchtext/datasets/snli.py
+++ b/torchtext/datasets/snli.py
@@ -37,7 +37,8 @@ class SNLI(data.TabularDataset):
 
     @classmethod
     def splits(cls, text_field, label_field, parse_field=None, root='.data',
-               train='snli_1.0_train.jsonl', validation='snli_1.0_dev.jsonl', test='snli_1.0_test.jsonl'):
+               train='snli_1.0_train.jsonl', validation='snli_1.0_dev.jsonl',
+               test='snli_1.0_test.jsonl'):
         """Create dataset objects for splits of the SNLI dataset.
 
         This is the most flexible way to use the dataset.

--- a/torchtext/datasets/translation.py
+++ b/torchtext/datasets/translation.py
@@ -73,7 +73,8 @@ class Multi30k(TranslationDataset):
 
     urls = ['http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/training.tar.gz',
             'http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz',
-            'https://staff.fnwi.uva.nl/d.elliott/wmt16/mmt16_task1_test.tgz']
+            'http://www.quest.dcs.shef.ac.uk/'
+            'wmt17_files_mmt/mmt_task1_test2016.tar.gz']
     name = 'multi30k'
     dirname = ''
 


### PR DESCRIPTION
The current SNLI dataset class fails for the test case test/snli.py.  Even the SNLI example in [examples/snli](https://github.com/pytorch/examples/blob/master/snli/train.py#L22) fails. 
This should fix it.