### PR TITLE
add include_length para in NestedField

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -532,7 +532,8 @@ class TestNestedField(TorchtextTestCase):
         # test include_length
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
                                    init_token="<w>", eos_token="</w>")
-        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True)
+        CHARS = data.NestedField(nesting_field, init_token="<s>",
+                                 eos_token="</s>", include_lengths=True)
         arr, seq_len, words_len = CHARS.pad(minibatch)
         assert arr == expected
         assert seq_len == [5, 4]
@@ -583,12 +584,12 @@ class TestNestedField(TorchtextTestCase):
         # test include length
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
                                    init_token="<w>", eos_token="</w>", fix_length=5)
-        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True)
+        CHARS = data.NestedField(nesting_field, init_token="<s>",
+                                 eos_token="</s>", include_lengths=True)
         arr, seq_len, words_len = CHARS.pad(minibatch)
         assert arr == expected
         assert seq_len == [5, 4]
         assert words_len == [[3, 5, 5, 5, 3], [3, 5, 5, 3, 0]]
-
 
     def test_pad_when_fix_length_is_not_none(self):
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
@@ -617,7 +618,8 @@ class TestNestedField(TorchtextTestCase):
         # test include length
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
                                    init_token="<w>", eos_token="</w>")
-        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True, fix_length=3)
+        CHARS = data.NestedField(nesting_field, init_token="<s>",
+                                 eos_token="</s>", include_lengths=True, fix_length=3)
         arr, seq_len, words_len = CHARS.pad(minibatch)
         assert arr == expected
         assert seq_len == [3, 3]
@@ -677,7 +679,8 @@ class TestNestedField(TorchtextTestCase):
         # test include_length
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
                                    init_token="<w>", eos_token="</w>")
-        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True,
+        CHARS = data.NestedField(nesting_field, init_token="<s>",
+                                 eos_token="</s>", include_lengths=True,
                                  pad_first=True)
         arr, seq_len, words_len = CHARS.pad(minibatch)
         assert arr == expected

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -768,7 +768,7 @@ class TestNestedField(TorchtextTestCase):
                    [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
                    [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
 
-        field.build_vocab(sources, vectors='glove.840B.300d.txt', unk_init=init.xavier_normal,
+        field.build_vocab(sources, vectors='glove.6B.50d.txt', unk_init=init.xavier_normal,
                           vectors_cache=".vector_cache")
 
 class TestLabelField(TorchtextTestCase):

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 import torch
 import torchtext.data as data
 import pytest
+from torch.nn import init
 
 from ..common.torchtext_test_case import TorchtextTestCase, verify_numericalized_example
 
@@ -756,23 +757,19 @@ class TestNestedField(TorchtextTestCase):
                 field, example, numericalized_example, batch_first=True)
 
     def test_build_vocab(self):
-        from torchtext import data
-        from torchtext.vocab import Vectors
-        from torch.nn import init
-        import torch
-
         nesting_field = data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
 
-        field = data.NestedField(nesting_field, init_token='<s>', eos_token='</s>', include_lengths=True,
+        field = data.NestedField(nesting_field, init_token='<s>', eos_token='</s>',
+                                 include_lengths=True,
                                  pad_first=True)
 
-        sources = [[['a'], ['s', 'e', 'n', 't', 'e', 'n', 'c', 'e'], ['o', 'f'], ['d', 'a', 't', 'a'], ['.']],
+        sources = [[['a'], ['s', 'e', 'n', 't', 'e', 'n', 'c', 'e'], ['o', 'f'],
+                    ['d', 'a', 't', 'a'], ['.']],
                    [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
                    [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
 
         field.build_vocab(sources, vectors='glove.840B.300d.txt', unk_init=init.xavier_normal,
                           vectors_cache=".vector_cache")
-
 
 class TestLabelField(TorchtextTestCase):
     def test_init(self):

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -529,6 +529,15 @@ class TestNestedField(TorchtextTestCase):
 
         assert CHARS.pad(minibatch) == expected
 
+        # test include_length
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True)
+        arr, seq_len, words_len = CHARS.pad(minibatch)
+        assert arr == expected
+        assert seq_len == [5, 4]
+        assert words_len == [[3, 6, 7, 6, 3], [3, 6, 7, 3, 0]]
+
     def test_pad_when_nesting_field_is_not_sequential(self):
         nesting_field = data.Field(sequential=False, unk_token="<cunk>",
                                    pad_token="<cpad>", init_token="<w>", eos_token="</w>")
@@ -571,6 +580,16 @@ class TestNestedField(TorchtextTestCase):
 
         assert CHARS.pad(minibatch) == expected
 
+        # test include length
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>", fix_length=5)
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True)
+        arr, seq_len, words_len = CHARS.pad(minibatch)
+        assert arr == expected
+        assert seq_len == [5, 4]
+        assert words_len == [[3, 5, 5, 5, 3], [3, 5, 5, 3, 0]]
+
+
     def test_pad_when_fix_length_is_not_none(self):
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
                                    init_token="<w>", eos_token="</w>")
@@ -594,6 +613,15 @@ class TestNestedField(TorchtextTestCase):
         ]
 
         assert CHARS.pad(minibatch) == expected
+
+        # test include length
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True, fix_length=3)
+        arr, seq_len, words_len = CHARS.pad(minibatch)
+        assert arr == expected
+        assert seq_len == [3, 3]
+        assert words_len == [[3, 6, 3], [3, 6, 3]]
 
     def test_pad_when_no_init_and_eos_tokens(self):
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
@@ -645,6 +673,16 @@ class TestNestedField(TorchtextTestCase):
         ]
 
         assert CHARS.pad(minibatch) == expected
+
+        # test include_length
+        nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",
+                                   init_token="<w>", eos_token="</w>")
+        CHARS = data.NestedField(nesting_field, init_token="<s>", eos_token="</s>", include_lengths=True,
+                                 pad_first=True)
+        arr, seq_len, words_len = CHARS.pad(minibatch)
+        assert arr == expected
+        assert seq_len == [5, 4]
+        assert words_len == [[3, 6, 7, 6, 3], [0, 3, 6, 7, 3]]
 
     def test_numericalize(self):
         nesting_field = data.Field(batch_first=True)

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -768,7 +768,7 @@ class TestNestedField(TorchtextTestCase):
                    [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
                    [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
 
-        field.build_vocab(sources, vectors='glove.6B.50d.txt', unk_init=init.xavier_normal,
+        field.build_vocab(sources, vectors='glove.6B.50d', unk_init=init.xavier_normal,
                           vectors_cache=".vector_cache")
 
 class TestLabelField(TorchtextTestCase):

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -741,11 +741,15 @@ class TestNestedField(TorchtextTestCase):
                 ["<cpad>"] * 7,
             ]
         ]
-        numericalized, seq_len, word_len = field.numericalize(field.pad(examples_data), device=-1)
+
+        numericalized, seq_len, word_len = field.numericalize(
+            (examples_data, [5, 4], [[3, 6, 7, 6, 3], [3, 6, 7, 3, 0]]),
+            device=-1)
 
         assert numericalized.dim() == 3
         assert len(seq_len) == 2
         assert len(word_len) == 2
+
         assert numericalized.size(0) == len(examples_data)
         for example, numericalized_example in zip(examples_data, numericalized):
             verify_numericalized_example(

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -768,8 +768,10 @@ class TestNestedField(TorchtextTestCase):
                    [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
                    [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
 
-        field.build_vocab(sources, vectors='glove.6B.50d', unk_init=init.xavier_normal,
+        field.build_vocab(sources, vectors='glove.6B.50d',
+                          unk_init=init.xavier_normal,
                           vectors_cache=".vector_cache")
+
 
 class TestLabelField(TorchtextTestCase):
     def test_init(self):

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -755,6 +755,24 @@ class TestNestedField(TorchtextTestCase):
             verify_numericalized_example(
                 field, example, numericalized_example, batch_first=True)
 
+    def test_build_vocab(self):
+        from torchtext import data
+        from torchtext.vocab import Vectors
+        from torch.nn import init
+        import torch
+
+        nesting_field = data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
+
+        field = data.NestedField(nesting_field, init_token='<s>', eos_token='</s>', include_lengths=True,
+                                 pad_first=True)
+
+        sources = [[['a'], ['s', 'e', 'n', 't', 'e', 'n', 'c', 'e'], ['o', 'f'], ['d', 'a', 't', 'a'], ['.']],
+                   [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
+                   [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
+
+        field.build_vocab(sources, vectors='glove.840B.300d.txt', unk_init=init.xavier_normal,
+                          vectors_cache=".vector_cache")
+
 
 class TestLabelField(TorchtextTestCase):
     def test_init(self):

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -741,7 +741,7 @@ class TestNestedField(TorchtextTestCase):
                 ["<cpad>"] * 7,
             ]
         ]
-        numericalized, seq_len, word_len = field.numericalize(examples_data, device=-1)
+        numericalized, seq_len, word_len = field.numericalize(field.pad(examples_data), device=-1)
 
         assert numericalized.dim() == 3
         assert len(seq_len) == 2

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -628,14 +628,17 @@ class NestedField(Field):
                 will be created with volatile=True. Default: True.
         """
         numericalized = []
+        old_include_lengths = self.include_lengths
         if self.include_lengths:
             arrs, sentence_lengths, word_lengths = arrs
+            self.include_lengths = False
         for arr in arrs:
             numericalized_ex = self.nesting_field.numericalize(
                 arr, device=device, train=train)
             numericalized.append(numericalized_ex)
         padded_batch = torch.stack(numericalized)
-        if self.include_lengths:
+        if old_include_lengths:
+            self.include_lengths = True
             return padded_batch, torch.LongTensor(sentence_lengths).cuda(device), torch.LongTensor(word_lengths).cuda(
                 device)
         return padded_batch

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -635,7 +635,8 @@ class NestedField(Field):
         super(NestedField, self).build_vocab()
         self.vocab.extend(self.nesting_field.vocab)
         if old_vectors is not None:
-            self.vocab.load_vectors(old_vectors, unk_init=old_unk_init, cache=old_vectors_cache)
+            self.vocab.load_vectors(old_vectors,
+                                    unk_init=old_unk_init, cache=old_vectors_cache)
 
         self.nesting_field.vocab = self.vocab
 

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -647,6 +647,7 @@ class NestedField(Field):
                 arr, device=device, train=train)
             numericalized.append(numericalized_ex)
         padded_batch = torch.stack(numericalized)
+
         self.nesting_field.include_lengths = True
         if self.include_lengths:
             sentence_lengths = torch.LongTensor(sentence_lengths)

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -161,8 +161,8 @@ class Field(RawField):
         first. If `sequential=True`, it will be tokenized. Then the input
         will be optionally lowercased and passed to the user-provided
         `preprocessing` Pipeline."""
-        if (six.PY2 and isinstance(x, six.string_types) and not
-        isinstance(x, six.text_type)):
+        if (six.PY2 and isinstance(x, six.string_types) and
+                not isinstance(x, six.text_type)):
             x = Pipeline(lambda s: six.text_type(s, encoding='utf-8'))(x)
         if self.sequential and isinstance(x, six.text_type):
             x = self.tokenize(x.rstrip('\n'))
@@ -566,11 +566,15 @@ class NestedField(Field):
                 lens = lens
                 pad = pad
             elif self.pad_first:
-                lens[:(max_sen_len - sentence_len)] = [0] * (max_sen_len - sentence_len)
-                pad[:(max_sen_len - sentence_len)] = [self.pad_token] * (max_sen_len - sentence_len)
+                lens[:(max_sen_len - sentence_len)] = (
+                    [0] * (max_sen_len - sentence_len))
+                pad[:(max_sen_len - sentence_len)] = (
+                    [self.pad_token] * (max_sen_len - sentence_len))
             else:
-                lens[-(max_sen_len - sentence_len):] = [0] * (max_sen_len - sentence_len)
-                pad[-(max_sen_len - sentence_len):] = [self.pad_token] * (max_sen_len - sentence_len)
+                lens[-(max_sen_len - sentence_len):] = (
+                    [0] * (max_sen_len - sentence_len))
+                pad[-(max_sen_len - sentence_len):] = (
+                    [self.pad_token] * (max_sen_len - sentence_len))
             word_lengths.append(lens)
             final_padded.append(pad)
         padded = final_padded
@@ -641,8 +645,9 @@ class NestedField(Field):
         padded_batch = torch.stack(numericalized)
         if old_include_lengths:
             self.include_lengths = True
-            return padded_batch, torch.LongTensor(sentence_lengths).cuda(device), torch.LongTensor(word_lengths).cuda(
-                device)
+            return (padded_batch,
+                    torch.LongTensor(sentence_lengths).cuda(device),
+                    torch.LongTensor(word_lengths).cuda(device))
         return padded_batch
 
 

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -161,8 +161,8 @@ class Field(RawField):
         first. If `sequential=True`, it will be tokenized. Then the input
         will be optionally lowercased and passed to the user-provided
         `preprocessing` Pipeline."""
-        if (six.PY2 and isinstance(x, six.string_types) and not
-        isinstance(x, six.text_type)):
+        if (six.PY2 and isinstance(x, six.string_types) and
+                not isinstance(x, six.text_type)):
             x = Pipeline(lambda s: six.text_type(s, encoding='utf-8'))(x)
         if self.sequential and isinstance(x, six.text_type):
             x = self.tokenize(x.rstrip('\n'))

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -618,9 +618,25 @@ class NestedField(Field):
         flattened = []
         for source in sources:
             flattened.extend(source)
+        old_vectors = None
+        old_unk_init = None
+        old_vectors_cache = None
+        if "vectors" in kwargs.keys():
+            old_vectors = kwargs["vectors"]
+            kwargs["vectors"] = None
+        if "unk_init" in kwargs.keys():
+            old_unk_init = kwargs["unk_init"]
+            kwargs["unk_init"] = None
+        if "vectors_cache" in kwargs.keys():
+            old_vectors_cache = kwargs["vectors_cache"]
+            kwargs["vectors_cache"] = None
+        # just build vocab and does not load vector
         self.nesting_field.build_vocab(*flattened, **kwargs)
         super(NestedField, self).build_vocab()
         self.vocab.extend(self.nesting_field.vocab)
+        if old_vectors is not None:
+            self.vocab.load_vectors(old_vectors, unk_init=old_unk_init, cache=old_vectors_cache)
+
         self.nesting_field.vocab = self.vocab
 
     def numericalize(self, arrs, device=None, train=True):

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -565,9 +565,11 @@ class NestedField(Field):
                 if sentence_len == max_sen_len:
                     lens = lens
                 elif self.pad_first:
-                    lens[:(max_sen_len - sentence_len)] = [0] * (max_sen_len - sentence_len)
+                    lens[:(max_sen_len - sentence_len)] = (
+                        [0] * (max_sen_len - sentence_len))
                 else:
-                    lens[-(max_sen_len - sentence_len):] = [0] * (max_sen_len - sentence_len)
+                    lens[-(max_sen_len - sentence_len):] = (
+                        [0] * (max_sen_len - sentence_len))
                 word_lengths.append(lens)
                 final_padded.append(pad)
             padded = final_padded
@@ -640,8 +642,9 @@ class NestedField(Field):
         padded_batch = torch.stack(numericalized)
         if old_include_lengths:
             self.include_lengths = True
-            return padded_batch, torch.LongTensor(sentence_lengths).cuda(device), torch.LongTensor(word_lengths).cuda(
-                device)
+            return (padded_batch,
+                    torch.LongTensor(sentence_lengths).cuda(device),
+                    torch.LongTensor(word_lengths).cuda(device))
         return padded_batch
 
 

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -444,7 +444,8 @@ class NestedField(Field):
 
     def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
                  fix_length=None, tensor_type=torch.LongTensor, preprocessing=None,
-                 postprocessing=None, tokenize=lambda s: s.split(), include_lengths=False, pad_token='<pad>',
+                 postprocessing=None, tokenize=lambda s: s.split(),
+                 include_lengths=False, pad_token='<pad>',
                  pad_first=False):
         if isinstance(nesting_field, NestedField):
             raise ValueError('nesting field must not be another NestedField')

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -532,7 +532,7 @@ class NestedField(Field):
                 otherwise.
 
         Returns:
-            list: The padded minibatch.
+            list: The padded minibatch. or (padded, sentence_lens, word_lengths)
         """
         minibatch = list(minibatch)
         if not self.nesting_field.sequential:
@@ -638,20 +638,24 @@ class NestedField(Field):
                 will be created with volatile=True. Default: True.
         """
         numericalized = []
-        old_include_lengths = self.include_lengths
+        self.nesting_field.include_lengths = False
         if self.include_lengths:
             arrs, sentence_lengths, word_lengths = arrs
-            self.include_lengths = False
+
         for arr in arrs:
             numericalized_ex = self.nesting_field.numericalize(
                 arr, device=device, train=train)
             numericalized.append(numericalized_ex)
         padded_batch = torch.stack(numericalized)
-        if old_include_lengths:
-            self.include_lengths = True
-            return (padded_batch,
-                    torch.LongTensor(sentence_lengths).cuda(device),
-                    torch.LongTensor(word_lengths).cuda(device))
+        self.nesting_field.include_lengths = True
+        if self.include_lengths:
+            sentence_lengths = torch.LongTensor(sentence_lengths)
+            word_lengths = torch.LongTensor(word_lengths)
+            if device == -1:
+                return (padded_batch, sentence_lengths, word_lengths)
+            else:
+                return (padded_batch,
+                        sentence_lengths.cuda(device), word_lengths.cuda(device))
         return padded_batch
 
 

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -444,8 +444,9 @@ class NestedField(Field):
 
     def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
                  fix_length=None, tensor_type=torch.LongTensor, preprocessing=None,
-                 postprocessing=None, tokenize=lambda s: s.split(), include_lengths=False, pad_token='<pad>',
-                 pad_first=False):
+                 postprocessing=None, tokenize=lambda s: s.split(),
+                 include_lengths=False, pad_token='<pad>',
+                 pad_first=False, truncate_first=False):
         if isinstance(nesting_field, NestedField):
             raise ValueError('nesting field must not be another NestedField')
         if nesting_field.include_lengths:
@@ -467,6 +468,7 @@ class NestedField(Field):
             pad_token=pad_token,
             unk_token=nesting_field.unk_token,
             pad_first=pad_first,
+            truncate_first=truncate_first,
             include_lengths=include_lengths
         )
         self.nesting_field = nesting_field

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -472,6 +472,8 @@ class NestedField(Field):
             include_lengths=include_lengths
         )
         self.nesting_field = nesting_field
+        # in case the user forget to do that
+        self.nesting_field.batch_first = True
 
     def preprocess(self, xs):
         """Preprocess a single example.


### PR DESCRIPTION
1. The sentence_length and word_length infomation couldn't be fetched from the origin NestedField, and i think the word_length infomation is useful to help us to get the right character rnn result through mask the rnn's output. In the new NestedField, the `include_lengths` parameter have beed added to the `__init__` method, using this parameter to determin whether return the `sentence_length` and `word_length` with `padded` mini-batch. 

2. fix the NestedField build_vocab method