### PR TITLE
Re-fix #137

### DIFF
--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -224,8 +224,8 @@ class BPTTIterator(Iterator):
         super(BPTTIterator, self).__init__(dataset, batch_size, **kwargs)
 
     def __len__(self):
-        return math.ceil((len(self.dataset[0].text) / self.batch_size - 1)
-                         / self.bptt_len)
+        return math.ceil((len(self.dataset[0].text) / self.batch_size - 1) /
+                         self.bptt_len)
 
     def __iter__(self):
         text = self.dataset[0].text

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -224,8 +224,8 @@ class BPTTIterator(Iterator):
         super(BPTTIterator, self).__init__(dataset, batch_size, **kwargs)
 
     def __len__(self):
-        return math.ceil((len(self.dataset[0].text) - 1) /
-                         (self.batch_size * self.bptt_len))
+        return math.ceil((len(self.dataset[0].text) / self.batch_size - 1)
+                         / self.bptt_len)
 
     def __iter__(self):
         text = self.dataset[0].text


### PR DESCRIPTION
This PR resolves #137.
Currently, `__len__` is implemented by:
```
    def __len__(self):
        return math.ceil((len(self.dataset[0].text) - 1) /
                         (self.batch_size * self.bptt_len))
```
This is insufficient, since "substraction by 1" should be performed in a batch-level.
