### PR TITLE
Fix deprecated StopIteration, increment iterations in BPTTIterator, make epoch() return int

### DIFF
--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -213,13 +213,14 @@ class BPTTIterator(Iterator):
             ('text', TEXT), ('target', TEXT)])
         while True:
             for i in range(0, len(self) * self.bptt_len, self.bptt_len):
+                self.iterations += 1
                 seq_len = min(self.bptt_len, len(data) - i - 1)
                 yield Batch.fromvars(
                     dataset, self.batch_size, train=self.train,
                     text=data[i:i + seq_len],
                     target=data[i + 1:i + 1 + seq_len])
             if not self.repeat:
-                raise StopIteration
+                return
 
 
 class BucketIterator(Iterator):

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -123,7 +123,7 @@ class Iterator(object):
 
     @property
     def epoch(self):
-        return self.iterations / len(self)
+        return math.floor(self.iterations / len(self))
 
     def __len__(self):
         if self.batch_size_fn is not None:


### PR DESCRIPTION
Fixes `BPTTIterator` for #244 and #256 
Also, `iter.epoch` was returning floats, so I floored this to integers since it's more intuitive. This can be reverted easily though if there is a not so obvious use-case.