### PR TITLE
Temporarily remove nltk downloader in travis CI tests

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -55,11 +55,6 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
     # SpaCy English models
     python -m spacy download en
 
-    # NLTK data needed for Moses tokenizer
-    if [[ "$PYTHON_VERSION" != "2.7" ]]; then
-        python -m nltk.downloader perluniprops nonbreaking_prefixes
-    fi
-
     # PyTorch
     conda install --yes pytorch torchvision -c pytorch
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -55,8 +55,9 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
     # SpaCy English models
     python -m spacy download en
 
+    # Disable certificate verify
+    python -c 'import ssl' 'ssl._create_default_https_context = ssl._create_unverified_context' 
     # NLTK data needed for Moses tokenizer
-    pip install certifi  # Install the certifi package
     python -m nltk.downloader perluniprops nonbreaking_prefixes
 
     # PyTorch

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -55,6 +55,11 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
     # SpaCy English models
     python -m spacy download en
 
+# TODO: Add nltk data back once moses tokenizer is back online.
+# https://github.com/alvations/sacremoses/issues/61 
+#    # NLTK data needed for Moses tokenizer
+#    python -m nltk.downloader perluniprops nonbreaking_prefixes
+#
     # PyTorch
     conda install --yes pytorch torchvision -c pytorch
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -56,6 +56,7 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
     python -m spacy download en
 
     # NLTK data needed for Moses tokenizer
+    pip install certifi  # Install the certifi package
     python -m nltk.downloader perluniprops nonbreaking_prefixes
 
     # PyTorch

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -55,10 +55,10 @@ if [[ "$SKIP_TESTS" != "true" ]]; then
     # SpaCy English models
     python -m spacy download en
 
-    # Disable certificate verify
-    python -c 'import ssl' 'ssl._create_default_https_context = ssl._create_unverified_context' 
     # NLTK data needed for Moses tokenizer
-    python -m nltk.downloader perluniprops nonbreaking_prefixes
+    if [[ "$PYTHON_VERSION" != "2.7" ]]; then
+        python -m nltk.downloader perluniprops nonbreaking_prefixes
+    fi
 
     # PyTorch
     conda install --yes pytorch torchvision -c pytorch

--- a/test/data/test_utils.py
+++ b/test/data/test_utils.py
@@ -21,6 +21,7 @@ class TestUtils(TorchtextTestCase):
             "complex", "punctuation", "."]
 
     # TODO: Remove this once issue was been resolved.
+    # TODO# Add nltk data back in build_tools/travis/install.sh.
     @pytest.mark.skip(reason=("Impractically slow! "
                               "https://github.com/alvations/sacremoses/issues/61"))
     def test_get_tokenizer_moses(self):


### PR DESCRIPTION
Fix the travis CI tests. Temporarily remove nltk downloader in travis CI tests. Need to push it back after the issue related to moses tokenizer is resolved. https://github.com/alvations/sacremoses/issues/61