### PR TITLE
update wordvector parameters for language modeling and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ torchtext.egg-info/
 *~
 .cache
 .vector_cache
+
+# Download folder
+.data

--- a/test/language_modeling.py
+++ b/test/language_modeling.py
@@ -1,0 +1,38 @@
+from torchtext import data
+from torchtext import datasets
+from torchtext.vocab import GloVe
+
+# Approach 1:
+# set up fields
+TEXT = data.Field(lower=True, batch_first=True)
+
+# make splits for data
+train, valid, test = datasets.WikiText2.splits(TEXT)
+
+# print information about the data
+print('train.fields', train.fields)
+print('len(train)', len(train))
+print('vars(train[0])', vars(train[0])['text'][0:10])
+
+# build the vocabulary
+TEXT.build_vocab(train, vectors=GloVe(name='6B', dim=300))
+
+# print vocab information
+print('len(TEXT.vocab)', len(TEXT.vocab))
+
+# make iterator for splits
+train_iter, valid_iter, test_iter = data.BPTTIterator.splits(
+    (train, valid, test), batch_size=3, bptt_len=30, device=0)
+
+# print batch information
+batch = next(iter(train_iter))
+print(batch.text)
+print(batch.target)
+
+# Approach 2:
+train_iter, valid_iter, test_iter = datasets.WikiText2.iters(batch_size=4, bptt_len=30)
+
+# print batch information
+batch = next(iter(train_iter))
+print(batch.text)
+print(batch.target)

--- a/torchtext/datasets/language_modeling.py
+++ b/torchtext/datasets/language_modeling.py
@@ -57,8 +57,8 @@ class WikiText2(LanguageModelingDataset):
             text_field=text_field)
 
     @classmethod
-    def iters(cls, batch_size=32, bptt_len=35, device=0, root='.data', wv_dir='.',
-              wv_type=None, wv_dim='300d', **kwargs):
+    def iters(cls, batch_size=32, bptt_len=35, device=0, root='.data',
+              vectors=None, **kwargs):
         """Create iterator objects for splits of the WikiText-2 dataset.
 
         This is the simplest way to use the dataset, and assumes common
@@ -81,7 +81,7 @@ class WikiText2(LanguageModelingDataset):
 
         train, val, test = cls.splits(TEXT, root=root, **kwargs)
 
-        TEXT.build_vocab(train, wv_dir=wv_dir, wv_type=wv_type, wv_dim=wv_dim)
+        TEXT.build_vocab(train, vectors=vectors)
 
         return data.BPTTIterator.splits(
             (train, val, test), batch_size=batch_size, bptt_len=bptt_len,


### PR DESCRIPTION
I found that `wv_*` parameters are no longer used and cause errors.
So I updated the params and added tests to verify.