### PR TITLE
Make vector loading more flexible.

### DIFF
--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -252,6 +252,10 @@ class Vectors(object):
         cache = '.vector_cache' if cache is None else cache
         self.unk_init = torch.Tensor.zero_ if unk_init is None else unk_init
         self.cache(name, cache, url=url, max_vectors=max_vectors)
+        self.itos = None
+        self.stoi = None
+        self.vectors = None
+        self.dim = None
 
     def __getitem__(self, token):
         if token in self.stoi:

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -1,8 +1,6 @@
 from __future__ import unicode_literals
-import array
 from collections import defaultdict
 from functools import partial
-import io
 import logging
 import os
 import zipfile
@@ -248,10 +246,13 @@ class Vectors(object):
            unk_init (callback): by default, initalize out-of-vocabulary word vectors
                to zero vectors; can be any function that takes in a Tensor and
                returns a Tensor of the same size
-            max_vectors (int): this can be used to limit the number of pre-trained vectors loaded.
-                Most pre-trained vector sets are sorted in the descending order of word frequency.
-                Thus, in situations where the entire set doesn't fit in memory, or is not needed
-                for another reason, passing max_vectors can limit the size of the loaded set.
+            max_vectors (int): this can be used to limit the number of
+                pre-trained vectors loaded.
+                Most pre-trained vector sets are sorted
+                in the descending order of word frequency.
+                Thus, in situations where the entire set doesn't fit in memory,
+                or is not needed for another reason, passing `max_vectors`
+                can limit the size of the loaded set.
          """
         cache = '.vector_cache' if cache is None else cache
         self.itos = None
@@ -339,7 +340,8 @@ class Vectors(object):
                         raise RuntimeError(
                             "Vector for token {} has {} dimensions, but previously "
                             "read vectors have {} dimensions. All vectors must have "
-                            "the same number of dimensions.".format(word, len(entries), dim))
+                            "the same number of dimensions.".format(word, len(entries),
+                                                                    dim))
 
                     try:
                         if isinstance(word, six.binary_type):

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -262,10 +262,18 @@ class Vectors(object):
     def cache(self, name, cache, url=None, max_vectors=None):
         if os.path.isfile(name):
             path = name
-            path_pt = os.path.join(cache, os.path.basename(name)) + '.pt'
+            if max_vectors:
+                file_suffix = '_{}.pt'.format(max_vectors)
+            else:
+                file_suffix = '.pt'
+            path_pt = os.path.join(cache, os.path.basename(name)) + file_suffix
         else:
             path = os.path.join(cache, name)
-            path_pt = path + '.pt'
+            if max_vectors:
+                file_suffix = '_{}.pt'.format(max_vectors)
+            else:
+                file_suffix = '.pt'
+            path_pt = path + file_suffix
 
         if not os.path.isfile(path_pt):
             if not os.path.isfile(path) and url:

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -300,10 +300,6 @@ class Vectors(object):
             if not os.path.isfile(path):
                 raise RuntimeError('no vectors found at {}'.format(path))
 
-            # str call is necessary for Python 2/3 compatibility, since
-            # argument must be Python 2 str (Python 3 bytes) or
-            # Python 3 str (Python 2 unicode)
-
             logger.info("Loading vectors from {}".format(path))
             ext = os.path.splitext(path)[1][1:]
             if ext == 'gz':

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -248,6 +248,10 @@ class Vectors(object):
            unk_init (callback): by default, initalize out-of-vocabulary word vectors
                to zero vectors; can be any function that takes in a Tensor and
                returns a Tensor of the same size
+            max_vectors (int): this can be used to limit the number of pre-trained vectors loaded.
+                Most pre-trained vector sets are sorted in the descending order of word frequency.
+                Thus, in situations where the entire set doesn't fit in memory, or is not needed
+                for another reason, passing max_vectors can limit the size of the loaded set.
          """
         cache = '.vector_cache' if cache is None else cache
         self.unk_init = torch.Tensor.zero_ if unk_init is None else unk_init

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -254,12 +254,12 @@ class Vectors(object):
                 for another reason, passing max_vectors can limit the size of the loaded set.
          """
         cache = '.vector_cache' if cache is None else cache
-        self.unk_init = torch.Tensor.zero_ if unk_init is None else unk_init
-        self.cache(name, cache, url=url, max_vectors=max_vectors)
         self.itos = None
         self.stoi = None
         self.vectors = None
         self.dim = None
+        self.unk_init = torch.Tensor.zero_ if unk_init is None else unk_init
+        self.cache(name, cache, url=url, max_vectors=max_vectors)
 
     def __getitem__(self, token):
         if token in self.stoi:

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -6,6 +6,7 @@ import io
 import logging
 import os
 import zipfile
+import gzip
 
 import six
 from six.moves.urllib.request import urlretrieve
@@ -221,7 +222,7 @@ class SubwordVocab(Vocab):
 class Vectors(object):
 
     def __init__(self, name, cache=None,
-                 url=None, unk_init=None):
+                 url=None, unk_init=None, max_vectors=None):
         """
         Arguments:
            name: name of the file that contains the vectors
@@ -233,7 +234,7 @@ class Vectors(object):
          """
         cache = '.vector_cache' if cache is None else cache
         self.unk_init = torch.Tensor.zero_ if unk_init is None else unk_init
-        self.cache(name, cache, url=url)
+        self.cache(name, cache, url=url, max_vectors=max_vectors)
 
     def __getitem__(self, token):
         if token in self.stoi:
@@ -241,7 +242,7 @@ class Vectors(object):
         else:
             return self.unk_init(torch.Tensor(1, self.dim))
 
-    def cache(self, name, cache, url=None):
+    def cache(self, name, cache, url=None, max_vectors=None):
         if os.path.isfile(name):
             path = name
             path_pt = os.path.join(cache, os.path.basename(name)) + '.pt'
@@ -268,8 +269,9 @@ class Vectors(object):
                     with zipfile.ZipFile(dest, "r") as zf:
                         zf.extractall(cache)
                 elif ext == 'gz':
-                    with tarfile.open(dest, 'r:gz') as tar:
-                        tar.extractall(path=cache)
+                    if dest.endswith('.tar.gz'):
+                        with tarfile.open(dest, 'r:gz') as tar:
+                            tar.extractall(path=cache)
             if not os.path.isfile(path):
                 raise RuntimeError('no vectors found at {}'.format(path))
 
@@ -278,49 +280,44 @@ class Vectors(object):
             # Python 3 str (Python 2 unicode)
             itos, vectors, dim = [], array.array(str('d')), None
 
-            # Try to read the whole file with utf-8 encoding.
-            binary_lines = False
-            try:
-                with io.open(path, encoding="utf8") as f:
-                    lines = [line for line in f]
-            # If there are malformed lines, read in binary mode
-            # and manually decode each word from utf-8
-            except:
-                logger.warning("Could not read {} as UTF8 file, "
-                               "reading file as bytes and skipping "
-                               "words with malformed UTF8.".format(path))
-                with open(path, 'rb') as f:
-                    lines = [line for line in f]
-                binary_lines = True
-
             logger.info("Loading vectors from {}".format(path))
-            for line in tqdm(lines, total=len(lines)):
-                # Explicitly splitting on " " is important, so we don't
-                # get rid of Unicode non-breaking spaces in the vectors.
-                entries = line.rstrip().split(b" " if binary_lines else " ")
+            ext = os.path.splitext(path)[1][1:]
+            if ext == 'gz':
+                open_file = gzip.open
+            else:
+                open_file = open
 
-                word, entries = entries[0], entries[1:]
-                if dim is None and len(entries) > 1:
-                    dim = len(entries)
-                elif len(entries) == 1:
-                    logger.warning("Skipping token {} with 1-dimensional "
-                                   "vector {}; likely a header".format(word, entries))
-                    continue
-                elif dim != len(entries):
-                    raise RuntimeError(
-                        "Vector for token {} has {} dimensions, but previously "
-                        "read vectors have {} dimensions. All vectors must have "
-                        "the same number of dimensions.".format(word, len(entries), dim))
+            vectors_loaded = 0
+            with open_file(path, 'rb') as f:
+                for line in tqdm(f):
+                    # Explicitly splitting on " " is important, so we don't
+                    # get rid of Unicode non-breaking spaces in the vectors.
+                    entries = line.rstrip().split(b" ")
 
-                if binary_lines:
+                    word, entries = entries[0], entries[1:]
+                    if dim is None and len(entries) > 1:
+                        dim = len(entries)
+                    elif len(entries) == 1:
+                        logger.warning("Skipping token {} with 1-dimensional "
+                                       "vector {}; likely a header".format(word, entries))
+                        continue
+                    elif dim != len(entries):
+                        raise RuntimeError(
+                            "Vector for token {} has {} dimensions, but previously "
+                            "read vectors have {} dimensions. All vectors must have "
+                            "the same number of dimensions.".format(word, len(entries), dim))
+
                     try:
                         if isinstance(word, six.binary_type):
                             word = word.decode('utf-8')
-                    except:
+                    except UnicodeDecodeError:
                         logger.info("Skipping non-UTF8 token {}".format(repr(word)))
                         continue
-                vectors.extend(float(x) for x in entries)
-                itos.append(word)
+                    vectors.extend(float(x) for x in entries)
+                    itos.append(word)
+                    vectors_loaded += 1
+                    if vectors_loaded == max_vectors:
+                        break
 
             self.itos = itos
             self.stoi = {word: i for i, word in enumerate(itos)}


### PR DESCRIPTION
* Add support for passing a `max_vectors` argument, in situations where the entire set of pre-trained vectors can't fit in memory (most pre-trained vector sets are sorted in the descending order of word frequency, so if you pass, say, `max_vectors=100_000`, you will get pre-trained for 100_000 most common words)
* Add ability to read pre-trained vectors from gzipped files (without tar)
* Read pre-trained vectors by iterating over the vectors file object line by line, without reading the whole file into memory first
* Only load the file in binary mode to make parsing logic more compact
* Make vector loading more memory-efficient (based on #298)
* Minor refactoring to improve style