### PR TITLE
Keep generator in Dataset() even with filter_pred

### DIFF
--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -39,7 +39,8 @@ class Dataset(torch.utils.data.Dataset):
         if filter_pred is not None:
             make_list = isinstance(examples, list)
             examples = filter(filter_pred, examples)
-            if make_list: examples = list(examples)
+            if make_list:
+                examples = list(examples)
         self.examples = examples
         self.fields = dict(fields)
 

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -37,7 +37,9 @@ class Dataset(torch.utils.data.Dataset):
                 Default is None.
         """
         if filter_pred is not None:
-            examples = list(filter(filter_pred, examples))
+            make_list = isinstance(examples, list)
+            examples = filter(filter_pred, examples)
+            if make_list: examples = list(examples)
         self.examples = examples
         self.fields = dict(fields)
 


### PR DESCRIPTION
This actually does the opposite of what's proposed in #185, because any behavior that materializes a dataset that was meant to be lazy is a bug.  