### PR TITLE
Fixed bug for Iterator using TabularDataset created using dict fields and csv/tsv files

### DIFF
--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -24,6 +24,8 @@ class TorchtextTestCase(TestCase):
             self.test_dir, "test_numerical_features_dataset")
         self.test_newline_dataset_path = os.path.join(self.test_dir,
                                                       "test_newline_dataset")
+        self.test_has_header_dataset_path = os.path.join(self.test_dir,
+                                                         "test_has_header_dataset")
 
     def tearDown(self):
         try:

--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -22,6 +22,8 @@ class TorchtextTestCase(TestCase):
         self.test_ppid_dataset_path = os.path.join(self.test_dir, "test_ppid_dataset")
         self.test_numerical_features_dataset_path = os.path.join(
             self.test_dir, "test_numerical_features_dataset")
+        self.test_newline_dataset_path = os.path.join(self.test_dir,
+                                                      "test_newline_dataset")
 
     def tearDown(self):
         try:

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -128,10 +128,13 @@ class TestDataset(TorchtextTestCase):
                                ("HELLO WORLD", "0"),
                                ("goodbye world", "1")]
 
+        TEXT = data.Field(lower=True, tokenize=lambda x: x)
         fields = {
-            "label": ("label", data.Field(sequential=False)),
-            "text": ("text", data.Field(lower=True, tokenize=lambda x: x))
+            "label": ("label", data.Field(use_vocab=False,
+                                          sequential=False)),
+            "text": ("text", TEXT)
         }
+        TEXT.build_vocab()
 
         for format_, delim in zip(["csv", "tsv"], [",", "\t"]):
             with open(self.test_has_header_dataset_path, "wt") as f:
@@ -151,3 +154,7 @@ class TestDataset(TorchtextTestCase):
             for i, example in enumerate(dataset):
                 self.assertEqual(example.text, example_with_header[i + 1][0].lower())
                 self.assertEqual(example.label, example_with_header[i + 1][1])
+
+            data_iter = data.Iterator(dataset, device=-1, batch_size=1,
+                                      sort_within_batch=False, repeat=False)
+            next(data_iter.__iter__())

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -6,7 +6,7 @@ import tarfile
 import torch.utils.data
 
 from .example import Example
-from ..utils import download_from_url
+from ..utils import download_from_url, unicode_csv_reader
 
 
 class Dataset(torch.utils.data.Dataset):
@@ -156,9 +156,16 @@ class TabularDataset(Dataset):
             'tsv': Example.fromTSV, 'csv': Example.fromCSV}[format.lower()]
 
         with io.open(os.path.expanduser(path), encoding="utf8") as f:
+            if format == 'csv':
+                reader = unicode_csv_reader(f)
+            elif format == 'tsv':
+                reader = unicode_csv_reader(f, delimiter='\t')
+            else:
+                reader = f
+
             if skip_header:
-                next(f)
-            examples = [make_example(line, fields) for line in f]
+                next(reader)
+            examples = [make_example(line, fields) for line in reader]
 
         if make_example in (Example.fromdict, Example.fromJSON):
             fields, field_dict = [], fields

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -157,7 +157,7 @@ class TabularDataset(Dataset):
         """
         make_example = {
             'json': Example.fromJSON, 'dict': Example.fromdict,
-            'tsv': Example.fromTSV, 'csv': Example.fromCSV}[format.lower()]
+            'tsv': Example.fromCSV, 'csv': Example.fromCSV}[format.lower()]
 
         with io.open(os.path.expanduser(path), encoding="utf8") as f:
             if format == 'csv':

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -181,7 +181,7 @@ class TabularDataset(Dataset):
 
             examples = [make_example(line, fields) for line in reader]
 
-        if make_example in (Example.fromdict, Example.fromJSON):
+        if isinstance(fields, dict):
             fields, field_dict = [], fields
             for field in field_dict.values():
                 if isinstance(field, list):

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -2,6 +2,7 @@ import io
 import os
 import zipfile
 import tarfile
+from functools import partial
 
 import torch.utils.data
 
@@ -141,14 +142,17 @@ class TabularDataset(Dataset):
             path (str): Path to the data file.
             format (str): The format of the data file. One of "CSV", "TSV", or
                 "JSON" (case-insensitive).
-            fields (list(tuple(str, Field)) or dict[str: tuple(str, Field)]: For CSV and
-                TSV formats, list of tuples of (name, field). The list should be in
-                the same order as the columns in the CSV or TSV file, while tuples of
-                (name, None) represent columns that will be ignored. For JSON format,
-                dictionary whose keys are the JSON keys and whose values are tuples of
-                (name, field). This allows the user to rename columns from their JSON key
-                names and also enables selecting a subset of columns to load
-                (since JSON keys not present in the input dictionary are ignored).
+            fields (list(tuple(str, Field)) or dict[str: tuple(str, Field)]:
+                If using a list, the format must be CSV or TSV, and the values of the list
+                should be tuples of (name, field).
+                The fields should be in the same order as the columns in the CSV or TSV
+                file, while tuples of (name, None) represent columns that will be ignored.
+
+                If using a dict, the keys should be a subset of the JSON keys or CSV/TSV
+                columns, and the values should be tuples of (name, field).
+                Keys not present in the input dictionary are ignored.
+                This allows the user to rename columns from their JSON/CSV/TSV key names
+                and also enables selecting a subset of columns to load.
             skip_header (bool): Whether to skip the first line of the input file.
         """
         make_example = {
@@ -163,8 +167,18 @@ class TabularDataset(Dataset):
             else:
                 reader = f
 
+            if format in ['csv', 'tsv'] and isinstance(fields, dict):
+                if skip_header:
+                    raise ValueError('When using a dict to specify fields with a {} file,'
+                                     'skip_header must be False and'
+                                     'the file must have a header.'.format(format))
+                header = next(reader)
+                field_to_index = {f: header.index(f) for f in fields.keys()}
+                make_example = partial(make_example, field_to_index=field_to_index)
+
             if skip_header:
                 next(reader)
+
             examples = [make_example(line, fields) for line in reader]
 
         if make_example in (Example.fromdict, Example.fromJSON):

--- a/torchtext/data/example.py
+++ b/torchtext/data/example.py
@@ -29,12 +29,22 @@ class Example(object):
         return ex
 
     @classmethod
-    def fromTSV(cls, data, fields):
-        return cls.fromlist(data, fields)
+    def fromTSV(cls, data, fields, field_to_index=None):
+        if field_to_index is None:
+            return cls.fromlist(data, fields)
+        else:
+            assert(isinstance(fields, dict))
+            data_dict = {f: data[idx] for f, idx in field_to_index.items()}
+            return cls.fromdict(data_dict, fields)
 
     @classmethod
-    def fromCSV(cls, data, fields):
-        return cls.fromlist(data, fields)
+    def fromCSV(cls, data, fields, field_to_index=None):
+        if field_to_index is None:
+            return cls.fromlist(data, fields)
+        else:
+            assert(isinstance(fields, dict))
+            data_dict = {f: data[idx] for f, idx in field_to_index.items()}
+            return cls.fromdict(data_dict, fields)
 
     @classmethod
     def fromlist(cls, data, fields):

--- a/torchtext/data/example.py
+++ b/torchtext/data/example.py
@@ -1,4 +1,3 @@
-import csv
 import json
 
 import six
@@ -31,25 +30,11 @@ class Example(object):
 
     @classmethod
     def fromTSV(cls, data, fields):
-        return cls.fromlist(data.split('\t'), fields)
+        return cls.fromlist(data, fields)
 
     @classmethod
     def fromCSV(cls, data, fields):
-        data = data.rstrip("\n")
-        # If Python 2, encode to utf-8 since CSV doesn't take unicode input
-        if six.PY2:
-            data = data.encode('utf-8')
-        # Use Python CSV module to parse the CSV line
-        parsed_csv_lines = csv.reader([data])
-
-        # If Python 2, decode back to unicode (the original input format).
-        if six.PY2:
-            for line in parsed_csv_lines:
-                parsed_csv_line = [six.text_type(col, 'utf-8') for col in line]
-                break
-        else:
-            parsed_csv_line = list(parsed_csv_lines)[0]
-        return cls.fromlist(parsed_csv_line, fields)
+        return cls.fromlist(data, fields)
 
     @classmethod
     def fromlist(cls, data, fields):

--- a/torchtext/data/example.py
+++ b/torchtext/data/example.py
@@ -29,15 +29,6 @@ class Example(object):
         return ex
 
     @classmethod
-    def fromTSV(cls, data, fields, field_to_index=None):
-        if field_to_index is None:
-            return cls.fromlist(data, fields)
-        else:
-            assert(isinstance(fields, dict))
-            data_dict = {f: data[idx] for f, idx in field_to_index.items()}
-            return cls.fromdict(data_dict, fields)
-
-    @classmethod
     def fromCSV(cls, data, fields, field_to_index=None):
         if field_to_index is None:
             return cls.fromlist(data, fields)

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -1,5 +1,7 @@
+import six
 from six.moves import urllib
 import requests
+import csv
 
 
 def reporthook(t):
@@ -43,3 +45,23 @@ def download_from_url(url, path):
         for chunk in response.iter_content(chunk_size):
             if chunk:
                 f.write(chunk)
+
+
+def unicode_csv_reader(unicode_csv_data, **kwargs):
+    """Since the standard csv library does not handle unicode in Python 2, we need a wrapper.
+    Borrwed and slightly modified from the Python docs:
+    https://docs.python.org/2/library/csv.html#csv-examples"""
+    if six.PY2:
+        # csv.py doesn't do Unicode; encode temporarily as UTF-8:
+        csv_reader = csv.reader(utf_8_encoder(unicode_csv_data), **kwargs)
+        for row in csv_reader:
+            # decode UTF-8 back to Unicode, cell by cell:
+            yield [cell.decode('utf-8') for cell in row]
+    else:
+        for line in csv.reader(unicode_csv_data, **kwargs):
+            yield line
+
+
+def utf_8_encoder(unicode_csv_data):
+    for line in unicode_csv_data:
+        yield line.encode('utf-8')


### PR DESCRIPTION
Due to a minor miss I made on my previous PR (#217), a TabularDataset created using csv/tsv files would raise an error when used by an Iterator. I've fixed the bug in this PR.
This PR comes after #220 and should be capable of being automatically merged with master after merging #220.