### PR TITLE
[wip] TabularDatasets can be read from gzip/bzip2 files

### DIFF
--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -6,6 +6,9 @@ import os
 import shutil
 import subprocess
 import tempfile
+import bz2
+import gzip
+import io
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +40,7 @@ class TorchtextTestCase(TestCase):
         except:
             subprocess.call(["rm", "-rf", self.test_dir])
 
-    def write_test_ppid_dataset(self, data_format="csv"):
+    def write_test_ppid_dataset(self, data_format="csv", compression=None):
         data_format = data_format.lower()
         if data_format == "csv":
             delim = ","
@@ -54,7 +57,10 @@ class TorchtextTestCase(TestCase):
              "question2": "2+2=?",
              "label": "1"},
         ]
-        with open(self.test_ppid_dataset_path, "w") as test_ppid_dataset_file:
+
+        open_call = {"gz": gzip.open, "bz2": bz2.open}.get(
+            compression, io.open)
+        with open_call(self.test_ppid_dataset_path, "wt", encoding="utf8") as test_ppid_dataset_file:
             for example in dict_dataset:
                 if data_format == "json":
                     test_ppid_dataset_file.write(json.dumps(example) + "\n")

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import torchtext.data as data
 import tempfile
 import six
+import itertools
 
 import pytest
 
@@ -12,8 +13,9 @@ import os
 
 class TestDataset(TorchtextTestCase):
     def test_tabular_simple_data(self):
-        for data_format in ["csv", "tsv", "json"]:
-            self.write_test_ppid_dataset(data_format=data_format)
+        for data_format, compression in itertools.product(["csv", "tsv", "json"], [None, "gz", "bz2"]):
+            self.write_test_ppid_dataset(
+                data_format=data_format, compression=compression)
 
             if data_format == "json":
                 question_field = data.Field(sequential=True)
@@ -28,7 +30,8 @@ class TestDataset(TorchtextTestCase):
                           ("q2", question_field), ("label", label_field)]
 
             dataset = data.TabularDataset(
-                path=self.test_ppid_dataset_path, format=data_format, fields=fields)
+                path=self.test_ppid_dataset_path, format=data_format, fields=fields,
+                compression=compression)
 
             assert len(dataset) == 3
 


### PR DESCRIPTION
* This PR introduces a new parameter `compression` for the TabularDataset constructor. This param defaults to None. When set to 'gz' or 'bz2', we open the dataset file with the corresponding decompressor.
* UTs seem to be passing.

An attempt to address https://github.com/pytorch/text/issues/454