### PR TITLE
 Add --user flag for README install instructions (avoid permission escalation)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,21 +21,21 @@ Installation
 
 Make sure you have Python 2.7 or 3.5+ and PyTorch 0.4.0 or newer. You can then install torchtext using pip::
 
-    pip install torchtext
+    pip install --user torchtext
     
-For PyTorch versions before 0.4.0, please use `pip install torchtext==0.2.3`.
+For PyTorch versions before 0.4.0, please use `pip install --user torchtext==0.2.3`.
 
 Optional requirements
 ---------------------
 
 If you want to use English tokenizer from `SpaCy <http://spacy.io/>`_, you need to install SpaCy and download its English model::
 
-    pip install spacy
-    python -m spacy download en
+    pip install --user spacy
+    python -m spacy download en --user
 
 Alternatively, you might want to use the `Moses <http://www.statmt.org/moses/>`_ tokenizer port in `SacreMoses <https://github.com/alvations/sacremoses>`_ (split from `NLTK <http://nltk.org/>`_). You have to install SacreMoses::
 
-    pip install sacremoses
+    pip install --user sacremoses
 
 Documentation
 =============


### PR DESCRIPTION
Fixes #374

Body of issue:

> The README contains bare commands that by default will look like they need escalated permissions. Many people are not experts in Python package management, and the Permission denied shown at the end of a failing pip install or spacy download will steer a lot of people towards running the commands as root, which for most is the wrong path to go down. It would be good to add --user to these commands to help them go down the right path.