### PR TITLE
Docs fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'torchtext'
-copyright = '2017, Torch Contributors'
+copyright = '2018, Torch Contributors'
 author = 'Torch Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -124,8 +124,9 @@ def setup(app):
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'torch': ('http://pytorch.org/docs/0.3.0/', None)
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None)
+    #,
+    #'torch': ('http://pytorch.org/docs/docs/stable/', None)
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,8 +125,6 @@ def setup(app):
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None)
-    #,
-    #'torch': ('http://pytorch.org/docs/docs/stable/', None)
 }
 
 

--- a/docs/source/vocab.rst
+++ b/docs/source/vocab.rst
@@ -59,8 +59,3 @@ Misc.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: _default_unk_index
-
-:hidden:`pretrained_aliases`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autodata:: pretrained_aliases

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -429,6 +429,7 @@ class CharNGram(Vectors):
 def _default_unk_index():
     return 0
 
+
 # Mapping from string name to factory function
 pretrained_aliases = {
     "charngram.100d": partial(CharNGram),

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -46,7 +46,7 @@ class Vocab(object):
                 or a list of aforementioned vectors
             unk_init (callback): by default, initialize out-of-vocabulary word vectors
                 to zero vectors; can be any function that takes in a Tensor and
-                returns a Tensor of the same size. Default: torch.Tensor.zero_
+                returns a Tensor of the same size. Default: torch.Tensor.zero\_
             vectors_cache: directory for cached vectors. Default: '.vector_cache'
         """
         self.freqs = counter
@@ -165,7 +165,7 @@ class Vocab(object):
             dim: The dimensionality of the vectors.
             unk_init (callback): by default, initialize out-of-vocabulary word vectors
                 to zero vectors; can be any function that takes in a Tensor and
-                returns a Tensor of the same size. Default: torch.Tensor.zero_
+                returns a Tensor of the same size. Default: torch.Tensor.zero\_
         """
         self.vectors = torch.Tensor(len(self), dim)
         for i, token in enumerate(self.itos):
@@ -429,7 +429,7 @@ class CharNGram(Vectors):
 def _default_unk_index():
     return 0
 
-
+# Mapping from string name to factory function
 pretrained_aliases = {
     "charngram.100d": partial(CharNGram),
     "fasttext.en.300d": partial(FastText, language="en"),
@@ -445,4 +445,3 @@ pretrained_aliases = {
     "glove.6B.200d": partial(GloVe, name="6B", dim="200"),
     "glove.6B.300d": partial(GloVe, name="6B", dim="300")
 }
-"""Mapping from string name to factory function"""


### PR DESCRIPTION
- Remove pointer to `torch` (alike torchvision)
- Remove docs for `pretrained aliases` as they were causing the build to fail
- Escape underscores in `torch.tensor.zero_`
- Bump year