### PR TITLE
Drop travis CI tests on python 2.7.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,21 @@ cache:
   - /home/travis/.cache/pip
 
 # This matrix tests that the code works on Python 2.7,
-# 2.7.9, 3.5, 3.6 (same versions as PyTorch CI), and passes lint.
+# 3.5, 3.6 (same versions as PyTorch CI), and passes lint.
 matrix:
   fast_finish: true
   include:
     - env: PYTHON_VERSION="2.7" COVERAGE="true"
-    - env: PYTHON_VERSION="2.7.9" COVERAGE="true"
     - env: PYTHON_VERSION="3.5" COVERAGE="true"
     - env: PYTHON_VERSION="3.6" COVERAGE="true"
     - env: PYTHON_VERSION="2.7" RUN_FLAKE8="true" SKIP_TESTS="true"
     - env: PYTHON_VERSION="3.6" RUN_FLAKE8="true" SKIP_TESTS="true"
-    - env: PYTHON_VERSION="2.7.9" RUN_SLOW="true" COVERAGE="true"
+    - env: PYTHON_VERSION="2.7" RUN_SLOW="true" COVERAGE="true"
       sudo: required
     - env: PYTHON_VERSION="3.6" RUN_SLOW="true" COVERAGE="true"
       sudo: required
   allow_failures:
-    - env: PYTHON_VERSION="2.7.9" RUN_SLOW="true" COVERAGE="true"
+    - env: PYTHON_VERSION="2.7" RUN_SLOW="true" COVERAGE="true"
     - env: PYTHON_VERSION="3.6" RUN_SLOW="true" COVERAGE="true"
 
 notifications:


### PR DESCRIPTION
conda doesn't vendor every dependency (in this case 2.7.9).

It is still covered by python 2.7, which is linked to python 2.7.16 in conda package.