### PR TITLE
fixed ParseTextField postprocessing, added genre field to MultiNLI

### DIFF
--- a/test/nli.py
+++ b/test/nli.py
@@ -2,58 +2,65 @@ from torchtext import data
 from torchtext import datasets
 
 # Testing SNLI
-TEXT = data.Field()
-LABEL = data.Field(sequential=False)
+print("Run test on SNLI...")
+TEXT = datasets.nli.ParsedTextField()
+LABEL = data.LabelField()
+TREE = datasets.nli.ShiftReduceField()
 
-train, val, test = datasets.SNLI.splits(TEXT, LABEL)
+train, val, test = datasets.SNLI.splits(TEXT, LABEL, TREE)
 
-print(train.fields)
-print(len(train))
-print(vars(train[0]))
+print("Fields:", train.fields)
+print("Number of examples:\n", len(train))
+print("First Example instance:\n", vars(train[0]))
 
 TEXT.build_vocab(train)
 LABEL.build_vocab(train)
 
-train_iter, val_iter, test_iter = data.BucketIterator.splits(
-    (train, val, test), batch_size=3)
+train_iter, val_iter, test_iter = data.Iterator.splits((train, val, test), batch_size=3)
 
 batch = next(iter(train_iter))
-print(batch.premise)
-print(batch.hypothesis)
-print(batch.label)
+print("Numericalize premises:\n", batch.premise)
+print("Numericalize hypotheses:\n", batch.hypothesis)
+print("Entailment labels:\n", batch.label)
 
-train_iter, val_iter, test_iter = datasets.SNLI.iters(batch_size=4)
+print("Test iters function")
+train_iter, val_iter, test_iter = datasets.SNLI.iters(batch_size=4, trees=True)
 
 batch = next(iter(train_iter))
-print(batch.premise)
-print(batch.hypothesis)
-print(batch.label)
+print("Numericalize premises:\n", batch.premise)
+print("Numericalize hypotheses:\n", batch.hypothesis)
+print("Entailment labels:\n", batch.label)
 
 
 # Testing MultiNLI
-TEXT = data.Field()
-LABEL = data.Field(sequential=False)
+print("Run test on MultiNLI...")
+TEXT = datasets.nli.ParsedTextField()
+LABEL = data.LabelField()
+GENRE = data.LabelField()
+TREE = datasets.nli.ShiftReduceField()
 
-train, val, test = datasets.MultiNLI.splits(TEXT, LABEL)
+train, val, test = datasets.MultiNLI.splits(TEXT, LABEL, TREE, GENRE)
 
-print(train.fields)
-print(len(train))
-print(vars(train[0]))
+print("Fields:", train.fields)
+print("Number of examples:\n", len(train))
+print("First Example instance:\n", vars(train[0]))
 
 TEXT.build_vocab(train)
 LABEL.build_vocab(train)
+GENRE.build_vocab(train, val, test)
 
-train_iter, val_iter, test_iter = data.BucketIterator.splits(
-    (train, val, test), batch_size=3)
-
-batch = next(iter(train_iter))
-print(batch.premise)
-print(batch.hypothesis)
-print(batch.label)
-
-train_iter, val_iter, test_iter = datasets.MultiNLI.iters(batch_size=4)
+train_iter, val_iter, test_iter = data.Iterator.splits((train, val, test), batch_size=3)
 
 batch = next(iter(train_iter))
-print(batch.premise)
-print(batch.hypothesis)
-print(batch.label)
+print("Numericalize premises:\n", batch.premise)
+print("Numericalize hypotheses:\n", batch.hypothesis)
+print("Entailment labels:\n", batch.label)
+print("Genre categories:\n", batch.genre)
+
+print("Test iters function")
+train_iter, val_iter, test_iter = datasets.MultiNLI.iters(batch_size=4, trees=True)
+
+batch = next(iter(train_iter))
+print("Numericalize premises:\n", batch.premise)
+print("Numericalize hypotheses:\n", batch.hypothesis)
+print("Entailment labels:\n", batch.label)

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -97,7 +97,8 @@ class Dataset(torch.utils.data.Dataset):
                 Default is False.
             strata_field (str): name of the examples Field stratified over.
                 Default is 'label' for the conventional label field.
-            random_state (int): the random seed used for shuffling.
+            random_state (tuple): the random seed used for shuffling.
+                A return value of `random.getstate()`.
 
         Returns:
             Tuple[Dataset]: Datasets for train, validation, and

--- a/torchtext/datasets/nli.py
+++ b/torchtext/datasets/nli.py
@@ -18,15 +18,17 @@ class ParsedTextField(data.Field):
         the parse tree annotations are already in tokenized form.
     """
     def __init__(self, eos_token='<pad>', lower=False, reverse=False):
-        """ remove parentheses to recover the original sentences """
-        preprocessing = lambda parse: [t for t in parse if t not in ('(', ')')]
         if reverse:
-            postprocessing = lambda parse, _: [list(reversed(p)) for p in parse]
+            super(ParsedTextField, self).__init__(
+                eos_token=eos_token, lower=lower,
+                preprocessing=lambda parse: [t for t in parse if t not in ('(', ')')],
+                postprocessing=lambda parse, _: [list(reversed(p)) for p in parse],
+                include_lengths=True)
         else:
-            postprocessing = None
-        super(ParsedTextField, self).__init__(
-            eos_token=eos_token, lower=lower, preprocessing=preprocessing,
-            postprocessing=postprocessing, include_lengths=True)
+            super(ParsedTextField, self).__init__(
+                eos_token=eos_token, lower=lower,
+                preprocessing=lambda parse: [t for t in parse if t not in ('(', ')')],
+                include_lengths=True)
 
 
 class NLIDataset(data.TabularDataset):

--- a/torchtext/datasets/nli.py
+++ b/torchtext/datasets/nli.py
@@ -41,8 +41,9 @@ class NLIDataset(data.TabularDataset):
             len(ex.premise), len(ex.hypothesis))
 
     @classmethod
-    def splits(cls, text_field, label_field, parse_field=None, extra_fields={}, root='.data',
-               train='train.jsonl', validation='val.jsonl', test='test.jsonl'):
+    def splits(cls, text_field, label_field, parse_field=None,
+               extra_fields={}, root='.data', train='train.jsonl',
+               validation='val.jsonl', test='test.jsonl'):
         """Create dataset objects for splits of the SNLI dataset.
 
         This is the most flexible way to use the dataset.
@@ -69,8 +70,10 @@ class NLIDataset(data.TabularDataset):
                       'sentence2': ('hypothesis', text_field),
                       'gold_label': ('label', label_field)}
         else:
-            fields = {'sentence1_binary_parse': [('premise', text_field), ('premise_transitions', parse_field)],
-                      'sentence2_binary_parse': [('hypothesis', text_field), ('hypothesis_transitions', parse_field)],
+            fields = {'sentence1_binary_parse': [('premise', text_field),
+                                                 ('premise_transitions', parse_field)],
+                      'sentence2_binary_parse': [('hypothesis', text_field),
+                                                 ('hypothesis_transitions', parse_field)],
                       'gold_label': ('label', label_field)}
 
         for key in extra_fields:
@@ -131,7 +134,8 @@ class SNLI(NLIDataset):
                train='snli_1.0_train.jsonl', validation='snli_1.0_dev.jsonl',
                test='snli_1.0_test.jsonl'):
         return super(SNLI, cls).splits(text_field, label_field, parse_field=parse_field,
-                                       root=root, train=train, validation=validation, test=test)
+                                       root=root, train=train, validation=validation,
+                                       test=test)
 
 
 class MultiNLI(NLIDataset):
@@ -140,7 +144,8 @@ class MultiNLI(NLIDataset):
     name = 'multinli'
 
     @classmethod
-    def splits(cls, text_field, label_field, parse_field=None, genre_field=None, root='.data',
+    def splits(cls, text_field, label_field, parse_field=None, genre_field=None,
+               root='.data',
                train='multinli_1.0_train.jsonl',
                validation='multinli_1.0_dev_matched.jsonl',
                test='multinli_1.0_dev_mismatched.jsonl'):
@@ -148,5 +153,8 @@ class MultiNLI(NLIDataset):
         if genre_field is not None:
             extra_fields["genre"] = ("genre", genre_field)
 
-        return super(MultiNLI, cls).splits(text_field, label_field, parse_field=parse_field, extra_fields=extra_fields,
-                                           root=root, train=train, validation=validation, test=test)
+        return super(MultiNLI, cls).splits(text_field, label_field,
+                                           parse_field=parse_field,
+                                           extra_fields=extra_fields,
+                                           root=root, train=train,
+                                           validation=validation, test=test)


### PR DESCRIPTION
- Fix ParsedTextField postprocessing that still accepts three args instead of two
- Added an option for ParsedTextField to whether to reverse the sentence as postprocessing
- Include parse trees for testing and reverse postprocessing test