### PR TITLE
Fix the hard code for the unk_index

### DIFF
--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -67,7 +67,6 @@ class Vocab(object):
             # only extend max size if specials are prepended
             max_size = None if max_size is None else max_size + len(specials)
 
-
         # frequencies of special tokens are not counted when building vocabulary
         # in frequency order
         for tok in specials:

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -63,8 +63,8 @@ class Vocab(object):
             # find the unk_index in specials
             if '<unk>' in specials:
                 self.unk_index = specials.index('<unk>')
-            elif '<pad>' in specials:
-                self.unk_index = specials.index('<pad>')
+            # elif '<pad>' in specials:
+                # self.unk_index = specials.index('<pad>')
 
         # frequencies of special tokens are not counted when building vocabulary
         # in frequency order
@@ -86,10 +86,10 @@ class Vocab(object):
             # find the unk_index in specials
             if '<unk>' in specials:
                 self.unk_index = specials.index('<unk>') + len(self.itos)
-            elif '<pad>' in specials:
-                self.unk_index = specials.index('<pad>') + len(self.itos)
+            # elif '<pad>' in specials:
+                # self.unk_index = specials.index('<pad>') + len(self.itos)
             self.itos.extend(list(specials))
-        
+
         if self.unk_index is None:
             self.stoi = defaultdict()
         else:
@@ -103,7 +103,7 @@ class Vocab(object):
             self.load_vectors(vectors, unk_init=unk_init, cache=vectors_cache)
         else:
             assert unk_init is None and vectors_cache is None
-    
+
     def _default_unk_index(self):
         return self.unk_index
 
@@ -234,9 +234,9 @@ class SubwordVocab(Vocab):
         # find the unk_index in specials
         if '<unk>' in specials:
             self.unk_index = specials.index('<unk>')
-        elif '<pad>' in specials:
-            self.unk_index = specials.index('<pad>')
-        
+        # elif '<pad>' in specials:
+            # self.unk_index = specials.index('<pad>')
+
         if self.unk_index is None:
             self.stoi = defaultdict()
         else:

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -57,14 +57,14 @@ class Vocab(object):
         min_freq = max(min_freq, 1)
 
         self.itos = list()
-        unk_index = -1
+        self.unk_index = None
         if specials_first:
             self.itos = list(specials)
             # find the unk_index in specials
             if '<unk>' in specials:
-                unk_index = specials.index('<unk>')
+                self.unk_index = specials.index('<unk>')
             elif '<pad>' in specials:
-                unk_index = specials.index('<pad>')
+                self.unk_index = specials.index('<pad>')
 
         # frequencies of special tokens are not counted when building vocabulary
         # in frequency order
@@ -85,15 +85,15 @@ class Vocab(object):
         if not specials_first:
             # find the unk_index in specials
             if '<unk>' in specials:
-                unk_index = specials.index('<unk>') + len(self.itos)
+                self.unk_index = specials.index('<unk>') + len(self.itos)
             elif '<pad>' in specials:
-                unk_index = specials.index('<pad>') + len(self.itos)
+                self.unk_index = specials.index('<pad>') + len(self.itos)
             self.itos.extend(list(specials))
         
-        if unk_index == -1:
+        if self.unk_index is None:
             self.stoi = defaultdict()
         else:
-            self.stoi = defaultdict(lambda: unk_index)
+            self.stoi = defaultdict(self._default_unk_index)
 
         # stoi is simply a reverse dict for itos
         self.stoi.update({tok: i for i, tok in enumerate(self.itos)})
@@ -103,6 +103,9 @@ class Vocab(object):
             self.load_vectors(vectors, unk_init=unk_init, cache=vectors_cache)
         else:
             assert unk_init is None and vectors_cache is None
+    
+    def _default_unk_index(self):
+        return self.unk_index
 
     def __eq__(self, other):
         if self.freqs != other.freqs:
@@ -227,17 +230,17 @@ class SubwordVocab(Vocab):
             print("Please install revtok.")
             raise
 
-        unk_index = -1
+        self.unk_index = None
         # find the unk_index in specials
         if '<unk>' in specials:
-            unk_index = specials.index('<unk>')
+            self.unk_index = specials.index('<unk>')
         elif '<pad>' in specials:
-            unk_index = specials.index('<pad>')
+            self.unk_index = specials.index('<pad>')
         
-        if unk_index == -1:
+        if self.unk_index is None:
             self.stoi = defaultdict()
         else:
-            self.stoi = defaultdict(lambda: unk_index)
+            self.stoi = defaultdict(self._default_unk_index)
 
         self.stoi.update({tok: i for i, tok in enumerate(specials)})
         self.itos = specials.copy()

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -107,6 +107,22 @@ class Vocab(object):
     def _default_unk_index(self):
         return self.unk_index
 
+    def __getstate__(self):
+        # avoid picking defaultdict
+        attrs = dict(self.__dict__)
+        # cast to regular dict
+        attrs['stoi'] = dict(self.stoi)
+        return attrs
+
+    def __setstate__(self, state):
+        if state['unk_index'] is None:
+            stoi = defaultdict()
+        else:
+            stoi = defaultdict(self._default_unk_index)
+        stoi.update(state['stoi'])
+        state['stoi'] = stoi
+        self.__dict__.update(state)
+
     def __eq__(self, other):
         if self.freqs != other.freqs:
             return False

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -57,8 +57,14 @@ class Vocab(object):
         min_freq = max(min_freq, 1)
 
         self.itos = list()
+        unk_index = -1
         if specials_first:
             self.itos = list(specials)
+            # find the unk_index in specials
+            if '<unk>' in specials:
+                unk_index = specials.index('<unk>')
+            elif '<pad>' in specials:
+                unk_index = specials.index('<pad>')
 
         # frequencies of special tokens are not counted when building vocabulary
         # in frequency order
@@ -77,12 +83,17 @@ class Vocab(object):
             self.itos.append(word)
 
         if not specials_first:
+            # find the unk_index in specials
+            if '<unk>' in specials:
+                unk_index = specials.index('<unk>') + len(self.itos)
+            elif '<pad>' in specials:
+                unk_index = specials.index('<pad>') + len(self.itos)
             self.itos.extend(list(specials))
-
-        if '<unk>' in specials:  # hard-coded for now
-            self.stoi = defaultdict(_default_unk_index)
-        else:
+        
+        if unk_index == -1:
             self.stoi = defaultdict()
+        else:
+            self.stoi = defaultdict(lambda: unk_index)
 
         # stoi is simply a reverse dict for itos
         self.stoi.update({tok: i for i, tok in enumerate(self.itos)})
@@ -216,7 +227,18 @@ class SubwordVocab(Vocab):
             print("Please install revtok.")
             raise
 
-        self.stoi = defaultdict(_default_unk_index)
+        unk_index = -1
+        # find the unk_index in specials
+        if '<unk>' in specials:
+            unk_index = specials.index('<unk>')
+        elif '<pad>' in specials:
+            unk_index = specials.index('<pad>')
+        
+        if unk_index == -1:
+            self.stoi = defaultdict()
+        else:
+            self.stoi = defaultdict(lambda: unk_index)
+
         self.stoi.update({tok: i for i, tok in enumerate(specials)})
         self.itos = specials.copy()
 
@@ -445,10 +467,6 @@ class CharNGram(Vectors):
         else:
             vector = self.unk_init(vector)
         return vector
-
-
-def _default_unk_index():
-    return 0
 
 
 pretrained_aliases = {


### PR DESCRIPTION
Hi all,

I notice that the Vocab uses the defaultdict but the default number is always 0. 
If I set specials_first=False, then the unk_index must be wrong;
If I set the specials=['\<eos\>', '\<sos\>', '\<pad\>', '\<unk\>'], then the unk_index is also wrong.

The correct way is to generate the unk_index according to the specials.

Best regards,
Xin Liu