### PR TITLE
Add's dataset feature - remove unkown words from dataset's examples

### DIFF
--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -197,6 +197,19 @@ class Dataset(torch.utils.data.Dataset):
                             shutil.copyfileobj(gz, uncompressed)
 
         return os.path.join(path, cls.dirname)
+ 
+
+    def filter_examples(self, field_names):
+        """Remove unknown words from dataset examples with respect to given field.
+
+        Arguments:
+            field_names (list(str)): Within example only the parts with field names in
+                field_names will have their unknown words deleted.
+        """
+        for i, example in enumerate(self.examples):
+            example_part = [word for word in getattr(example,field_name) if word in self.fields[field_name].vocab.stoi]
+            setattr(example, field_name, example_part)
+            self.examples[i] = example 
 
 
 class TabularDataset(Dataset):


### PR DESCRIPTION
Response to issue #355. As @mttk pointed out this feature should be solved differently as to optimize for performance, so I implemented his idea for temporary fix. As this is something that will probably get removed in future, I haven't written any tests yet, but if needed, I am completely open to that option too.

I also changed the arguments @mttk suggested and I think this seems like reasonable approach, but I am open to change this too.