### PR TITLE
Add support for multiple fields per single data column

### DIFF
--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -159,7 +159,7 @@ class TestDataset(TorchtextTestCase):
         spacy_tok_question_field = data.Field(sequential=True, tokenize="spacy")
         label_field = data.Field(sequential=False)
         # Field name/value as nested tuples
-        fields = [("ids", None), #Ignore id
+        fields = [("ids", None),
                   (("q1", "q1_spacy"), (question_field, spacy_tok_question_field)),
                   (("q2", "q2_spacy"), (question_field, spacy_tok_question_field)),
                   ("label", label_field)]
@@ -186,4 +186,5 @@ class TestDataset(TorchtextTestCase):
             self.assertEqual(example.q2_spacy, expected_examples[i][3])
             self.assertEqual(example.label, expected_examples[i][4])
 
-        assert len(dataset.fields) == 6 #Including None for ids
+        # 6 Fields including None for ids
+        assert len(dataset.fields) == 6

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -151,3 +151,39 @@ class TestDataset(TorchtextTestCase):
             for i, example in enumerate(dataset):
                 self.assertEqual(example.text, example_with_header[i + 1][0].lower())
                 self.assertEqual(example.label, example_with_header[i + 1][1])
+
+    def test_csv_file_no_header_one_col_multiple_fields(self):
+        self.write_test_ppid_dataset(data_format="csv")
+
+        question_field = data.Field(sequential=True)
+        spacy_tok_question_field = data.Field(sequential=True, tokenize="spacy")
+        label_field = data.Field(sequential=False)
+        # Field name/value as nested tuples
+        fields = [("ids", None), #Ignore id
+                  (("q1", "q1_spacy"), (question_field, spacy_tok_question_field)),
+                  (("q2", "q2_spacy"), (question_field, spacy_tok_question_field)),
+                  ("label", label_field)]
+        dataset = data.TabularDataset(
+            path=self.test_ppid_dataset_path, format="csv", fields=fields)
+        expected_examples = [
+            (["When", "do", "you", "use", "シ", "instead", "of", "し?"],
+             ["When", "do", "you", "use", "シ", "instead", "of", "し", "?"],
+             ["When", "do", "you", "use", "\"&\"",
+              "instead", "of", "\"and\"?"],
+             ["When", "do", "you", "use", "\"", "&", "\"",
+              "instead", "of", "\"", "and", "\"", "?"], "0"),
+            (["Where", "was", "Lincoln", "born?"],
+             ["Where", "was", "Lincoln", "born", "?"],
+             ["Which", "location", "was", "Abraham", "Lincoln", "born?"],
+             ["Which", "location", "was", "Abraham", "Lincoln", "born", "?"],
+             "1"),
+            (["What", "is", "2+2"], ["What", "is", "2", "+", "2"],
+             ["2+2=?"], ["2", "+", "2=", "?"], "1")]
+        for i, example in enumerate(dataset):
+            self.assertEqual(example.q1, expected_examples[i][0])
+            self.assertEqual(example.q1_spacy, expected_examples[i][1])
+            self.assertEqual(example.q2, expected_examples[i][2])
+            self.assertEqual(example.q2_spacy, expected_examples[i][3])
+            self.assertEqual(example.label, expected_examples[i][4])
+
+        assert len(dataset.fields) == 6 #Including None for ids

--- a/test/sequence_tagging.py
+++ b/test/sequence_tagging.py
@@ -55,7 +55,7 @@ PTB_TAG = data.Field(init_token="<bos>", eos_token="<eos>")
 CHAR_NESTING = data.Field(tokenize=list, init_token="<bos>", eos_token="<eos>")
 CHAR = data.NestedField(CHAR_NESTING, init_token="<bos>", eos_token="<eos>")
 
-fields = [(('word', 'char'),(WORD, CHAR)), (None, None), ('ptbtag', PTB_TAG)]
+fields = [(('word', 'char'), (WORD, CHAR)), (None, None), ('ptbtag', PTB_TAG)]
 train, val, test = datasets.UDPOS.splits(fields=fields)
 
 print(train.fields)

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -41,6 +41,11 @@ class Dataset(torch.utils.data.Dataset):
                 examples = list(examples)
         self.examples = examples
         self.fields = dict(fields)
+        # Unpack field tuples
+        for n, f in list(self.fields.items()):
+            if isinstance(n, tuple):
+                self.fields.update(zip(n, f))
+                del self.fields[n]
 
     @classmethod
     def splits(cls, path=None, root='.data', train=None, validation=None,

--- a/torchtext/data/example.py
+++ b/torchtext/data/example.py
@@ -44,7 +44,12 @@ class Example(object):
             if field is not None:
                 if isinstance(val, six.string_types):
                     val = val.rstrip('\n')
-                setattr(ex, name, field.preprocess(val))
+                # Handle field tuples
+                if isinstance(name, tuple):
+                    for n, f in zip(name, field):
+                        setattr(ex, n, f.preprocess(val))
+                else:
+                    setattr(ex, name, field.preprocess(val))
         return ex
 
     @classmethod


### PR DESCRIPTION
With this change we can now pass a nested tuple to map a single data column to multiple fields (e.g. when we need both word and character embeddings):
```
WORD = data.Field(init_token="<bos>", eos_token="<eos>")
CHAR_NESTING = data.Field(tokenize=list, init_token="<bos>", eos_token="<eos>")
CHAR = data.NestedField(CHAR_NESTING, init_token="<bos>", eos_token="<eos>")

fields = [(('word', 'char'),(WORD, CHAR)), (None, None), ('ptbtag', PTB_TAG)]
train, val, test = datasets.UDPOS.splits(fields=fields)
```

Files modified:
* *torchtext/data/example.py*: Added code to process nested name-Field tuples
* *torchtext/data/dataset.py*: Added code to unpack Field tuples in Field dict
* *test/data/test_dataset.py*: Added testcase to test multiple fields in a CSV file
* *test/sequence_tagging.py*: Example of how to use multiple Fields