### PR TITLE
New argument to add special tokens after building vocab

### DIFF
--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -32,6 +32,23 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.itos, expected_itos)
         self.assertEqual(dict(v.stoi), expected_stoi)
 
+    def test_vocab_specials_first(self):
+        c = Counter("a a b b c c".split())
+
+        # add specials into vocabulary at first
+        v = vocab.Vocab(c, max_size=2, specials=['<pad>', '<eos>'])
+        expected_itos = ['<pad>', '<eos>', 'a', 'b']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+        self.assertEqual(v.itos, expected_itos)
+        self.assertEqual(dict(v.stoi), expected_stoi)
+
+        # add specials into vocabulary at last
+        v = vocab.Vocab(c, max_size=2, specials=['<pad>', '<eos>'], specials_first=False)
+        expected_itos = ['a', 'b', '<pad>', '<eos>']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+        self.assertEqual(v.itos, expected_itos)
+        self.assertEqual(dict(v.stoi), expected_stoi)
+
     def test_vocab_set_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5,
                      'ｔｅｓｔ': 4, 'freq_too_low': 2})

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -28,7 +28,7 @@ class Vocab(object):
         itos: A list of token strings indexed by their numerical identifiers.
     """
     def __init__(self, counter, max_size=None, min_freq=1, specials=['<pad>'],
-                 vectors=None, unk_init=None, vectors_cache=None):
+                 vectors=None, unk_init=None, vectors_cache=None, specials_first=True):
         """Create a Vocab object from a collections.Counter.
 
         Arguments:
@@ -48,12 +48,18 @@ class Vocab(object):
                 to zero vectors; can be any function that takes in a Tensor and
                 returns a Tensor of the same size. Default: torch.Tensor.zero\_
             vectors_cache: directory for cached vectors. Default: '.vector_cache'
+            specials_first: Whether to add special tokens into the vocabulary at first.
+                If it is False, they are added into the vocabulary at last.
+                Default: True.
         """
         self.freqs = counter
         counter = counter.copy()
         min_freq = max(min_freq, 1)
 
-        self.itos = list(specials)
+        self.itos = list()
+        if specials_first:
+            self.itos = list(specials)
+
         # frequencies of special tokens are not counted when building vocabulary
         # in frequency order
         for tok in specials:
@@ -69,6 +75,9 @@ class Vocab(object):
             if freq < min_freq or len(self.itos) == max_size:
                 break
             self.itos.append(word)
+
+        if not specials_first:
+            self.itos.extend(list(specials))
 
         self.stoi = defaultdict(_default_unk_index)
         # stoi is simply a reverse dict for itos


### PR DESCRIPTION
Related to #322.

New argument can specify when do tokes in `specials` add into `itos` and `stoi` in `Vocab` class.

Example
```python
from torchtext.vocab import Vocab
from collections import Counter

counter = Counter("a a b b c c".split())
v = Vocab(counter, max_size=2, specials=['<pad>', '<eos>'])
print(v.stoi, v.itos)

v = Vocab(counter, max_size=2, specials=['<pad>', '<eos>'], specials_first=False)
print(v.stoi, v.itos)
```

Output
```python
# `specials_first=True` (default)
defaultdict(<function _default_unk_index at 0x11cdb20d0>,
{'<pad>': 0, '<eos>': 1, 'a': 2, 'b': 3})
['<pad>', '<eos>', 'a', 'b']

# `specials_first=False`
defaultdict(<function _default_unk_index at 0x11cdb20d0>, 
{'a': 0, 'b': 1, '<pad>': 2, '<eos>': 3})
['a', 'b', '<pad>', '<eos>']
```
