### PR TITLE
Add label field

### DIFF
--- a/torchtext/data/__init__.py
+++ b/torchtext/data/__init__.py
@@ -1,7 +1,7 @@
 from .batch import Batch
 from .dataset import Dataset, TabularDataset
 from .example import Example
-from .field import RawField, Field, ReversibleField, SubwordField, NestedField
+from .field import RawField, Field, ReversibleField, SubwordField, NestedField, LabelField
 from .iterator import (batch, BucketIterator, Iterator, BPTTIterator,
                        pool)
 from .pipeline import Pipeline
@@ -11,6 +11,7 @@ __all__ = ["Batch",
            "Dataset", "TabularDataset",
            "Example",
            "RawField", "Field", "ReversibleField", "SubwordField", "NestedField",
+           "LabelField",
            "batch", "BucketIterator", "Iterator", "BPTTIterator",
            "pool",
            "Pipeline",

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -604,3 +604,18 @@ class NestedField(Field):
                 arr, device=device, train=train)
             numericalized.append(numericalized_ex)
         return torch.stack(numericalized)
+
+
+class LabelField(Field):
+    """A Label field.
+
+    A label field is a shallow wrapper around a standard field designed to hold labels
+    for a classification task. Its only use is to set the unk_token and sequential to
+    `None` by default.
+    """
+    def __init__(self, **kwargs):
+        # whichever value is set for sequential and unk_token will be overwritten
+        kwargs['sequential'] = False
+        kwargs['unk_token'] = None
+
+        super(LabelField, self).__init__(**kwargs)


### PR DESCRIPTION
- Added a LabelField subclass of Field that forces `sequential=False` and `unk_token=None`
- Added the LabelField to `__init__.py`
- Added some rudimentary tests (comparison of modified stoi/itos and field checks)

Two things that could be modified, but are not for the sake of simplicity:
- Print a warning message when user passes either of the arguments with values different than the forced ones
  - throwing a ValueError seemed like an overkill due to intuitiveness, so currently the constructor silently overwrites the arguments (which could be bad tbh)
- Modify '__setattr__' to deny modifications of those fields
  - seemed like something that should be left to the user
