### PR TITLE
Set `is_target` to False by default in `RawField`

### DIFF
--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -29,11 +29,14 @@ class RawField(object):
             using this field before assigning to a batch.
             Function signature: (batch(list)) -> object
             Default: None.
+        is_target: Whether this field is a target variable.
+            Affects iteration over batches. Default: False
     """
 
-    def __init__(self, preprocessing=None, postprocessing=None):
+    def __init__(self, preprocessing=None, postprocessing=None, is_target=False):
         self.preprocessing = preprocessing
         self.postprocessing = postprocessing
+        self.is_target = is_target
 
     def preprocess(self, x):
         """ Preprocess an example if the `preprocessing` Pipeline is provided. """


### PR DESCRIPTION
Fixing issue potentially caused by #288. You can now use RawField directly without any workarounds as mentioned in issue 422.