### PR TITLE
Add truncate_first parameter to Field Constructor

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -86,6 +86,14 @@ class TestField(TorchtextTestCase):
         field = data.Field(fix_length=3, include_lengths=True)
         assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
 
+        field = data.Field(fix_length=3, truncate_first=True)
+        expected_padded_minibatch = [["of", "data", "."],
+                                     ["yet", "another", "<pad>"],
+                                     ["one", "last", "sent"]]
+        assert field.pad(minibatch) == expected_padded_minibatch
+
+
+
         # Test init_token is properly handled.
         field = data.Field(fix_length=4, init_token="<bos>")
         minibatch = [["a", "sentence", "of", "data", "."],

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -85,14 +85,11 @@ class TestField(TorchtextTestCase):
         assert field.pad(minibatch) == expected_padded_minibatch
         field = data.Field(fix_length=3, include_lengths=True)
         assert field.pad(minibatch) == (expected_padded_minibatch, expected_lengths)
-
         field = data.Field(fix_length=3, truncate_first=True)
         expected_padded_minibatch = [["of", "data", "."],
                                      ["yet", "another", "<pad>"],
                                      ["one", "last", "sent"]]
         assert field.pad(minibatch) == expected_padded_minibatch
-
-
 
         # Test init_token is properly handled.
         field = data.Field(fix_length=4, init_token="<bos>")

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -212,12 +212,12 @@ class Field(RawField):
                 padded.append(
                     [self.pad_token] * max(0, max_len - len(x)) +
                     ([] if self.init_token is None else [self.init_token]) +
-                    list(x[:max_len] if self.truncate_first else x[-max_len:]) +
+                    list(x[-max_len:] if self.truncate_first else x[:max_len]) +
                     ([] if self.eos_token is None else [self.eos_token]))
             else:
                 padded.append(
                     ([] if self.init_token is None else [self.init_token]) +
-                    list(x[:max_len] if self.truncate_first else x[-max_len:]) +
+                    list(x[-max_len:] if self.truncate_first else x[:max_len]) +
                     ([] if self.eos_token is None else [self.eos_token]) +
                     [self.pad_token] * max(0, max_len - len(x)))
             lengths.append(len(padded[-1]) - max(0, max_len - len(x)))


### PR DESCRIPTION
Motivated by Keras test preprocessing.

Using `truncate_first` parameter, we can truncate the sentence at the beginning or at the end. 