### PR TITLE
Adding a link to the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,11 @@ Alternatively, you might want to use Moses tokenizer from `NLTK <http://nltk.org
     pip install nltk
     python -m nltk.downloader perluniprops nonbreaking_prefixes
 
+Documentation
+=============
+
+Find the documentation `here <https://torchtext.readthedocs.io/en/latest/index.html>`.
+
 Data
 ====
 


### PR DESCRIPTION
Couldn't find the documentation in the `readme.rst`, so I've added it.