### PR TITLE
Fix 'splits' functions of Multi30k and WMT14 datasets 

### DIFF
--- a/torchtext/datasets/translation.py
+++ b/torchtext/datasets/translation.py
@@ -97,7 +97,7 @@ class Multi30k(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
-        path = os.path.join('data', 'multi30k')
+        path = os.path.join('data', self.name)
         return super(Multi30k, cls).splits(
             exts, fields, path, root, train, validation, test, **kwargs)
 
@@ -206,6 +206,6 @@ class WMT14(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
-        path = os.path.join('data', 'wmt14')
+        path = os.path.join('data', self.name)
         return super(WMT14, cls).splits(
             exts, fields, path, root, train, validation, test, **kwargs)

--- a/torchtext/datasets/translation.py
+++ b/torchtext/datasets/translation.py
@@ -97,7 +97,7 @@ class Multi30k(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
-        path = os.path.join('data', self.name)
+        path = os.path.join('data', cls.name)
         return super(Multi30k, cls).splits(
             exts, fields, path, root, train, validation, test, **kwargs)
 
@@ -206,6 +206,6 @@ class WMT14(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
-        path = os.path.join('data', self.name)
+        path = os.path.join('data', cls.name)
         return super(WMT14, cls).splits(
             exts, fields, path, root, train, validation, test, **kwargs)

--- a/torchtext/datasets/translation.py
+++ b/torchtext/datasets/translation.py
@@ -97,8 +97,9 @@ class Multi30k(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
+        path = os.path.join('data', 'multi30k')
         return super(Multi30k, cls).splits(
-            exts, fields, root, train, validation, test, **kwargs)
+            exts, fields, path, root, train, validation, test, **kwargs)
 
 
 class IWSLT(TranslationDataset):
@@ -205,5 +206,6 @@ class WMT14(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
+        path = os.path.join('data', 'wmt14')
         return super(WMT14, cls).splits(
-            exts, fields, root, train, validation, test, **kwargs)
+            exts, fields, path, root, train, validation, test, **kwargs)


### PR DESCRIPTION
Should fix #312. Added path arguments to Multi30k and WMT14 splits.