### PR TITLE
Fix error with None fields

### DIFF
--- a/torchtext/data/batch.py
+++ b/torchtext/data/batch.py
@@ -44,8 +44,9 @@ class Batch(object):
         if not self.__dict__:
             return 'Empty {} instance'.format(torch.typename(self))
 
+        fields_to_index = filter(lambda field: field is not None, self.fields)
         var_strs = '\n'.join(['\t[.' + name + ']' + ":" + _short_str(getattr(self, name))
-                              for name in self.fields if hasattr(self, name)])
+                              for name in fields_to_index if hasattr(self, name)])
 
         data_str = (' from {}'.format(self.dataset.name.upper())
                     if hasattr(self.dataset, 'name') and


### PR DESCRIPTION
When some fields in the `TabularDataset` were defined as `None` (to be skipped), the `getattr` call in `Batch.__str__` would fail for those fields. 