### PR TITLE
Fix SubwordVocab

### DIFF
--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -199,7 +199,7 @@ class SubwordVocab(Vocab):
 
         self.stoi = defaultdict(_default_unk_index)
         self.stoi.update({tok: i for i, tok in enumerate(specials)})
-        self.itos = specials
+        self.itos = specials.copy()
 
         self.segment = revtok.SubwordSegmenter(counter, max_size)
 
@@ -210,6 +210,8 @@ class SubwordVocab(Vocab):
                       key=lambda tup: (len(tup[0]) != 1, -tup[1], tup[0]))
 
         for tok, _ in toks:
+            if len(self.itos) == max_size:
+                break
             self.itos.append(tok)
             self.stoi[tok] = len(self.itos) - 1
 


### PR DESCRIPTION
Fix #398 and use `max_size`. 

```
from torchtext.vocab import SubwordVocab
from collections import Counter

counter = Counter("torch torch test".split())

v1 = SubwordVocab(counter, max_size=10)
print(v1.itos, v1.stoi)

v2 = SubwordVocab(counter, max_size=10)
print(v2.itos, v2.stoi)
```

This version's output
```
# v1
['<pad>', 't', 'c', 'e', 'h', 'o', 'r', 's', 'torch', 'test', 'est'] defaultdict(<function _default_unk_index at 0x11bc13158>,
{'<pad>': 0, 't': 1, 'c': 2, 'e': 3, 'h': 4, 'o': 5, 'r': 6, 's': 7, 'torch': 8, 'test': 9, 'est': 10})

# v2: the same to v1
['<pad>', 't', 'c', 'e', 'h', 'o', 'r', 's', 'torch', 'test', 'est'] defaultdict(<function _default_unk_index at 0x11bc13158>,
{'<pad>': 0, 't': 1, 'c': 2, 'e': 3, 'h': 4, 'o': 5, 'r': 6, 's': 7, 'torch': 8, 'test': 9, 'est': 10})
```