### PR TITLE
[WIP] Add word2vec class

### DIFF
--- a/docs/source/vocab.rst
+++ b/docs/source/vocab.rst
@@ -38,6 +38,14 @@ Pretrained Word Embeddings
     :members:
     :special-members: __init__
 
+:hidden:`Word2Vec`
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Word2Vec
+    :members:
+    :special-members: __init__
+
+
 :hidden:`FastText`
 ~~~~~~~~~~~~~~~~~~
 

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -411,7 +411,8 @@ class GloVe(Vectors):
 
 class Word2Vec(Vectors):
     urls = {
-        'googlenews': 'https://s3.amazonaws.com/dl4j-distribution/GoogleNews-vectors-negative300.bin.gz'
+        'googlenews': 'https://s3.amazonaws.com/'
+                      'dl4j-distribution/GoogleNews-vectors-negative300.bin.gz'
     }
 
     def __init__(self, name='googlenews', **kwargs):

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -237,21 +237,20 @@ class SubwordVocab(Vocab):
 def _infer_shape(f):
     num_lines, vector_dim = 0, None
 
-    # Assuming word, [vector] format
-
-    # Read header
+    # Read the first line (it may be a header of word2vec/fasttext format)
     line = f.readline()
-    if isinstance(line, six.binary_type):
-        line = line.decode('utf-8')
-    row = line.rstrip().split(" ")
+    row = line.rstrip().split(b" ")
 
+    # Assuming word, [vector] format
     if len(row) == 2:
-        num_lines, vector_dim = list(map(int, row))
-    else:
-        vector = row[1:]
         # The header present in some (w2v) formats contains two elements.
+        num_lines, vector_dim = list(map(int, row))
+        num_lines += 1
+    else:
+        # glove format: no header line
+        vector = row[1:]
         vector_dim = len(vector)
-        num_lines += 1  # First element read
+        num_lines += 1
 
         for _ in f:
             num_lines += 1

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -236,16 +236,24 @@ class SubwordVocab(Vocab):
 
 def _infer_shape(f):
     num_lines, vector_dim = 0, None
-    for line in f:
-        if vector_dim is None:
-            row = line.rstrip().split(b" ")
-            vector = row[1:]
-            # Assuming word, [vector] format
-            if len(vector) > 2:
-                # The header present in some (w2v) formats contains two elements.
-                vector_dim = len(vector)
-                num_lines += 1  # First element read
-        else:
+
+    # Assuming word, [vector] format
+
+    # Read header
+    line = f.readline()
+    if isinstance(line, six.binary_type):
+        line = line.decode('utf-8')
+    row = line.rstrip().split(" ")
+
+    if len(row) == 2:
+        num_lines, vector_dim = list(map(int, row))
+    else:
+        vector = row[1:]
+        # The header present in some (w2v) formats contains two elements.
+        vector_dim = len(vector)
+        num_lines += 1  # First element read
+
+        for _ in f:
             num_lines += 1
     f.seek(0)
     return num_lines, vector_dim

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -388,7 +388,7 @@ class Vectors(object):
 
 
 class GloVe(Vectors):
-    url = {
+    urls = {
         '42B': 'http://nlp.stanford.edu/data/glove.42B.300d.zip',
         '840B': 'http://nlp.stanford.edu/data/glove.840B.300d.zip',
         'twitter.27B': 'http://nlp.stanford.edu/data/glove.twitter.27B.zip',
@@ -396,9 +396,19 @@ class GloVe(Vectors):
     }
 
     def __init__(self, name='840B', dim=300, **kwargs):
-        url = self.url[name]
+        url = self.urls[name]
         name = 'glove.{}.{}d.txt'.format(name, str(dim))
         super(GloVe, self).__init__(name, url=url, **kwargs)
+
+
+class Word2Vec(Vectors):
+    urls = {
+        'googlenews': 'https://s3.amazonaws.com/dl4j-distribution/GoogleNews-vectors-negative300.bin.gz'
+    }
+
+    def __init__(self, name='googlenews', **kwargs):
+        url = self.url[name]
+        super(Word2Vec, self).__init__(name, url=url, **kwargs)
 
 
 class FastText(Vectors):
@@ -460,6 +470,7 @@ pretrained_aliases = {
     "glove.6B.50d": partial(GloVe, name="6B", dim="50"),
     "glove.6B.100d": partial(GloVe, name="6B", dim="100"),
     "glove.6B.200d": partial(GloVe, name="6B", dim="200"),
-    "glove.6B.300d": partial(GloVe, name="6B", dim="300")
+    "glove.6B.300d": partial(GloVe, name="6B", dim="300"),
+    "word2vec.googlenews.300d": partial(Word2Vec, name="googlenews"),
 }
 """Mapping from string name to factory function"""


### PR DESCRIPTION
See #276.

To download skip-gram embeddings trained on google news, we can use [DL4J's url](https://s3.amazonaws.com/dl4j-distribution/GoogleNews-vectors-negative300.bin.gz).

I also checked whether this mirror model is the same as [the original model](https://code.google.com/archive/p/word2vec/).

```
$ diff GoogleNews-vectors-negative300.bin original-GoogleNews-vectors-negative300.bin
$ # same!
```

I will update `Vector`'s cache function to read the binary file of word2vec.