### PR TITLE
Save nesting_field.vocab.freqs

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -514,7 +514,8 @@ class TestNestedField(TorchtextTestCase):
         for c in expected:
             assert c in CHARS.vocab.stoi
 
-        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == Counter({"a": 6, "b": 6, "c": 1})
+        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == \
+               Counter({"a": 6, "b": 6, "c": 1})
 
     def test_build_vocab_from_iterable(self):
         nesting_field = data.Field(unk_token="<cunk>", pad_token="<cpad>")
@@ -529,7 +530,8 @@ class TestNestedField(TorchtextTestCase):
         for c in expected:
             assert c in CHARS.vocab.stoi
 
-        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == Counter({"a": 6, "b": 12, "c": 4})
+        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == \
+               Counter({"a": 6, "b": 12, "c": 4})
 
     def test_pad(self):
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -514,6 +514,8 @@ class TestNestedField(TorchtextTestCase):
         for c in expected:
             assert c in CHARS.vocab.stoi
 
+        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == Counter({"a": 6, "b": 6, "c": 1})
+
     def test_build_vocab_from_iterable(self):
         nesting_field = data.Field(unk_token="<cunk>", pad_token="<cpad>")
         CHARS = data.NestedField(nesting_field)
@@ -526,6 +528,8 @@ class TestNestedField(TorchtextTestCase):
         assert len(CHARS.vocab) == len(expected)
         for c in expected:
             assert c in CHARS.vocab.stoi
+
+        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == Counter({"a": 6, "b": 12, "c": 4})
 
     def test_pad(self):
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -514,8 +514,8 @@ class TestNestedField(TorchtextTestCase):
         for c in expected:
             assert c in CHARS.vocab.stoi
 
-        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == \
-               Counter({"a": 6, "b": 6, "c": 1})
+        expected_freqs = Counter({"a": 6, "b": 6, "c": 1})
+        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == expected_freqs
 
     def test_build_vocab_from_iterable(self):
         nesting_field = data.Field(unk_token="<cunk>", pad_token="<cpad>")
@@ -530,8 +530,8 @@ class TestNestedField(TorchtextTestCase):
         for c in expected:
             assert c in CHARS.vocab.stoi
 
-        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == \
-               Counter({"a": 6, "b": 12, "c": 4})
+        expected_freqs = Counter({"a": 6, "b": 12, "c": 4})
+        assert CHARS.vocab.freqs == CHARS.nesting_field.vocab.freqs == expected_freqs
 
     def test_pad(self):
         nesting_field = data.Field(tokenize=list, unk_token="<cunk>", pad_token="<cpad>",

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -644,6 +644,7 @@ class NestedField(Field):
         self.nesting_field.build_vocab(*flattened, **kwargs)
         super(NestedField, self).build_vocab()
         self.vocab.extend(self.nesting_field.vocab)
+        self.vocab.freqs = self.nesting_field.vocab.freqs.copy()
         if old_vectors is not None:
             self.vocab.load_vectors(old_vectors,
                                     unk_init=old_unk_init, cache=old_vectors_cache)


### PR DESCRIPTION
I guess this PR fixes #372 .

In the currect code, `nestedField.vocab.freqs` and `nestedField.nesting_field.vocab.freqs` are empty.

1. `nestedField.vocab.freqs` is empty because `build_vocab()` does not have any argument in [this line](https://github.com/pytorch/text/blob/master/torchtext/data/field.py#L645).
1. `nestedField.nesting_field.vocab.freqs` is not empty in `build_vocab` function, but it becomes empty because [the current code]((https://github.com/pytorch/text/blob/master/torchtext/data/field.py#L651)) assigns `nestedField.vocab` to `nestedField.nesting_field.vocab`.

In this PR, `nestedField.nesting_field.vocab.freqs` is copyed into `nestedField.vocab.freqs` to access `nestedField.nesting_field.vocab.freqs`. 

Is it expected behavior?

If so, I will add test code to this PR.