### PR TITLE
Field serialization, tokenizers in different languages

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -426,11 +426,6 @@ class TestField(TorchtextTestCase):
     def test_serialization_pre_build(self):
         self.write_test_ppid_dataset(data_format="tsv")
         question_field = data.Field(sequential=True)
-        tsv_fields = [("id", None), ("q1", question_field),
-                      ("q2", question_field), ("label", None)]
-        tsv_dataset = data.TabularDataset(
-            path=self.test_ppid_dataset_path, format="tsv",
-            fields=tsv_fields)
 
         question_pickle_filename = "question.pl"
         question_pickle_path = os.path.join(self.test_dir, question_pickle_filename)
@@ -835,7 +830,6 @@ class TestNestedField(TorchtextTestCase):
             verify_numericalized_example(
                 field, example, numericalized_example, batch_first=True)
 
-
     def test_serialization(self):
         nesting_field = data.Field(batch_first=True)
         field = data.NestedField(nesting_field)
@@ -871,7 +865,6 @@ class TestNestedField(TorchtextTestCase):
         pickled_numericalization = loaded_field.numericalize(examples_data)
 
         assert torch.all(torch.eq(original_numericalization, pickled_numericalization))
-
 
     @slow
     def test_build_vocab(self):

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -138,7 +138,7 @@ class Field(RawField):
     def __init__(self, sequential=True, use_vocab=True, init_token=None,
                  eos_token=None, fix_length=None, dtype=torch.long,
                  preprocessing=None, postprocessing=None, lower=False,
-                 tokenize=string.split, tokenizer_language='en', include_lengths=False,
+                 tokenize=None, tokenizer_language='en', include_lengths=False,
                  batch_first=False, pad_token="<pad>", unk_token="<unk>",
                  pad_first=False, truncate_first=False, stop_words=None,
                  is_target=False):
@@ -489,7 +489,7 @@ class NestedField(Field):
 
     def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
                  fix_length=None, dtype=torch.long, preprocessing=None,
-                 postprocessing=None, tokenize=string.split,
+                 postprocessing=None, tokenize=None,
                  include_lengths=False, pad_token='<pad>',
                  pad_first=False, truncate_first=False):
         if isinstance(nesting_field, NestedField):

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -3,7 +3,6 @@ from collections import Counter, OrderedDict
 from itertools import chain
 import six
 import torch
-import string
 from tqdm import tqdm
 
 from .dataset import Dataset

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -190,7 +190,7 @@ class Field(RawField):
         state['dtype'] = getattr(torch, state['dtype'])
         if not state['tokenize']:
             state['tokenize'] = get_tokenizer(*state['tokenizer_args'])
-        self.__dict__ = state
+        self.__dict__.update(state)
 
     def __hash__(self):
         # we don't expect this to be called often

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -95,8 +95,11 @@ class Field(RawField):
             Default: None.
         lower: Whether to lowercase the text in this field. Default: False.
         tokenize: The function used to tokenize strings using this field into
-            sequential examples. If "spacy", the SpaCy English tokenizer is
-            used. Default: string.split.
+            sequential examples. If "spacy", the SpaCy tokenizer is
+            used. If a non-serializable function is passed as an argument,
+            the field will not be able to be serialized. Default: string.split.
+        tokenizer_language: The language of the tokenizer to be constructed. 
+            Various languages currently supported only in SpaCy.
         include_lengths: Whether to return a tuple of a padded minibatch and
             a list containing the lengths of each examples, or just a padded
             minibatch. Default: False.
@@ -477,9 +480,12 @@ class NestedField(Field):
         include_lengths: Whether to return a tuple of a padded minibatch and
             a list containing the lengths of each examples, or just a padded
             minibatch. Default: False.
-        tokenize (callable or str): The function used to tokenize strings using this
-            field into sequential examples. If "spacy", the SpaCy English tokenizer is
-            used. Default: ``lambda s: s.split()``
+        tokenize: The function used to tokenize strings using this field into
+            sequential examples. If "spacy", the SpaCy tokenizer is
+            used. If a non-serializable function is passed as an argument,
+            the field will not be able to be serialized. Default: string.split.
+        tokenizer_language: The language of the tokenizer to be constructed. 
+            Various languages currently supported only in SpaCy.
         pad_token (str): The string token used as padding. If ``nesting_field`` is
             sequential, this will be set to its ``pad_token``. Default: ``"<pad>"``.
         pad_first (bool): Do the padding of the sequence at the beginning. Default:
@@ -488,7 +494,7 @@ class NestedField(Field):
 
     def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
                  fix_length=None, dtype=torch.long, preprocessing=None,
-                 postprocessing=None, tokenize=None,
+                 postprocessing=None, tokenize=None, tokenizer_language='en',
                  include_lengths=False, pad_token='<pad>',
                  pad_first=False, truncate_first=False):
         if isinstance(nesting_field, NestedField):
@@ -508,6 +514,7 @@ class NestedField(Field):
             postprocessing=postprocessing,
             lower=nesting_field.lower,
             tokenize=tokenize,
+            tokenizer_language=tokenizer_language,
             batch_first=True,
             pad_token=pad_token,
             unk_token=nesting_field.unk_token,

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -3,6 +3,7 @@ from collections import Counter, OrderedDict
 from itertools import chain
 import six
 import torch
+import string
 from tqdm import tqdm
 
 from .dataset import Dataset
@@ -96,7 +97,7 @@ class Field(RawField):
         lower: Whether to lowercase the text in this field. Default: False.
         tokenize: The function used to tokenize strings using this field into
             sequential examples. If "spacy", the SpaCy English tokenizer is
-            used. Default: str.split.
+            used. Default: string.split.
         include_lengths: Whether to return a tuple of a padded minibatch and
             a list containing the lengths of each examples, or just a padded
             minibatch. Default: False.
@@ -137,7 +138,7 @@ class Field(RawField):
     def __init__(self, sequential=True, use_vocab=True, init_token=None,
                  eos_token=None, fix_length=None, dtype=torch.long,
                  preprocessing=None, postprocessing=None, lower=False,
-                 tokenize=str.split, tokenizer_language='en', include_lengths=False,
+                 tokenize=string.split, tokenizer_language='en', include_lengths=False,
                  batch_first=False, pad_token="<pad>", unk_token="<unk>",
                  pad_first=False, truncate_first=False, stop_words=None,
                  is_target=False):
@@ -488,7 +489,7 @@ class NestedField(Field):
 
     def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
                  fix_length=None, dtype=torch.long, preprocessing=None,
-                 postprocessing=None, tokenize=str.split,
+                 postprocessing=None, tokenize=string.split,
                  include_lengths=False, pad_token='<pad>',
                  pad_first=False, truncate_first=False):
         if isinstance(nesting_field, NestedField):

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -98,7 +98,7 @@ class Field(RawField):
             sequential examples. If "spacy", the SpaCy tokenizer is
             used. If a non-serializable function is passed as an argument,
             the field will not be able to be serialized. Default: string.split.
-        tokenizer_language: The language of the tokenizer to be constructed. 
+        tokenizer_language: The language of the tokenizer to be constructed.
             Various languages currently supported only in SpaCy.
         include_lengths: Whether to return a tuple of a padded minibatch and
             a list containing the lengths of each examples, or just a padded
@@ -484,7 +484,7 @@ class NestedField(Field):
             sequential examples. If "spacy", the SpaCy tokenizer is
             used. If a non-serializable function is passed as an argument,
             the field will not be able to be serialized. Default: string.split.
-        tokenizer_language: The language of the tokenizer to be constructed. 
+        tokenizer_language: The language of the tokenizer to be constructed.
             Various languages currently supported only in SpaCy.
         pad_token (str): The string token used as padding. If ``nesting_field`` is
             sequential, this will be set to its ``pad_token``. Default: ``"<pad>"``.

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -170,7 +170,6 @@ class Field(RawField):
         self.stop_words = stop_words
         self.is_target = is_target
 
-
     def __getstate__(self):
         str_type = dtype_to_attr(self.dtype)
         if is_tokenizer_serializable(*self.tokenizer_args):
@@ -178,7 +177,7 @@ class Field(RawField):
         else:
             # signal to restore in `__setstate__`
             tokenize = None
-        attrs = {k:v for k, v in self.__dict__.items() if k not in self.ignore}
+        attrs = {k: v for k, v in self.__dict__.items() if k not in self.ignore}
         attrs['dtype'] = str_type
         attrs['tokenize'] = tokenize
 
@@ -190,18 +189,15 @@ class Field(RawField):
             state['tokenize'] = get_tokenizer(*state['tokenizer_args'])
         self.__dict__ = state
 
-
     def __hash__(self):
         # we don't expect this to be called often
         return 42
-
 
     def __eq__(self, other):
         if not isinstance(other, RawField):
             return False
 
         return self.__dict__ == other.__dict__
-
 
     def preprocess(self, x):
         """Load a single example using this field, tokenizing if necessary.

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -4,8 +4,10 @@ from copy import deepcopy
 
 from functools import partial
 
+
 def _spacy_tokenize(x, spacy):
     return [tok.text for tok in spacy.tokenizer(x)]
+
 
 def get_tokenizer(tokenizer, language='en'):
     # simply return if a function is passed

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -8,6 +8,7 @@ from functools import partial
 def _split_tokenizer(x):
     return x.split()
 
+
 def _spacy_tokenize(x, spacy):
     return [tok.text for tok in spacy.tokenizer(x)]
 

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -5,11 +5,18 @@ from copy import deepcopy
 from functools import partial
 
 
+def _split_tokenizer(x):
+    return x.split()
+
 def _spacy_tokenize(x, spacy):
     return [tok.text for tok in spacy.tokenizer(x)]
 
 
 def get_tokenizer(tokenizer, language='en'):
+    # default tokenizer is string.split(), added as a module function for serialization
+    if tokenizer is None:
+        return _split_tokenizer
+
     # simply return if a function is passed
     if callable(tokenizer):
         return tokenizer


### PR DESCRIPTION
- Add the option to serialize fields with `torch.save` or `pickle.dump`
- Add basic tests
- Allows tokenizers in different languages for spacy (argument `tokenizer_language`)

All lambdas were removed from the pipeline and replaced with closures / partials or explicit functions. The responsibility of a custom tokenizer being serializable is on the user. 
An ugly hack overcomes the problem of `torch.[dtype]` not being serializable.
