### PR TITLE
[WIP] add new APIs to build dataset

### DIFF
--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -323,8 +323,22 @@ def stratify(examples, strata_field):
 
 
 def rationed_split(examples, train_ratio, test_ratio, val_ratio, rnd):
-    # Create a random permutation of examples, then split them
-    # by ratio x length slices for each of the train/test/dev? splits
+    """Create a random permutation of examples, then split them by ratios
+
+    Arguments:
+        examples: a list of data
+        train_ratio, test_ratio, val_ratio: split fractions.
+        rnd: a random shuffler
+
+    Examples:
+        >>> examples = []
+        >>> train_ratio, test_ratio, val_ratio = 0.7, 0.2, 0.1
+        >>> rnd = torchtext.data.dataset.RandomShuffler(None)
+        >>> train_examples, test_examples, valid_examples = \
+                torchtext.data.dataset.rationed_split(examples, train_ratio,
+                                                      test_ratio, val_ratio,
+                                                      rnd)
+    """
     N = len(examples)
     randperm = rnd(range(N))
     train_len = int(round(train_ratio * N))

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -252,6 +252,17 @@ class BucketIterator(Iterator):
                                 sort_within_batch=self.sort_within_batch)
 
 
+def generate_iterators(datasets, batch_sizes, **kwargs):
+    """Create Iterator objects for multiple splits of a dataset.
+    """
+    ret = []
+    for i in range(len(datasets)):
+        train = i == 0
+        ret.append(Iterator(
+            datasets[i], batch_size=batch_sizes[i], train=train, **kwargs))
+    return tuple(ret)
+
+
 def batch(data, batch_size, batch_size_fn=None):
     """Yield elements from data in chunks of batch_size."""
     if batch_size_fn is None:

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -252,28 +252,6 @@ class BucketIterator(Iterator):
                                 sort_within_batch=self.sort_within_batch)
 
 
-def generate_iterators(datasets, batch_sizes, **kwargs):
-    """Create Iterator objects for multiple splits of a dataset.
-
-    Arguments:
-        datasets: a tuple of Datasets
-        batch_sizes: a list of batch_size, corresponding to each dataset.
-        Remaining keyword arguments: Passed to the constructor of Iterator.
-
-    Examples:
-        >>> batch_size = 64
-        >>> train_iter, test_iter, valid_iter = generate_iterators(
-            (train_dataset, test_dataset, valid_dataset), [batch_size] * 3,
-            device="cpu")
-    """
-    ret = []
-    for i in range(len(datasets)):
-        train = i == 0
-        ret.append(Iterator(
-            datasets[i], batch_size=batch_sizes[i], train=train, **kwargs))
-    return tuple(ret)
-
-
 def batch(data, batch_size, batch_size_fn=None):
     """Yield elements from data in chunks of batch_size."""
     if batch_size_fn is None:

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -254,6 +254,17 @@ class BucketIterator(Iterator):
 
 def generate_iterators(datasets, batch_sizes, **kwargs):
     """Create Iterator objects for multiple splits of a dataset.
+
+    Arguments:
+        datasets: a tuple of Datasets
+        batch_sizes: a list of batch_size, corresponding to each dataset.
+        Remaining keyword arguments: Passed to the constructor of Iterator.
+
+    Examples:
+        >>> batch_size = 64
+        >>> train_iter, test_iter, valid_iter = generate_iterators(
+            (train_dataset, test_dataset, valid_dataset), [batch_size] * 3,
+            device="cpu")
     """
     ret = []
     for i in range(len(datasets)):

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -115,19 +115,26 @@ def dtype_to_attr(dtype):
 
 
 def generate_ngrams(token_list, ngrams):
-    """Generate a list of token with ngrams.
+    """Generate a list of token up to ngrams.
+
     Arguments:
         token_list: A list of tokens
         ngrams: the number of ngrams.
+
     Examples:
         >>> token_list = ['here', 'we', 'are']
-        >>> generate_ngrams(token_list, 2)
-        >>> ['here we', 'we are']
+        >>> torchtext.data.utils.generate_ngrams(token_list, 2)
+        >>> ['here', 'here we', 'we', 'we are', 'are']
     """
 
-    sequences = [token_list[i:] for i in range(ngrams)]
-    ngram_list = list(zip(*sequences))
-    return [' '.join(list(gram)) for gram in ngram_list]
+    re_list = []
+    for i in range(0, len(token_list)):
+        x = token_list[i]
+        re_list.append(x)
+        for j in range(i + 1, min(i + ngrams, len(token_list))):
+            x += ' ' + token_list[j]
+            re_list.append(x)
+    return re_list
 
 
 class RandomShuffler(object):

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -114,6 +114,22 @@ def dtype_to_attr(dtype):
     return dtype
 
 
+def generate_ngrams(token_list, ngrams):
+    """Generate a list of token with ngrams.
+    Arguments:
+        token_list: A list of tokens
+        ngrams: the number of ngrams.
+    Examples:
+        >>> token_list = ['here', 'we', 'are']
+        >>> generate_ngrams(token_list, 2)
+        >>> ['here we', 'we are']
+    """
+
+    sequences = [token_list[i:] for i in range(ngrams)]
+    ngram_list = list(zip(*sequences))
+    return [' '.join(list(gram)) for gram in ngram_list]
+
+
 class RandomShuffler(object):
     """Use random functions while keeping track of the random state to make it
     reproducible and deterministic."""

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -3,7 +3,6 @@ import requests
 import csv
 from tqdm import tqdm
 import os
-import errno
 import tarfile
 
 
@@ -28,7 +27,18 @@ def reporthook(t):
 
 
 def download_from_url(url, path):
-    """Download file, with logic (from tensor2tensor) for Google Drive"""
+    """Download file, with logic (from tensor2tensor) for Google Drive
+
+    Arguments:
+        url: the url for online Dataset
+        path: directory and filename for the downloaded dataset.
+
+    Examples:
+        >>> url = 'http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz'
+        >>> path = './validation.tar.gz'
+        >>> torchtext.utils.download_from_url(url, path)
+    """
+
     def process_response(r):
         chunk_size = 16 * 1024
         total_size = int(r.headers.get('Content-length', 0))
@@ -80,20 +90,21 @@ def utf_8_encoder(unicode_csv_data):
         yield line.encode('utf-8')
 
 
-def makedir_exist_ok(dirpath):
-    """
-    Python2 support for os.makedirs(.., exist_ok=True)
-    """
-    try:
-        os.makedirs(dirpath)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            pass
-        else:
-            raise
-
-
 def extract_archive(from_path, to_path=None, remove_finished=False):
+    """Extract tar.gz archives.
+
+    Arguments:
+        from_path: the path where the tar.gz file is.
+        to_path: the path where the extracted files are.
+        remove_finished: remove the original tar.gz file. Default: False
+
+    Examples:
+        >>> url = 'http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz'
+        >>> from_path = './validation.tar.gz'
+        >>> to_path = './'
+        >>> torchtext.utils.download_from_url(url, from_path)
+        >>> torchtext.utils.extract_archive(from_path, to_path)
+    """
     if to_path is None:
         to_path = os.path.dirname(from_path)
 
@@ -105,15 +116,3 @@ def extract_archive(from_path, to_path=None, remove_finished=False):
 
     if remove_finished:
         os.remove(from_path)
-
-
-def gen_bar_updater():
-    pbar = tqdm(total=None)
-
-    def bar_update(count, block_size, total_size):
-        if pbar.total is None and total_size:
-            pbar.total = total_size
-        progress_bytes = count * block_size
-        pbar.update(progress_bytes - pbar.n)
-
-    return bar_update

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -220,11 +220,15 @@ class Vocab(object):
 
 def build_vocab(dataset, field, data_name, **kwargs):
     """Construct the Vocab object for the field from a dataset.
+
     Arguments:
-        dataset: Dataset carries the set of data
-        field: Field object used to process token.
-        data_name: The name of data used to build vocab.
+        dataset: Dataset with the iterable data.
+        field: Field object with the information of the special tokens.
+        data_name: The name of data used to build vocab (e.g. 'text', 'label').
         Remaining keyword arguments: Passed to the constructor of Vocab.
+
+    Examples:
+        >>> field.vocab = build_vocab(dataset, field, 'text')
     """
     counter = Counter()
     for x in dataset:

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -218,13 +218,14 @@ class Vocab(object):
                 self.vectors[i] = unk_init(self.vectors[i])
 
 
-def build_vocab(dataset, field, data_name, **kwargs):
+def build_dictionary(dataset, field, data_name, **kwargs):
     """Construct the Vocab object for the field from a dataset.
 
     Arguments:
         dataset: Dataset with the iterable data.
         field: Field object with the information of the special tokens.
-        data_name: The name of data used to build vocab (e.g. 'text', 'label').
+        data_name: The names of data used to build vocab (e.g. 'text', 'label').
+            It must be the attributes of dataset's examples.
         Remaining keyword arguments: Passed to the constructor of Vocab.
 
     Examples:


### PR DESCRIPTION
With some very basic APIs (download_from_url, extract_archive, build_dictionary, rationed_split, generate_ngrams), we hope to build new datasets directly from torch.utils.data.dataset. The existing abstract dataset class in TorchText (i.e. torchtext.data.Dataset) is too complicated. We hope to gain flexibility with this simplified pattern. A few supervised learning dataset will be implemented based on this new pattern. As more necessary APIs are added, we hope the new APIs allow a user to do everything they want to do.

Steps to build datasets with the new pattern:
- The download_from_url and extract_archive functions are used to download and extract the online raw data. 
- Some text preprocessors/processors (e.g. spaCy) are required to clean the data and tokenize the sentence. It should be noted that the text preprocessors vary with the actual datasets so users are expected to prepare the preprocessors/processors. A generic preprocessor API is not pursued here.
- The build_vocab function is to build vocab object based on the tokens lists.
- Use rationed_split function to split the initial data into train/test/valid sets.
- The train/test/valid sets generated from last step are passed to the generate_iterators function. Here, data are batched. The output (train/test/valid iterators) can be used to train/test models.