### PR TITLE
Feature to ignore tokens

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -345,15 +345,14 @@ class TestField(TorchtextTestCase):
         question_field.build_vocab(tsv_dataset)
 
         test_example_data = question_field.pad(
-                               [question_field.preprocess(x) for x in
-                                    [["When", "do", "you", "use", "シ",
-                                     "instead", "of", "し?"],
-                                    ["What", "is", "2+2", "<pad>", "<pad>",
-                                     "<pad>", "<pad>", "<pad>"],
-                                    ["Here", "is", "a", "sentence", "with",
-                                     "some", "oovs", "<pad>"]]
-                                ]
-                            )
+            [question_field.preprocess(x) for x in
+             [["When", "do", "you", "use", "シ",
+              "instead", "of", "し?"],
+              ["What", "is", "2+2", "<pad>", "<pad>",
+              "<pad>", "<pad>", "<pad>"],
+              ["Here", "is", "a", "sentence", "with",
+               "some", "oovs", "<pad>"]]]
+        )
 
         # Test with batch_first
         stopwords_removed_numericalized = question_field.numericalize(test_example_data)

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -9,6 +9,7 @@ import pytest
 from torch.nn import init
 
 from ..common.torchtext_test_case import TorchtextTestCase, verify_numericalized_example
+from ..common.test_markers import slow
 
 
 class TestField(TorchtextTestCase):
@@ -749,6 +750,7 @@ class TestNestedField(TorchtextTestCase):
             verify_numericalized_example(
                 field, example, numericalized_example, batch_first=True)
 
+    @slow
     def test_build_vocab(self):
         nesting_field = data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
 

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -332,6 +332,36 @@ class TestField(TorchtextTestCase):
                                      reversed_test_example_data,
                                      postprocessed_numericalized)
 
+    def test_numericalize_stop_words(self):
+        # Based on request from #354
+        self.write_test_ppid_dataset(data_format="tsv")
+        question_field = data.Field(sequential=True, batch_first=True,
+                                    stop_words=set(["do", "you"]))
+        tsv_fields = [("id", None), ("q1", question_field),
+                      ("q2", question_field), ("label", None)]
+        tsv_dataset = data.TabularDataset(
+            path=self.test_ppid_dataset_path, format="tsv",
+            fields=tsv_fields)
+        question_field.build_vocab(tsv_dataset)
+
+        test_example_data = question_field.pad(
+                               [question_field.preprocess(x) for x in
+                                    [["When", "do", "you", "use", "シ",
+                                     "instead", "of", "し?"],
+                                    ["What", "is", "2+2", "<pad>", "<pad>",
+                                     "<pad>", "<pad>", "<pad>"],
+                                    ["Here", "is", "a", "sentence", "with",
+                                     "some", "oovs", "<pad>"]]
+                                ]
+                            )
+
+        # Test with batch_first
+        stopwords_removed_numericalized = question_field.numericalize(test_example_data)
+        verify_numericalized_example(question_field,
+                                     test_example_data,
+                                     stopwords_removed_numericalized,
+                                     batch_first=True)
+
     def test_numerical_features_no_vocab(self):
         self.write_test_numerical_features_dataset()
         # Test basic usage

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -106,6 +106,7 @@ class Field(RawField):
         unk_token: The string token used to represent OOV words. Default: "<unk>".
         pad_first: Do the padding of the sequence at the beginning. Default: False.
         truncate_first: Do the truncating of the sequence at the beginning. Default: False
+        stop_words: Tokens to discard during the preprocessing step. Default: None
     """
 
     vocab_cls = Vocab
@@ -134,7 +135,7 @@ class Field(RawField):
                  preprocessing=None, postprocessing=None, lower=False,
                  tokenize=(lambda s: s.split()), include_lengths=False,
                  batch_first=False, pad_token="<pad>", unk_token="<unk>",
-                 pad_first=False, truncate_first=False):
+                 pad_first=False, truncate_first=False, stop_words=None):
         self.sequential = sequential
         self.use_vocab = use_vocab
         self.init_token = init_token
@@ -151,6 +152,7 @@ class Field(RawField):
         self.pad_token = pad_token if self.sequential else None
         self.pad_first = pad_first
         self.truncate_first = truncate_first
+        self.stop_words = stop_words
 
     def preprocess(self, x):
         """Load a single example using this field, tokenizing if necessary.
@@ -166,6 +168,8 @@ class Field(RawField):
             x = self.tokenize(x.rstrip('\n'))
         if self.lower:
             x = Pipeline(six.text_type.lower)(x)
+        if self.sequential and self.use_vocab and self.stop_words is not None:
+            x = [w for w in x if w not in self.stop_words]
         if self.preprocessing is not None:
             return self.preprocessing(x)
         else:

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -106,7 +106,8 @@ class Field(RawField):
         unk_token: The string token used to represent OOV words. Default: "<unk>".
         pad_first: Do the padding of the sequence at the beginning. Default: False.
         truncate_first: Do the truncating of the sequence at the beginning. Default: False
-        stop_words: Tokens to discard during the preprocessing step. Default: None
+        stop_words: Tokens to discard during the preprocessing step.
+            Must be an iterable. Default: None
     """
 
     vocab_cls = Vocab
@@ -152,7 +153,13 @@ class Field(RawField):
         self.pad_token = pad_token if self.sequential else None
         self.pad_first = pad_first
         self.truncate_first = truncate_first
-        self.stop_words = stop_words
+        if stop_words is not None:
+            try:
+                self.stop_words = set(stop_words)
+            except:
+                raise ValueError("Stop words must be convertible to a set")
+        else:
+            self.stop_words = stop_words
 
     def preprocess(self, x):
         """Load a single example using this field, tokenizing if necessary.


### PR DESCRIPTION
Feature implementation for #354 
Simply added option to pass stop words to a field during initialization and have it remove words during preprocessing. API is based on the [CountTokenizer from scikit-learn](http://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html).
Stop words being an attribute of the field (not the vocab) seems natural when you consider the vocab as just a mapping from tokens to integers.