### PR TITLE
Set device to CPU if CUDA is not available

### DIFF
--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -4,6 +4,7 @@ import math
 import random
 from contextlib import contextmanager
 from copy import deepcopy
+import torch
 
 from .batch import Batch
 from .dataset import Dataset
@@ -90,6 +91,8 @@ class Iterator(object):
         else:
             self.sort_key = sort_key
         self.device = device
+        if not torch.cuda.is_available() and self.device is None:
+            self.device = -1
 
         self.random_shuffler = RandomShuffler()
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/text/issues/236 by setting device to CPU if torch can't detect CUDA. 

I wonder if any tests should be written for this?