### PR TITLE
Exposed parameters for csv reader to user through dataset

### DIFF
--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 import torchtext.data as data
 import tempfile
+import six
 
 import pytest
 
@@ -216,7 +217,7 @@ class TestDataset(TorchtextTestCase):
 
         with tempfile.NamedTemporaryFile(dir=self.test_dir) as f:
             for example in example_data:
-                f.write(bytes("{}\n".format(",".join(example)), "utf-8"))
+                f.write(six.b("{}\n".format(",".join(example))))
 
             TEXT = data.Field(lower=True, tokenize=lambda x: x.split())
             fields = {

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import torchtext.data as data
+import tempfile
 
 import pytest
 
@@ -205,6 +206,40 @@ class TestDataset(TorchtextTestCase):
 
         # 6 Fields including None for ids
         assert len(dataset.fields) == 6
+
+    def test_csv_dataset_quotechar(self):
+        # Based on issue #349
+        example_data = [("text", "label"),
+                        ('" hello world', "0"),
+                        ('goodbye " world', "1"),
+                        ('this is a pen " ', "0")]
+
+        with tempfile.NamedTemporaryFile(dir=self.test_dir) as f:
+            for example in example_data:
+                f.write(bytes("{}\n".format(",".join(example)), "utf-8"))
+
+            TEXT = data.Field(lower=True, tokenize=lambda x: x.split())
+            fields = {
+                "label": ("label", data.Field(use_vocab=False,
+                                              sequential=False)),
+                "text": ("text", TEXT)
+            }
+
+            f.seek(0)
+
+            dataset = data.TabularDataset(
+                path=f.name, format="csv",
+                skip_header=False, fields=fields,
+                csv_reader_params={"quotechar": None})
+
+            TEXT.build_vocab(dataset)
+
+            self.assertEqual(len(dataset), len(example_data) - 1)
+
+            for i, example in enumerate(dataset):
+                self.assertEqual(example.text,
+                                 example_data[i + 1][0].lower().split())
+                self.assertEqual(example.label, example_data[i + 1][1])
 
     def test_dataset_split_arguments(self):
         num_examples, num_labels = 30, 3

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -217,7 +217,8 @@ class Dataset(torch.utils.data.Dataset):
 class TabularDataset(Dataset):
     """Defines a Dataset of columns stored in CSV, TSV, or JSON format."""
 
-    def __init__(self, path, format, fields, skip_header=False, **kwargs):
+    def __init__(self, path, format, fields, skip_header=False,
+                 csv_reader_params={}, **kwargs):
         """Create a TabularDataset given a path, file format, and field list.
 
         Arguments:
@@ -236,6 +237,11 @@ class TabularDataset(Dataset):
                 This allows the user to rename columns from their JSON/CSV/TSV key names
                 and also enables selecting a subset of columns to load.
             skip_header (bool): Whether to skip the first line of the input file.
+            csv_reader_params(dict): Parameters to pass to the csv reader.
+                Only relevant when format is csv or tsv.
+                See
+                https://docs.python.org/3/library/csv.html#csv.reader
+                for more details.
         """
         format = format.lower()
         make_example = {
@@ -244,9 +250,9 @@ class TabularDataset(Dataset):
 
         with io.open(os.path.expanduser(path), encoding="utf8") as f:
             if format == 'csv':
-                reader = unicode_csv_reader(f)
+                reader = unicode_csv_reader(f, **csv_reader_params)
             elif format == 'tsv':
-                reader = unicode_csv_reader(f, delimiter='\t')
+                reader = unicode_csv_reader(f, delimiter='\t', **csv_reader_params)
             else:
                 reader = f
 


### PR DESCRIPTION
Handles issue #349 and also exposes additional attributes of `csv_reader` to the user of `TabularDataset` so that they can modify the handling of csv files as they see fit.
Any keyword arguments can now be passed to csv_reader through the `csv_reader_params` keyword argument.