### PR TITLE
Patch subword test failing in python 2.7

### DIFF
--- a/test/data/test_subword.py
+++ b/test/data/test_subword.py
@@ -1,10 +1,14 @@
 import unittest
+import pytest
+import sys
 
 from torchtext import data
 from torchtext.datasets import TREC
 
 
 class TestSubword(unittest.TestCase):
+    @pytest.mark.skipif(sys.version_info < (3,0),
+                    reason="revtok currently breaks for python 2.7")
     def test_subword_trec(self):
         TEXT = data.SubwordField()
         LABEL = data.Field(sequential=False)

--- a/test/data/test_subword.py
+++ b/test/data/test_subword.py
@@ -8,7 +8,7 @@ from torchtext.datasets import TREC
 
 class TestSubword(unittest.TestCase):
     @pytest.mark.skipif(sys.version_info < (3,0),
-                    reason="revtok currently breaks for python 2.7")
+                        reason="revtok currently breaks for python 2.7")
     def test_subword_trec(self):
         TEXT = data.SubwordField()
         LABEL = data.Field(sequential=False)

--- a/test/data/test_subword.py
+++ b/test/data/test_subword.py
@@ -7,7 +7,7 @@ from torchtext.datasets import TREC
 
 
 class TestSubword(unittest.TestCase):
-    @pytest.mark.skipif(sys.version_info < (3,0),
+    @pytest.mark.skipif(sys.version_info < (3, 0),
                         reason="revtok currently breaks for python 2.7")
     def test_subword_trec(self):
         TEXT = data.SubwordField()


### PR DESCRIPTION
[TestSubword](https://github.com/pytorch/text/blob/master/test/data/test_subword.py#L8) fails for python 2.7, making other tests not to run in recent PR's.

Since the problem seems to be external (revtok), this patch will skip the test for py2.7 so that the failing test does not stop patch and codecov.