### PR TITLE
Prevent `NestedField` to have another `NestedField` as nesting field

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -429,6 +429,13 @@ class TestNestedField(TorchtextTestCase):
             data.NestedField(nesting_field)
         assert "nesting field cannot have include_lengths=True" in str(excinfo.value)
 
+    def test_init_with_nested_field_as_nesting_field(self):
+        nesting_field = data.NestedField(data.Field())
+
+        with pytest.raises(ValueError) as excinfo:
+            data.NestedField(nesting_field)
+        assert "nesting field must not be another NestedField" in str(excinfo.value)
+
     def test_init_full(self):
         nesting_field = data.Field()
         field = data.NestedField(

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -441,6 +441,8 @@ class NestedField(Field):
                  fix_length=None, tensor_type=torch.LongTensor, preprocessing=None,
                  postprocessing=None, tokenize=lambda s: s.split(), pad_token='<pad>',
                  pad_first=False):
+        if isinstance(nesting_field, NestedField):
+            raise ValueError('nesting field must not be another NestedField')
         if nesting_field.include_lengths:
             raise ValueError('nesting field cannot have include_lengths=True')
 


### PR DESCRIPTION
As discussed in #197, `NestedField` assumes that the nesting field is not another `NestedField`. This PR introduces a check for that. An error is raised when the assumption is violated.