### PR TITLE
Fix TabularDataset failing for files with newlines in the text (#210)

### DIFF
--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -22,6 +22,8 @@ class TorchtextTestCase(TestCase):
         self.test_ppid_dataset_path = os.path.join(self.test_dir, "test_ppid_dataset")
         self.test_numerical_features_dataset_path = os.path.join(
             self.test_dir, "test_numerical_features_dataset")
+        self.test_newline_dataset_path = os.path.join(self.test_dir,
+                                                      "test_newline_dataset")
 
     def tearDown(self):
         try:

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -6,7 +6,7 @@ import tarfile
 import torch.utils.data
 
 from .example import Example
-from ..utils import download_from_url
+from ..utils import download_from_url, unicode_csv_reader
 
 
 class Dataset(torch.utils.data.Dataset):
@@ -156,9 +156,16 @@ class TabularDataset(Dataset):
             'tsv': Example.fromTSV, 'csv': Example.fromCSV}[format.lower()]
 
         with io.open(os.path.expanduser(path), encoding="utf8") as f:
+            if format == 'csv':
+                reader = unicode_csv_reader(f)
+            elif format == 'tsv':
+                reader = unicode_csv_reader(f, delimiter='\t')
+            else:
+                reader = f
+
             if skip_header:
-                next(f)
-            examples = [make_example(line, fields) for line in f]
+                next(reader)
+            examples = [make_example(line, fields) for line in reader]
 
         if make_example in (Example.fromdict, Example.fromJSON):
             fields, field_dict = [], fields

--- a/torchtext/data/example.py
+++ b/torchtext/data/example.py
@@ -1,4 +1,3 @@
-import csv
 import json
 
 import six
@@ -31,25 +30,11 @@ class Example(object):
 
     @classmethod
     def fromTSV(cls, data, fields):
-        return cls.fromlist(data.split('\t'), fields)
+        return cls.fromlist(data, fields)
 
     @classmethod
     def fromCSV(cls, data, fields):
-        data = data.rstrip("\n")
-        # If Python 2, encode to utf-8 since CSV doesn't take unicode input
-        if six.PY2:
-            data = data.encode('utf-8')
-        # Use Python CSV module to parse the CSV line
-        parsed_csv_lines = csv.reader([data])
-
-        # If Python 2, decode back to unicode (the original input format).
-        if six.PY2:
-            for line in parsed_csv_lines:
-                parsed_csv_line = [six.text_type(col, 'utf-8') for col in line]
-                break
-        else:
-            parsed_csv_line = list(parsed_csv_lines)[0]
-        return cls.fromlist(parsed_csv_line, fields)
+        return cls.fromlist(data, fields)
 
     @classmethod
     def fromlist(cls, data, fields):

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -1,5 +1,7 @@
+import six
 from six.moves import urllib
 import requests
+import csv
 
 
 def reporthook(t):
@@ -43,3 +45,23 @@ def download_from_url(url, path):
         for chunk in response.iter_content(chunk_size):
             if chunk:
                 f.write(chunk)
+
+
+def unicode_csv_reader(unicode_csv_data, **kwargs):
+    """Since the standard csv library does not handle unicode in Python 2, we need a wrapper.
+    Borrwed and slightly modified from the Python docs:
+    https://docs.python.org/2/library/csv.html#csv-examples"""
+    if six.PY2:
+        # csv.py doesn't do Unicode; encode temporarily as UTF-8:
+        csv_reader = csv.reader(utf_8_encoder(unicode_csv_data), **kwargs)
+        for row in csv_reader:
+            # decode UTF-8 back to Unicode, cell by cell:
+            yield [cell.decode('utf-8') for cell in row]
+    else:
+        for line in csv.reader(unicode_csv_data, **kwargs):
+            yield line
+
+
+def utf_8_encoder(unicode_csv_data):
+    for line in unicode_csv_data:
+        yield line.encode('utf-8')


### PR DESCRIPTION
I've made the TabularDataset class handle csv and tsv files using the standard csv library in Python. This should resolve the bugs surrounding newlines within the text (and probably some more hidden ones that are covered by the standard library).

I've added a unit test, run flake8 and confirmed the tests pass in both Python 2.7 and 3.6. If there's anything else I should do, please let me know:)