### PR TITLE
Implement a nested field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ docs/build
 
 # Download folder
 .data
+
+# Coverage reports
+.coverage
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -8,11 +8,36 @@ This repository consists of:
 - [torchtext.data](#data) : Generic data loaders, abstractions, and iterators for text (including vocabulary and word vectors)
 - [torchtext.datasets](#datasets) : Pre-built loaders for common NLP datasets
 
-# Data
+## Installation
+
+Make sure you have Python 2.7 or 3.5+ and PyTorch 0.2.0 or newer. You can then install torchtext using pip:
+
+```
+pip install torchtext
+```
+
+### Optional requirements
+
+If you want to use English tokenizer from [SpaCy](http://spacy.io/), you need to install SpaCy and download its English model:
+
+```
+pip install spacy
+python -m spacy download en
+```
+
+Alternatively, you might want to use Moses tokenizer from [NLTK](http://nltk.org/). You have to install NLTK and download the data needed:
+
+```
+pip install nltk
+python -m nltk.downloader perluniprops nonbreaking_prefixes
+```
+
+## Data
 
 The data module provides the following:
 
 - Ability to describe declaratively how to load a custom NLP dataset that's in a "normal" format:
+
 ```python
 pos = data.TabularDataset(
     path='data/pos/pos_wsj_train.tsv', format='tsv',
@@ -24,7 +49,9 @@ sentiment = data.TabularDataset(
     fields={'sentence_tokenized': ('text', data.Field(sequential=True)),
              'sentiment_gold': ('labels', data.Field(sequential=False))})
 ```
+
 - Ability to define a preprocessing pipeline:
+
 ```python
 src = data.Field(tokenize=my_custom_tokenizer)
 trg = data.Field(tokenize=my_custom_tokenizer)
@@ -33,6 +60,7 @@ mt_train = datasets.TranslationDataset(
     fields=(src, trg))
 ```
 - Batching, padding, and numericalizing (including building a vocabulary object):
+
 ```python
 # continuing from above
 mt_dev = data.TranslationDataset(
@@ -43,13 +71,15 @@ trg.build_vocab(mt_train, max_size=40000)
 # mt_dev shares the fields, so it shares their vocab objects
 
 train_iter = data.BucketIterator(
-    dataset=mt_train, batch_size=32, 
+    dataset=mt_train, batch_size=32,
     sort_key=lambda x: data.interleave_keys(len(x.src), len(x.trg)))
 # usage
 >>>next(iter(train_iter))
 <data.Batch(batch_size=32, src=[LongTensor (32, 25)], trg=[LongTensor (32, 28)])>
 ```
+
 - Wrapper for dataset splits (train, validation, test):
+
 ```python
 TEXT = data.Field()
 LABELS = data.Field()
@@ -67,7 +97,7 @@ TEXT.build_vocab(train)
 LABELS.build_vocab(train)
 ```
 
-# Datasets
+## Datasets
 
 The datasets module currently contains:
 

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -35,6 +35,8 @@ Field
 
 .. autoclass:: Field
 
+.. autoclass:: NestedField
+
 Iterator
 ~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,10 @@ nltk
 spacy
 git+git://github.com/jekbradbury/revtok.git
 
+# Documentation
+Sphinx
+sphinx_rtd_theme
+
 # Required for tests only:
 
 # Style-checking for PEP8

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -391,3 +391,276 @@ class TestField(TorchtextTestCase):
                                   "some", "oovs", "<pad>"]]
             question_field.numericalize(
                 test_example_data, device=-1)
+
+
+class TestNestedField(TorchtextTestCase):
+    def test_init_minimal(self):
+        nesting_field = data.Field()
+        field = data.NestedField(nesting_field)
+
+        assert isinstance(field, data.Field)
+        assert field.nesting_field is nesting_field
+        assert field.sequential
+        assert field.use_vocab
+        assert field.init_token is None
+        assert field.eos_token is None
+        assert field.unk_token == nesting_field.unk_token
+        assert field.fix_length is None
+        assert field.tensor_type is torch.LongTensor
+        assert field.preprocessing is None
+        assert field.postprocessing is None
+        assert field.lower == nesting_field.lower
+        assert field.tokenize("a b c") == "a b c".split()
+        assert not field.include_lengths
+        assert field.batch_first
+        assert field.pad_token == nesting_field.pad_token
+        assert not field.pad_first
+
+    def test_init_when_nesting_field_is_not_sequential(self):
+        nesting_field = data.Field(sequential=False)
+        field = data.NestedField(nesting_field)
+
+        assert field.pad_token == "<pad>"
+
+    def test_init_when_nesting_field_has_include_lengths_equal_true(self):
+        nesting_field = data.Field(include_lengths=True)
+
+        with pytest.raises(ValueError) as excinfo:
+            data.NestedField(nesting_field)
+        assert "nesting field cannot have include_lengths=True" in str(excinfo.value)
+
+    def test_init_full(self):
+        nesting_field = data.Field()
+        field = data.NestedField(
+            nesting_field,
+            use_vocab=False,
+            init_token="<s>",
+            eos_token="</s>",
+            fix_length=10,
+            tensor_type=torch.FloatTensor,
+            preprocessing=lambda xs: list(reversed(xs)),
+            postprocessing=lambda xs: [x.upper() for x in xs],
+            tokenize=list,
+            pad_first=True,
+        )
+
+        assert not field.use_vocab
+        assert field.init_token == "<s>"
+        assert field.eos_token == "</s>"
+        assert field.fix_length == 10
+        assert field.tensor_type is torch.FloatTensor
+        assert field.preprocessing("a b c".split()) == "c b a".split()
+        assert field.postprocessing("a b c".split()) == "A B C".split()
+        assert field.tokenize("abc") == ["a", "b", "c"]
+        assert field.pad_first
+
+    def test_preprocess(self):
+        nesting_field = data.Field(
+            tokenize=list, preprocessing=lambda xs: [x.upper() for x in xs])
+        field = data.NestedField(nesting_field, preprocessing=lambda xs: reversed(xs))
+        preprocessed = field.preprocess("john loves mary")
+
+        assert preprocessed == [list("MARY"), list("LOVES"), list("JOHN")]
+
+    def test_build_vocab_from_dataset(self):
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>")
+        ex1 = data.Example.fromlist(["aaa bbb c"], [("chars", CHARS)])
+        ex2 = data.Example.fromlist(["bbb aaa"], [("chars", CHARS)])
+        dataset = data.Dataset([ex1, ex2], [("chars", CHARS)])
+
+        CHARS.build_vocab(dataset, min_freq=2)
+
+        expected = "a b <w> </w> <s> </s> <cunk> <cpad>".split()
+        assert len(CHARS.vocab) == len(expected)
+        for c in expected:
+            assert c in CHARS.vocab.stoi
+
+    def test_build_vocab_from_iterable(self):
+        nesting_field = data.Field(unk_token="<cunk>", pad_token="<cpad>")
+        CHARS = data.NestedField(nesting_field)
+        CHARS.build_vocab(
+            [[list("aaa"), list("bbb"), ["c"]], [list("bbb"), list("aaa")]],
+            [[list("ccc"), list("bbb")], [list("bbb")]],
+        )
+
+        expected = "a b c <cunk> <cpad>".split()
+        assert len(CHARS.vocab) == len(expected)
+        for c in expected:
+            assert c in CHARS.vocab.stoi
+
+    def test_pad(self):
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>")
+        minibatch = [
+            [list("john"), list("loves"), list("mary")],
+            [list("mary"), list("cries")],
+        ]
+        expected = [
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("john") + ["</w>", "<cpad>"],
+                ["<w>"] + list("loves") + ["</w>"],
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+            ],
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>"] + list("cries") + ["</w>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+                ["<cpad>"] * 7,
+            ]
+        ]
+
+        assert CHARS.pad(minibatch) == expected
+
+    def test_pad_when_nesting_field_is_not_sequential(self):
+        nesting_field = data.Field(sequential=False, unk_token="<cunk>",
+                                   pad_token="<cpad>", init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>")
+        minibatch = [
+            ["john", "loves", "mary"],
+            ["mary", "cries"]
+        ]
+        expected = [
+            ["<s>", "john", "loves", "mary", "</s>"],
+            ["<s>", "mary", "cries", "</s>", "<pad>"],
+        ]
+
+        assert CHARS.pad(minibatch) == expected
+
+    def test_pad_when_nesting_field_has_fix_length(self):
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>", fix_length=5)
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>")
+        minibatch = [
+            ["john", "loves", "mary"],
+            ["mary", "cries"]
+        ]
+        expected = [
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 2,
+                ["<w>"] + list("joh") + ["</w>"],
+                ["<w>"] + list("lov") + ["</w>"],
+                ["<w>"] + list("mar") + ["</w>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 2,
+            ],
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 2,
+                ["<w>"] + list("mar") + ["</w>"],
+                ["<w>"] + list("cri") + ["</w>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 2,
+                ["<cpad>"] * 5,
+            ]
+        ]
+
+        assert CHARS.pad(minibatch) == expected
+
+    def test_pad_when_fix_length_is_not_none(self):
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(
+            nesting_field, init_token="<s>", eos_token="</s>", fix_length=3)
+        minibatch = [
+            ["john", "loves", "mary"],
+            ["mary", "cries"]
+        ]
+        expected = [
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("john") + ["</w>", "<cpad>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+            ],
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+            ]
+        ]
+
+        assert CHARS.pad(minibatch) == expected
+
+    def test_pad_when_no_init_and_eos_tokens(self):
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field)
+        minibatch = [
+            ["john", "loves", "mary"],
+            ["mary", "cries"]
+        ]
+        expected = [
+            [
+                ["<w>"] + list("john") + ["</w>", "<cpad>"],
+                ["<w>"] + list("loves") + ["</w>"],
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+            ],
+            [
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>"] + list("cries") + ["</w>"],
+                ["<cpad>"] * 7,
+            ]
+        ]
+
+        assert CHARS.pad(minibatch) == expected
+
+    def test_pad_when_pad_first_is_true(self):
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>",
+                                 pad_first=True)
+        minibatch = [
+            [list("john"), list("loves"), list("mary")],
+            [list("mary"), list("cries")],
+        ]
+        expected = [
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("john") + ["</w>", "<cpad>"],
+                ["<w>"] + list("loves") + ["</w>"],
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+            ],
+            [
+                ["<cpad>"] * 7,
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>"] + list("cries") + ["</w>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+            ]
+        ]
+
+        assert CHARS.pad(minibatch) == expected
+
+    def test_numericalize(self):
+        nesting_field = data.Field(batch_first=True)
+        field = data.NestedField(nesting_field)
+        ex1 = data.Example.fromlist(["john loves mary"], [("words", field)])
+        ex2 = data.Example.fromlist(["mary cries"], [("words", field)])
+        dataset = data.Dataset([ex1, ex2], [("words", field)])
+        field.build_vocab(dataset)
+        examples_data = [
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("john") + ["</w>", "<cpad>"],
+                ["<w>"] + list("loves") + ["</w>"],
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+            ],
+            [
+                ["<w>", "<s>", "</w>"] + ["<cpad>"] * 4,
+                ["<w>"] + list("mary") + ["</w>", "<cpad>"],
+                ["<w>"] + list("cries") + ["</w>"],
+                ["<w>", "</s>", "</w>"] + ["<cpad>"] * 4,
+                ["<cpad>"] * 7,
+            ]
+        ]
+        numericalized = field.numericalize(examples_data, device=-1)
+
+        assert numericalized.dim() == 3
+        assert numericalized.size(0) == len(examples_data)
+        for example, numericalized_example in zip(examples_data, numericalized):
+            verify_numericalized_example(
+                field, example, numericalized_example, batch_first=True)

--- a/torchtext/data/__init__.py
+++ b/torchtext/data/__init__.py
@@ -1,16 +1,16 @@
 from .batch import Batch
 from .dataset import Dataset, TabularDataset
 from .example import Example
-from .field import RawField, Field, ReversibleField, SubwordField
+from .field import RawField, Field, ReversibleField, SubwordField, NestedField
 from .iterator import (batch, BucketIterator, Iterator, BPTTIterator,
                        pool)
 from .pipeline import Pipeline
 from .utils import get_tokenizer, interleave_keys
 
 __all__ = ["Batch",
-           "Dataset", "TabularDataset", "ZipDataset",
+           "Dataset", "TabularDataset",
            "Example",
-           "RawField", "Field", "ReversibleField", "SubwordField",
+           "RawField", "Field", "ReversibleField", "SubwordField", "NestedField",
            "batch", "BucketIterator", "Iterator", "BPTTIterator",
            "pool",
            "Pipeline",

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -395,3 +395,211 @@ class SubwordField(ReversibleField):
         for data in sources:
             for x in tqdm(data, 'segmenting'):
                 x[:] = self.vocab.segment(x)
+
+
+class NestedField(Field):
+    """A nested field.
+
+    A nested field holds another field (called *nesting field*), accepts an untokenized
+    string or a list string tokens and groups and treats them as one field as described
+    by the nesting field. Every token will be preprocessed, padded, etc. in the manner
+    specified by the nesting field. Note that this means a nested field always has
+    ``sequential=True``. The two fields' vocabularies will be shared. Their
+    numericalization results will be stacked into a single tensor. This field is
+    primarily used to implement character embeddings. See ``tests/data/test_field.py``
+    for examples on how to use this field.
+
+    Arguments:
+        nesting_field (Field): A field contained in this nested field.
+        use_vocab (bool): Whether to use a Vocab object. If False, the data in this
+            field should already be numerical. Default: ``True``.
+        init_token (str): A token that will be prepended to every example using this
+            field, or None for no initial token. Default: ``None``.
+        eos_token (str): A token that will be appended to every example using this
+            field, or None for no end-of-sentence token. Default: ``None``.
+        fix_length (int): A fixed length that all examples using this field will be
+            padded to, or ``None`` for flexible sequence lengths. Default: ``None``.
+        tensor_type: The torch.Tensor class that represents a batch of examples
+            of this kind of data. Default: ``torch.LongTensor``.
+        preprocessing (Pipeline): The Pipeline that will be applied to examples
+            using this field after tokenizing but before numericalizing. Many
+            Datasets replace this attribute with a custom preprocessor.
+            Default: ``None``.
+        postprocessing (Pipeline): A Pipeline that will be applied to examples using
+            this field after numericalizing but before the numbers are turned
+            into a Tensor. The pipeline function takes the batch as a list,
+            the field's Vocab, and train (a bool). Default: ``None``.
+        tokenize (callable or str): The function used to tokenize strings using this
+            field into sequential examples. If "spacy", the SpaCy English tokenizer is
+            used. Default: ``lambda s: s.split()``
+        pad_token (str): The string token used as padding. If ``nesting_field`` is
+            sequential, this will be set to its ``pad_token``. Default: ``"<pad>"``.
+        pad_first (bool): Do the padding of the sequence at the beginning. Default:
+            ``False``.
+    """
+    def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
+                 fix_length=None, tensor_type=torch.LongTensor, preprocessing=None,
+                 postprocessing=None, tokenize=lambda s: s.split(), pad_token='<pad>',
+                 pad_first=False):
+        if nesting_field.include_lengths:
+            raise ValueError('nesting field cannot have include_lengths=True')
+
+        if nesting_field.sequential:
+            pad_token = nesting_field.pad_token
+        super(NestedField, self).__init__(
+            use_vocab=use_vocab,
+            init_token=init_token,
+            eos_token=eos_token,
+            fix_length=fix_length,
+            tensor_type=tensor_type,
+            preprocessing=preprocessing,
+            postprocessing=postprocessing,
+            lower=nesting_field.lower,
+            tokenize=tokenize,
+            batch_first=True,
+            pad_token=pad_token,
+            unk_token=nesting_field.unk_token,
+            pad_first=pad_first,
+        )
+        self.nesting_field = nesting_field
+
+    def preprocess(self, xs):
+        """Preprocess a single example.
+
+        Firstly, tokenization and the supplied preprocessing pipeline is applied. Since
+        this field is always sequential, the result is a list. Then, each element of
+        the list is preprocessed using ``self.nesting_field.preprocess`` and the resulting
+        list is returned.
+
+        Arguments:
+            xs (list or str): The input to preprocess.
+
+        Returns:
+            list: The preprocessed list.
+        """
+        return [self.nesting_field.preprocess(x)
+                for x in super(NestedField, self).preprocess(xs)]
+
+    def pad(self, minibatch):
+        """Pad a batch of examples using this field.
+
+        If ``self.nesting_field.sequential`` is ``False``, each example in the batch must
+        be a list of string tokens, and pads them as if by a ``Field`` with
+        ``sequential=True``. Otherwise, each example must be a list of list of tokens.
+        Using ``self.nesting_field``, pads the list of tokens to
+        ``self.nesting_field.fix_length`` if provided, or otherwise to the length of the
+        longest list of tokens in the batch. Next, using this field, pads the result by
+        filling short examples with ``self.nesting_field.pad_token``.
+
+        Example:
+            >>> import pprint
+            >>> pp = pprint.PrettyPrinter(indent=4)
+            >>>
+            >>> nesting_field = Field(pad_token='<c>', init_token='<w>', eos_token='</w>')
+            >>> field = NestedField(nesting_field, init_token='<s>', eos_token='</s>')
+            >>> minibatch = [
+            ...     [list('john'), list('loves'), list('mary')],
+            ...     [list('mary'), list('cries')],
+            ... ]
+            >>> padded = field.pad(minibatch)
+            >>> pp.pprint(padded)
+            [   [   ['<w>', '<s>', '</w>', '<c>', '<c>', '<c>', '<c>'],
+                    ['<w>', 'j', 'o', 'h', 'n', '</w>', '<c>'],
+                    ['<w>', 'l', 'o', 'v', 'e', 's', '</w>'],
+                    ['<w>', 'm', 'a', 'r', 'y', '</w>', '<c>'],
+                    ['<w>', '</s>', '</w>', '<c>', '<c>', '<c>', '<c>']],
+                [   ['<w>', '<s>', '</w>', '<c>', '<c>', '<c>', '<c>'],
+                    ['<w>', 'm', 'a', 'r', 'y', '</w>', '<c>'],
+                    ['<w>', 'c', 'r', 'i', 'e', 's', '</w>'],
+                    ['<w>', '</s>', '</w>', '<c>', '<c>', '<c>', '<c>'],
+                    ['<c>', '<c>', '<c>', '<c>', '<c>', '<c>', '<c>']]]
+
+        Arguments:
+            minibatch (list): Each element is a list of string if
+                ``self.nesting_field.sequential`` is ``False``, a list of list of string
+                otherwise.
+
+        Returns:
+            list: The padded minibatch.
+        """
+        minibatch = list(minibatch)
+        if not self.nesting_field.sequential:
+            return super(NestedField, self).pad(minibatch)
+
+        # Save values of attributes to be monkeypatched
+        old_pad_token = self.pad_token
+        old_init_token = self.init_token
+        old_eos_token = self.eos_token
+        old_fix_len = self.nesting_field.fix_length
+        # Monkeypatch the attributes
+        if self.nesting_field.fix_length is None:
+            max_len = max(len(xs) for ex in minibatch for xs in ex)
+            fix_len = max_len + 2 - (self.nesting_field.init_token,
+                                     self.nesting_field.eos_token).count(None)
+            self.nesting_field.fix_length = fix_len
+        self.pad_token = [self.pad_token] * self.nesting_field.fix_length
+        if self.init_token is not None:
+            self.init_token = self.nesting_field.pad([[self.init_token]])[0]
+        if self.eos_token is not None:
+            self.eos_token = self.nesting_field.pad([[self.eos_token]])[0]
+        # Do padding
+        padded = [self.nesting_field.pad(ex) for ex in minibatch]
+        padded = super(NestedField, self).pad(padded)
+        # Restore monkeypatched attributes
+        self.nesting_field.fix_length = old_fix_len
+        self.pad_token = old_pad_token
+        self.init_token = old_init_token
+        self.eos_token = old_eos_token
+
+        return padded
+
+    def build_vocab(self, *args, **kwargs):
+        """Construct the Vocab object for nesting field and combine it with this field's vocab.
+
+        Arguments:
+            Positional arguments: Dataset objects or other iterable data
+                sources from which to construct the Vocab object that
+                represents the set of possible values for the nesting field. If
+                a Dataset object is provided, all columns corresponding
+                to this field are used; individual columns can also be
+                provided directly.
+            Remaining keyword arguments: Passed to the constructor of Vocab.
+        """
+        sources = []
+        for arg in args:
+            if isinstance(arg, Dataset):
+                sources.extend(
+                    [getattr(arg, name) for name, field in arg.fields.items()
+                     if field is self]
+                )
+            else:
+                sources.append(arg)
+
+        flattened = []
+        for source in sources:
+            flattened.extend(source)
+        self.nesting_field.build_vocab(*flattened, **kwargs)
+        super(NestedField, self).build_vocab()
+        self.vocab.extend(self.nesting_field.vocab)
+        self.nesting_field.vocab = self.vocab
+
+    def numericalize(self, arrs, device=None, train=True):
+        """Convert a padded minibatch into a variable tensor.
+
+        Each item in the minibatch will be numericalized independently and the resulting
+        tensors will be stacked at the first dimension.
+
+        Arguments:
+            arr (List[List[str]]): List of tokenized and padded examples.
+            device (int): Device to create the Variable's Tensor on.
+                Use -1 for CPU and None for the currently active GPU device.
+                Default: None.
+            train (bool): Whether the batch is for a training set. If False, the Variable
+                will be created with volatile=True. Default: True.
+        """
+        numericalized = []
+        for arr in arrs:
+            numericalized_ex = self.nesting_field.numericalize(
+                arr, device=device, train=train)
+            numericalized.append(numericalized_ex)
+        return torch.stack(numericalized)


### PR DESCRIPTION
This PR mostly addresses #124 by introducing a nested field: a field that can contain another field. Please see `NestedField` class docstring for more info and `TestNestedField` class in `test/test_field.py` for examples. A complete list of what's introduced in this PR:

* Implement a `NestedField` class. This class implements a custom `preprocess`, `pad`, `build_vocab`, and `numericalize` method. The `pad` method is especially hacky since it uses monkeypatching. Unfortunately I can't think of any other idea. Suggestions for a more elegant approach are welcomed.
* Add `Sphinx` and `sphinx_rtd_theme` to `requirements.txt` to allow building docs locally.
* Put installation instructions in README, including the optional requirements (which is not optional if you want to run tests). Without this, contributors need to see `build_tools/install.sh` to figure those out.
* Update .gitignore to exclude coverage files which are produced when generating coverage reports locally.

Please let me know what you think @jekbradbury.