### PR TITLE
Fix translation dataset splits errors

### DIFF
--- a/test/translation.py
+++ b/test/translation.py
@@ -78,7 +78,7 @@ EN = data.Field(tokenize=tokenize_en)
 
 train, val = datasets.TranslationDataset.splits(
     path='.data/multi30k/', train='train',
-    validation='val', exts=('.de', '.en'),
+    validation='val', test=None, exts=('.de', '.en'),
     fields=(DE, EN))
 
 print(train.fields)

--- a/torchtext/datasets/translation.py
+++ b/torchtext/datasets/translation.py
@@ -99,6 +99,7 @@ class Multi30k(TranslationDataset):
         """
         expected_folder = os.path.join(root, cls.name)
         path = expected_folder if os.path.exists(expected_folder) else None
+
         return super(Multi30k, cls).splits(
             exts, fields, path, root, train, validation, test, **kwargs)
 

--- a/torchtext/datasets/translation.py
+++ b/torchtext/datasets/translation.py
@@ -97,7 +97,8 @@ class Multi30k(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
-        path = os.path.join('data', cls.name)
+        expected_folder = os.path.join(root, cls.name)
+        path = expected_folder if os.path.exists(expected_folder) else None
         return super(Multi30k, cls).splits(
             exts, fields, path, root, train, validation, test, **kwargs)
 
@@ -206,6 +207,8 @@ class WMT14(TranslationDataset):
             Remaining keyword arguments: Passed to the splits method of
                 Dataset.
         """
-        path = os.path.join('data', cls.name)
+        expected_folder = os.path.join(root, cls.name)
+        path = expected_folder if os.path.exists(expected_folder) else None
+
         return super(WMT14, cls).splits(
             exts, fields, path, root, train, validation, test, **kwargs)


### PR DESCRIPTION
Fixes #384

The situation here is much more convoluted than necessary, and I don't like two path checks in a row.