### PR TITLE
Fix parameter's explanation in Dataset.split

### DIFF
--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -97,7 +97,7 @@ class Dataset(torch.utils.data.Dataset):
                 Default is False.
             strata_field (str): name of the examples Field stratified over.
                 Default is 'label' for the conventional label field.
-            random_state (int): the random seed used for shuffling.
+            random_state (tuple): the random seed used for shuffling. A return value of `random.getstate()`.
 
         Returns:
             Tuple[Dataset]: Datasets for train, validation, and

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -97,7 +97,8 @@ class Dataset(torch.utils.data.Dataset):
                 Default is False.
             strata_field (str): name of the examples Field stratified over.
                 Default is 'label' for the conventional label field.
-            random_state (tuple): the random seed used for shuffling. A return value of `random.getstate()`.
+            random_state (tuple): the random seed used for shuffling.
+                A return value of `random.getstate()`.
 
         Returns:
             Tuple[Dataset]: Datasets for train, validation, and


### PR DESCRIPTION
Current `random_state` takes a tuple returned by `random.getstate()`, not `int` (See #336 ). So I fix the docstring.
