### PR TITLE
Add WikiText-103 to lang. modeling datasets

### DIFF
--- a/torchtext/datasets/language_modeling.py
+++ b/torchtext/datasets/language_modeling.py
@@ -91,6 +91,67 @@ class WikiText2(LanguageModelingDataset):
             device=device)
 
 
+class WikiText103(LanguageModelingDataset):
+
+    urls = ['https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-v1.zip']
+    name = 'wikitext-103'
+    dirname = 'wikitext-103'
+
+    @classmethod
+    def splits(cls, text_field, root='.data', train='wiki.train.tokens',
+               validation='wiki.valid.tokens', test='wiki.test.tokens',
+               **kwargs):
+        """Create dataset objects for splits of the WikiText-103 dataset.
+
+        This is the most flexible way to use the dataset.
+
+        Arguments:
+            text_field: The field that will be used for text data.
+            root: The root directory that the dataset's zip archive will be
+                expanded into; therefore the directory in whose wikitext-103
+                subdirectory the data files will be stored.
+            train: The filename of the train data. Default: 'wiki.train.tokens'.
+            validation: The filename of the validation data, or None to not
+                load the validation set. Default: 'wiki.valid.tokens'.
+            test: The filename of the test data, or None to not load the test
+                set. Default: 'wiki.test.tokens'.
+        """
+        return super(WikiText103, cls).splits(
+            root=root, train=train, validation=validation, test=test,
+            text_field=text_field, **kwargs)
+
+    @classmethod
+    def iters(cls, batch_size=32, bptt_len=35, device=0, root='.data',
+              vectors=None, **kwargs):
+        """Create iterator objects for splits of the WikiText-103 dataset.
+
+        This is the simplest way to use the dataset, and assumes common
+        defaults for field, vocabulary, and iterator parameters.
+
+        Arguments:
+            batch_size: Batch size.
+            bptt_len: Length of sequences for backpropagation through time.
+            device: Device to create batches on. Use -1 for CPU and None for
+                the currently active GPU device.
+            root: The root directory that the dataset's zip archive will be
+                expanded into; therefore the directory in whose wikitext-2
+                subdirectory the data files will be stored.
+            wv_dir, wv_type, wv_dim: Passed to the Vocab constructor for the
+                text field. The word vectors are accessible as
+                train.dataset.fields['text'].vocab.vectors.
+            Remaining keyword arguments: Passed to the splits method.
+        """
+        TEXT = data.Field()
+
+        train, val, test = cls.splits(TEXT, root=root, **kwargs)
+
+        TEXT.build_vocab(train, vectors=vectors)
+
+        return data.BPTTIterator.splits(
+            (train, val, test), batch_size=batch_size, bptt_len=bptt_len,
+            device=device)
+
+
 class PennTreebank(LanguageModelingDataset):
     """The Penn Treebank dataset.
     A relatively small dataset originally created for POS tagging.


### PR DESCRIPTION
I've noticed that WikiText-103 for language modeling wasn't available in the current codebase, so I added it, following the practices in` text/torchtext/datasets/language_modeling.py`. I've obtained the dataset through [this site](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) (word level).