### PR TITLE
Refined Example.fromJSON() to make JSON processing more powerful.

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -4,7 +4,7 @@
 Examples
 =========
 
-Ability to describe declaratively how to load a custom NLP dataset that's in a "normal" format:
+1. Ability to describe declaratively how to load a custom NLP dataset that's in a "normal" format:
 
 .. code-block:: python
 
@@ -18,7 +18,25 @@ Ability to describe declaratively how to load a custom NLP dataset that's in a "
         fields={'sentence_tokenized': ('text', data.Field(sequential=True)),
                  'sentiment_gold': ('labels', data.Field(sequential=False))})
 
-Ability to define a preprocessing pipeline:
+2. Ability to parse nested keys for loading a JSON dataset
+
+2.1 sample.json
+.. code-block:: json
+    {"foods": {
+        "fruits": ["Apple", "Banana"], 
+        "vegetables": [{"name": "lettuce"}, {"name": "marrow"}]
+        }
+    }
+
+2.2 pass in nested keys to parse nested data directly
+.. code-block:: python
+    In [1]: from torchtext import data
+    In [2]: fields = {'foods.vegetables.name': ('vegs', data.Field())}
+    In [3]: dataset = data.TabularDataset(path='sample.json', format='json', fields=fields)
+    In [4]: dataset.examples[0].vegs
+    Out[4]: ['lettuce', 'marrow']
+
+3. Ability to define a preprocessing pipeline:
 
 .. code-block:: python
 
@@ -28,7 +46,7 @@ Ability to define a preprocessing pipeline:
         path='data/mt/wmt16-ende.train', exts=('.en', '.de'),
         fields=(src, trg))
 
-Batching, padding, and numericalizing (including building vocabulary object):
+4. Batching, padding, and numericalizing (including building vocabulary object):
 
 .. code-block:: python
 
@@ -47,7 +65,7 @@ Batching, padding, and numericalizing (including building vocabulary object):
     >>>next(iter(train_iter))
     <data.Batch(batch_size=32, src=[LongTensor (32, 25)], trg=[LongTensor (32, 28)])>
 
-Wrapper for dataset splits (train, validation, test):
+5. Wrapper for dataset splits (train, validation, test):
 
 .. code-block:: python
 

--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -31,7 +31,7 @@ class TorchtextTestCase(TestCase):
         self.test_dataset_splitting_path = os.path.join(self.test_dir,
                                                         "test_dataset_split")
         self.test_nested_key_json_dataset_path = os.path.join(self.test_dir,
-                                                        "test_nested_key_json")
+                                                              "test_nested_key_json")
 
     def tearDown(self):
         try:
@@ -72,19 +72,16 @@ class TorchtextTestCase(TestCase):
         Used only to test nested key parsing of Example.fromJSON()
         """
         dict_dataset = [
-            {"foods": 
-                {"fruits": ["Apple", "Banana"], 
-                "vegetables": [
-                    {"name": "lettuce"}, 
-                    {"name": "marrow"}
-                    ]
-                }
-            }
+            {"foods":
+                {"fruits": ["Apple", "Banana"],
+                 "vegetables": [
+                    {"name": "lettuce"},
+                    {"name": "marrow"}]}}
         ]
-        with open(self.test_nested_key_json_dataset_path, "w") as test_nested_key_json_dataset_file:
+        with open(self.test_nested_key_json_dataset_path,
+                  "w") as test_nested_key_json_dataset_file:
             for example in dict_dataset:
                 test_nested_key_json_dataset_file.write(json.dumps(example) + "\n")
-
 
     def write_test_numerical_features_dataset(self):
         with open(self.test_numerical_features_dataset_path,

--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -30,6 +30,8 @@ class TorchtextTestCase(TestCase):
                                                             "test_msg_field_dst")
         self.test_dataset_splitting_path = os.path.join(self.test_dir,
                                                         "test_dataset_split")
+        self.test_nested_key_json_dataset_path = os.path.join(self.test_dir,
+                                                        "test_nested_key_json")
 
     def tearDown(self):
         try:
@@ -64,6 +66,25 @@ class TorchtextTestCase(TestCase):
                                     example["question2"], example["label"]])))
                 else:
                     raise ValueError("Invalid format {}".format(data_format))
+
+    def write_test_nested_key_json_dataset(self):
+        """
+        Used only to test nested key parsing of Example.fromJSON()
+        """
+        dict_dataset = [
+            {"foods": 
+                {"fruits": ["Apple", "Banana"], 
+                "vegetables": [
+                    {"name": "lettuce"}, 
+                    {"name": "marrow"}
+                    ]
+                }
+            }
+        ]
+        with open(self.test_nested_key_json_dataset_path, "w") as test_nested_key_json_dataset_file:
+            for example in dict_dataset:
+                test_nested_key_json_dataset_file.write(json.dumps(example) + "\n")
+
 
     def write_test_numerical_features_dataset(self):
         with open(self.test_numerical_features_dataset_path,

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -100,8 +100,8 @@ class TestDataset(TorchtextTestCase):
 
         valid_expected_results = ['lettuce', 'marrow']
         dataset = data.TabularDataset(
-            path=self.test_nested_key_json_dataset_path, 
-            format="json", 
+            path=self.test_nested_key_json_dataset_path,
+            format="json",
             fields=valid_fields)
         # check results
         assert dataset.examples[0].vegs[0] == valid_expected_results[0]
@@ -109,9 +109,9 @@ class TestDataset(TorchtextTestCase):
 
         with self.assertRaises(ValueError):
             data.TabularDataset(
-                    path=self.test_nested_key_json_dataset_path, 
-                    format="json",
-                    fields=invalid_fields)
+                path=self.test_nested_key_json_dataset_path,
+                format="json",
+                fields=invalid_fields)
 
     def test_errors(self):
         # Ensure that trying to retrieve a key not in JSON data errors

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -100,15 +100,18 @@ class TestDataset(TorchtextTestCase):
 
         valid_expected_results = ['lettuce', 'marrow']
         dataset = data.TabularDataset(
-            path=self.test_nested_key_json_dataset_path, format="json", fields=valid_fields)
+            path=self.test_nested_key_json_dataset_path, 
+            format="json", 
+            fields=valid_fields)
         # check results
         assert dataset.examples[0].vegs[0] == valid_expected_results[0]
         assert dataset.examples[0].vegs[1] == valid_expected_results[1]
 
         with self.assertRaises(ValueError):
             data.TabularDataset(
-                path=self.test_nested_key_json_dataset_path, format="json", fields=invalid_fields)
-
+                    path=self.test_nested_key_json_dataset_path, 
+                    format="json",
+                    fields=invalid_fields)
 
     def test_errors(self):
         # Ensure that trying to retrieve a key not in JSON data errors

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -93,6 +93,23 @@ class TestDataset(TorchtextTestCase):
             self.assertEqual(example.q2_spacy, expected_examples[i][3])
             self.assertEqual(example.label, expected_examples[i][4])
 
+    def test_json_valid_and_invalid_nested_key(self):
+        self.write_test_nested_key_json_dataset()
+        valid_fields = {'foods.vegetables.name': ('vegs', data.Field())}
+        invalid_fields = {'foods.vegetables.color': ('vegs', data.Field())}
+
+        valid_expected_results = ['lettuce', 'marrow']
+        dataset = data.TabularDataset(
+            path=self.test_nested_key_json_dataset_path, format="json", fields=valid_fields)
+        # check results
+        assert dataset.examples[0].vegs[0] == valid_expected_results[0]
+        assert dataset.examples[0].vegs[1] == valid_expected_results[1]
+
+        with self.assertRaises(ValueError):
+            data.TabularDataset(
+                path=self.test_nested_key_json_dataset_path, format="json", fields=invalid_fields)
+
+
     def test_errors(self):
         # Ensure that trying to retrieve a key not in JSON data errors
         self.write_test_ppid_dataset(data_format="json")

--- a/torchtext/data/example.py
+++ b/torchtext/data/example.py
@@ -1,6 +1,6 @@
-import json
-
 import six
+import json
+from functools import reduce
 
 
 class Example(object):
@@ -8,10 +8,43 @@ class Example(object):
 
     Stores each column of the example as an attribute.
     """
-
     @classmethod
     def fromJSON(cls, data, fields):
-        return cls.fromdict(json.loads(data), fields)
+        ex = cls()
+        obj = json.loads(data)
+
+        for key, vals in fields.items():
+            if vals is not None:
+                if not isinstance(vals, list):
+                    vals = [vals]
+
+                for val in vals:
+                    # for processing the key likes 'foo.bar'
+                    name, field = val
+                    ks = key.split('.')
+
+                    def reducer(obj, key):
+                        if isinstance(obj, list):
+                            results = []
+                            for data in obj:
+                                if key not in data:
+                                    # key error
+                                    raise ValueError("Specified key {} was not found in "
+                                                     "the input data".format(key))
+                                else:
+                                    results.append(data[key])
+                            return results
+                        else:
+                            # key error
+                            if key not in obj:
+                                raise ValueError("Specified key {} was not found in "
+                                                 "the input data".format(key))
+                            else:
+                                return obj[key]
+
+                    v = reduce(reducer, ks, obj)
+                    setattr(ex, name, field.preprocess(v))
+        return ex
 
     @classmethod
     def fromdict(cls, data, fields):


### PR DESCRIPTION
**sample.json:**
```json
{"foods": {"fruits": ["Apple", "Banana"], "vegetables": [{"name": "lettuce"}, {"name": "marrow"}] }}
````

**Before:**
```python3
In [1]: from torchtext import data

In [2]: fields = {'foods.vegetables.name': ('vegs', data.Field())}

In [3]: vegs = data.TabularDataset(path='sample.json', format='json', fields=fields)

ValueError: Specified key foods.vegetables.name was not found in the input data
```

**Now:**
```python3
In [1]: from torchtext import data

In [2]: fields = {'foods.vegetables.name': ('vegs', data.Field())}

In [3]: vegs = data.TabularDataset(path='sample.json', format='json', fields=fields)

In [4]: vegs.examples[0].vegs
Out[4]: ['lettuce', 'marrow']
```