### PR TITLE
changed special token indexing

### DIFF
--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -240,7 +240,7 @@ class Field(RawField):
                     x = [x]
                 counter.update(x)
         specials = list(OrderedDict.fromkeys(
-            tok for tok in [self.unk_token, self.pad_token, self.init_token,
+            tok for tok in [self.pad_token, self.unk_token, self.init_token,
                             self.eos_token]
             if tok is not None))
         self.vocab = self.vocab_cls(counter, specials=specials, **kwargs)


### PR DESCRIPTION
Changed specials token indexing in field's numericalize function to make sure that pad_token is 0, so that torchtext works with torch.rnn.utils.pack_padded_sequence