### PR TITLE
Error with the encoding on python 3

### DIFF
--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -29,7 +29,7 @@ class IMDB(data.Dataset):
 
         for label in ['pos', 'neg']:
             for fname in glob.iglob(os.path.join(path, label, '*.txt')):
-                with open(fname, 'r') as f:
+                with open(fname, 'r', encoding="utf-8") as f:
                     text = f.readline()
                 examples.append(data.Example.fromlist([text, label], fields))
 


### PR DESCRIPTION
Using `pytorch` with `fast.ai` and not correctly configured Linux system leads to this kind of errors:

The code used

```
torchtext.datasets.IMDB.splits(TEXT, IMDB_LABEL, '/tmp/')
```

The error that is shown:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 796: 
ordinal not in range(128)
```
Adding the correct encoding in the open statement solve this problem.

More information here:

http://forums.fast.ai/t/imdb-test-data-is-different-from-what-is-shown-in-the-class/8138/13