### PR TITLE
[Bug Fix] numericalize doesn't create cuda tensor 

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -336,7 +336,7 @@ class TestField(TorchtextTestCase):
         # Test basic usage
         int_field = data.Field(sequential=False, use_vocab=False)
         float_field = data.Field(sequential=False, use_vocab=False,
-                                 tensor_type=torch.FloatTensor)
+                                 dtype=torch.float)
         tsv_fields = [("int", int_field), ("float", float_field), ("string", None)]
         tsv_dataset = data.TabularDataset(
             path=self.test_numerical_features_dataset_path, format="tsv",
@@ -355,7 +355,7 @@ class TestField(TorchtextTestCase):
         int_field = data.Field(sequential=False, use_vocab=False,
                                postprocessing=lambda arr, _: [x + 1 for x in arr])
         float_field = data.Field(sequential=False, use_vocab=False,
-                                 tensor_type=torch.FloatTensor,
+                                 dtype=torch.float,
                                  postprocessing=lambda arr, _: [x * 0.5 for x in arr])
         tsv_fields = [("int", int_field), ("float", float_field), ("string", None)]
         tsv_dataset = data.TabularDataset(
@@ -406,7 +406,7 @@ class TestNestedField(TorchtextTestCase):
         assert field.eos_token is None
         assert field.unk_token == nesting_field.unk_token
         assert field.fix_length is None
-        assert field.tensor_type is torch.LongTensor
+        assert field.dtype is torch.long
         assert field.preprocessing is None
         assert field.postprocessing is None
         assert field.lower == nesting_field.lower
@@ -444,7 +444,7 @@ class TestNestedField(TorchtextTestCase):
             init_token="<s>",
             eos_token="</s>",
             fix_length=10,
-            tensor_type=torch.FloatTensor,
+            dtype=torch.float,
             preprocessing=lambda xs: list(reversed(xs)),
             postprocessing=lambda xs: [x.upper() for x in xs],
             tokenize=list,
@@ -455,7 +455,7 @@ class TestNestedField(TorchtextTestCase):
         assert field.init_token == "<s>"
         assert field.eos_token == "</s>"
         assert field.fix_length == 10
-        assert field.tensor_type is torch.FloatTensor
+        assert field.dtype is torch.float
         assert field.preprocessing("a b c".split()) == "c b a".split()
         assert field.postprocessing("a b c".split()) == "A B C".split()
         assert field.tokenize("abc") == ["a", "b", "c"]

--- a/torchtext/datasets/babi.py
+++ b/torchtext/datasets/babi.py
@@ -2,7 +2,6 @@ import os
 from io import open
 
 import torch
-from torch.autograd import Variable
 
 from ..data import Dataset, Field, Example, Iterator
 
@@ -36,21 +35,18 @@ class BABI20Field(Field):
         else:
             return super(BABI20Field, self).pad(minibatch)
 
-    def numericalize(self, arr, device=None, train=True):
+    def numericalize(self, arr, device=None):
         if isinstance(arr[0][0], list):
             tmp = [
-                super(BABI20Field, self).numericalize(x, device=device, train=train).data
+                super(BABI20Field, self).numericalize(x, device=device).data
                 for x in arr
             ]
             arr = torch.stack(tmp)
-            if device == -1:
-                if self.sequential:
-                    arr = arr.contiguous()
-            else:
-                arr = arr.cuda(device)
-            return Variable(arr, volatile=not train)
+            if self.sequential:
+                arr = arr.contiguous()
+            return arr
         else:
-            return super(BABI20Field, self).numericalize(arr, device=device, train=train)
+            return super(BABI20Field, self).numericalize(arr, device=device)
 
 
 class BABI20(Dataset):


### PR DESCRIPTION
the fixes to pytorch 0.4 compatibility issues stop creating cuda tensor due to:
```python
self.tensor_type(arr, device=device)
```
tensor_type is torch.LongTensor by default which doesn't accept a `device` argument. as suggested by [migration guide](http://pytorch.org/2018/04/22/0_4_0-migration-guide.html), i change it to `torch.tensor` for numericalization. 

pytorch 0.4 also decouples type, device, layout from creation of tensors. i changed `tensor_type` to `dtype`, because the tensor_type like `torch.LongTensor` explicitly creates a CPU dense tensor of type long, which means more than just a type.