### PR TITLE
Fix the overflow error by changing maxInt

### DIFF
--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -125,7 +125,7 @@ def unicode_csv_reader(unicode_csv_data, **kwargs):
             csv.field_size_limit(maxInt)
             break
         except OverflowError:
-            maxInt = int(maxInt / 10)   
+            maxInt = int(maxInt / 10)
     csv.field_size_limit(maxInt)
 
     if six.PY2:

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -127,7 +127,7 @@ def unicode_csv_reader(unicode_csv_data, **kwargs):
         except OverflowError:
             maxInt = int(maxInt / 10)
 
-    csv.field_size_limit(sys.maxsize)
+    csv.field_size_limit(maxInt)
 
     if six.PY2:
         # csv.py doesn't do Unicode; encode temporarily as UTF-8:

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -125,8 +125,7 @@ def unicode_csv_reader(unicode_csv_data, **kwargs):
             csv.field_size_limit(maxInt)
             break
         except OverflowError:
-            maxInt = int(maxInt / 10)
-
+            maxInt = int(maxInt / 10)   
     csv.field_size_limit(maxInt)
 
     if six.PY2:


### PR DESCRIPTION
csv.field_size_limit input was changed from sys.maxsize to maxInt. This Will resolve the "OverflowError: Python int too large to convert to C"  error.