### PR TITLE
Avoid installation of `test` folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup_info = dict(
     ],
 
     # Package info
-    packages=find_packages(exclude=('test',)),
+    packages=find_packages(exclude=('test','test.*')),
 
     zip_safe=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup_info = dict(
     ],
 
     # Package info
-    packages=find_packages(exclude=('test','test.*')),
+    packages=find_packages(exclude=('test', 'test.*')),
 
     zip_safe=True,
 )


### PR DESCRIPTION
A small patch to avoid copying `test/common` and `test/data` folders when `torchtext` is installed.
Currently one can find them at
```
ls <python>/site-packages/test/
> common  data
```