### PR TITLE
Add __len__ & get_vecs_by_tokens to Vectors

### DIFF
--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -330,7 +330,7 @@ class TestVocab(TorchtextTestCase):
         pickle.dump(v, open(pickle_path, "wb"))
         v_loaded = pickle.load(open(pickle_path, "rb"))
         assert v == v_loaded
-    
+
     @slow
     def test_vectors_get_vecs(self):
         vec = GloVe(name='twitter.27B', dim='25')
@@ -343,7 +343,7 @@ class TestVocab(TorchtextTestCase):
         assert_allclose(vec[tokens[0]].numpy(), token_vecs[0])
         assert_allclose(vec[tokens[1]].numpy(), token_vecs[1])
         assert_allclose(vec['<unk>'].numpy(), token_vecs[2])
-    
+
         token_one_vec = vec.get_vecs_by_tokens(tokens[0], lower_case_backup=True).numpy()
         self.assertEqual(token_one_vec.shape[0], vec.dim)
         assert_allclose(vec[tokens[0].lower()].numpy(), token_one_vec)

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -431,6 +431,20 @@ class Vectors(object):
         return len(self.vectors)
 
     def get_vecs_by_tokens(self, tokens, lower_case_backup=False):
+        """Look up embedding vectors of tokens.
+
+        Arguments:
+            tokens: a token or a list of tokens. if `tokens` is a string, 
+                returns a 1-D tensor of shape `self.dim`; if `tokens` is a 
+                list of strings, returns a 2-D tensor of shape=(len(tokens),  self.dim).
+            lower_case_backup : Whether to look up the token in the lower case.
+                If False, each token in the original case will be looked up; if True, each token in the original case will be looked up first, if not found in the keys of the property `stoi`, the token in the lower case will be looked up. Default: False.
+
+        Examples: 
+            >>> examples = ['chip', 'baby', 'Beautiful'] 
+            >>> vec = text.vocab.GloVe(name='6B', dim=50)
+            >>> ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True) 
+        """
         to_reduce = False
 
         if not isinstance(tokens, list):

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -434,16 +434,20 @@ class Vectors(object):
         """Look up embedding vectors of tokens.
 
         Arguments:
-            tokens: a token or a list of tokens. if `tokens` is a string, 
-                returns a 1-D tensor of shape `self.dim`; if `tokens` is a 
-                list of strings, returns a 2-D tensor of shape=(len(tokens),  self.dim).
+            tokens: a token or a list of tokens. if `tokens` is a string,
+                returns a 1-D tensor of shape `self.dim`; if `tokens` is a
+                list of strings, returns a 2-D tensor of shape=(len(tokens),
+                self.dim).
             lower_case_backup : Whether to look up the token in the lower case.
-                If False, each token in the original case will be looked up; if True, each token in the original case will be looked up first, if not found in the keys of the property `stoi`, the token in the lower case will be looked up. Default: False.
+                If False, each token in the original case will be looked up;
+                if True, each token in the original case will be looked up first,
+                if not found in the keys of the property `stoi`, the token in the
+                lower case will be looked up. Default: False.
 
-        Examples: 
-            >>> examples = ['chip', 'baby', 'Beautiful'] 
+        Examples:
+            >>> examples = ['chip', 'baby', 'Beautiful']
             >>> vec = text.vocab.GloVe(name='6B', dim=50)
-            >>> ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True) 
+            >>> ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True)
         """
         to_reduce = False
 

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from collections import defaultdict
+from collections import defaultdict, Iterable
 from functools import partial
 import logging
 import os
@@ -426,6 +426,26 @@ class Vectors(object):
         else:
             logger.info('Loading vectors from {}'.format(path_pt))
             self.itos, self.stoi, self.vectors, self.dim = torch.load(path_pt)
+    
+    def __len__(self):
+        return len(self.vectors)
+
+    def get_vecs_by_tokens(self, tokens, lower_case_backup=False):
+        to_reduce = False
+
+        if not isinstance(tokens, list):
+            tokens = [tokens]
+            to_reduce = True
+
+        if not lower_case_backup:
+            indices = [self[token] for token in tokens]
+        else:
+            indices = [self[token] if token in self.stoi
+                       else self[token.lower()]
+                       for token in tokens]
+        
+        vecs = torch.stack(indices)
+        return vecs[0] if to_reduce else vecs
 
 
 class GloVe(Vectors):

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -445,7 +445,7 @@ class Vectors(object):
                 lower case will be looked up. Default: False.
 
         Examples:
-            >>> examples = ['chip', 'Baby', 'Beautiful']
+            >>> examples = ['chip', 'baby', 'Beautiful']
             >>> vec = text.vocab.GloVe(name='6B', dim=50)
             >>> ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True)
         """

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from collections import defaultdict, Iterable
+from collections import defaultdict
 from functools import partial
 import logging
 import os
@@ -426,7 +426,7 @@ class Vectors(object):
         else:
             logger.info('Loading vectors from {}'.format(path_pt))
             self.itos, self.stoi, self.vectors, self.dim = torch.load(path_pt)
-    
+
     def __len__(self):
         return len(self.vectors)
 
@@ -443,7 +443,7 @@ class Vectors(object):
             indices = [self[token] if token in self.stoi
                        else self[token.lower()]
                        for token in tokens]
-        
+
         vecs = torch.stack(indices)
         return vecs[0] if to_reduce else vecs
 

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -445,7 +445,7 @@ class Vectors(object):
                 lower case will be looked up. Default: False.
 
         Examples:
-            >>> examples = ['chip', 'baby', 'Beautiful']
+            >>> examples = ['chip', 'Baby', 'Beautiful']
             >>> vec = text.vocab.GloVe(name='6B', dim=50)
             >>> ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True)
         """


### PR DESCRIPTION
Add __len and get_vecs_by_tokens functions to Vectors

I'm using torchtext to rewrite a GluonNLP-based program(https://d2l.ai/chapter_natural-language-processing/similarity-analogy.html)，I want to use the Vectors in a more flexible way. For example:

```python
# GluonNLP implement
def knn(W, x, k):
    cos = nd.dot(W, x.reshape((-1,))) / (
        (nd.sum(W * W, axis=1) + 1e-9).sqrt() * nd.sum(x * x).sqrt())
    topk = nd.topk(cos, k=k, ret_typ='indices').asnumpy().astype('int32')
    return topk, [cos[i].asscalar() for i in topk]

def get_similar_tokens(query_token, k, embed):
    topk, cos = knn(embed.idx_to_vec,
                    embed.get_vecs_by_tokens([query_token]), k+1)
    for i, c in zip(topk[1:], cos[1:]):  # 除去输入词
        print('cosine sim=%.3f: %s' % (c, (embed.idx_to_token[i])))

def get_analogy(token_a, token_b, token_c, embed):
    vecs = embed.get_vecs_by_tokens([token_a, token_b, token_c])
    x = vecs[1] - vecs[0] + vecs[2]
    topk, cos = knn(embed.idx_to_vec, x, 1)
    return embed.idx_to_token[topk[0]]

# torchtext implement
def knn(W, x, k):
    cos = torch.mm(W, x.reshape(-1, 1)) / (
        (torch.sum(W * W, dim=1, keepdim=True) + 1e-9).sqrt() * torch.sum(x * x).sqrt())
    _, topk = torch.topk(cos, k=k, dim=0)
    return topk, [cos[i].item() for i in topk]

def get_similar_tokens(query_token, k, embed):
        topk, cos = knn(embed.vectors,
                    embed[query_token], k+1)
    for i, c in zip(topk[1:], cos[1:]): 
        print('cosine sim=%.3f: %s' % (c, (embed.itos[i])))

def get_analogy(token_a, token_b, token_c, embed):
    vecs_a, vecs_b, vecs_c = embed[token_a], embed[token_b], embed[token_c]
    x = vecs_b - vecs_a + vecs_c
    topk, cos = knn(embed.vectors, x, 1)
    return embed.itos[topk[0]]
```