### PR TITLE
Fix backwards compatibility of vocab serialization

### DIFF
--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -335,7 +335,7 @@ class TestVocab(TorchtextTestCase):
         # Test whether loading works on models saved in which
         #  the state was not required to have an "unk_index".
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
-        v = vocab.Vocab(c, min_freq=3, specials=['<pad>', '<bos>']) # no unk special
+        v = vocab.Vocab(c, min_freq=3, specials=['<pad>', '<bos>'])  # no unk special
         # Mock old vocabulary
         del v.__dict__["unk_index"]
 

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -331,6 +331,19 @@ class TestVocab(TorchtextTestCase):
         v_loaded = pickle.load(open(pickle_path, "rb"))
         assert v == v_loaded
 
+    def test_serialization_backcompat(self):
+        # Test whether loading works on models saved in which
+        #  the state was not required to have an "unk_index".
+        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
+        v = vocab.Vocab(c, min_freq=3, specials=['<pad>', '<bos>']) # no unk special
+        # Mock old vocabulary
+        del v.__dict__["unk_index"]
+
+        pickle_path = os.path.join(self.test_dir, "vocab.pkl")
+        pickle.dump(v, open(pickle_path, "wb"))
+        v_loaded = pickle.load(open(pickle_path, "rb"))
+        assert v == v_loaded
+
     @slow
     def test_vectors_get_vecs(self):
         vec = GloVe(name='twitter.27B', dim='25')

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -116,7 +116,7 @@ class Vocab(object):
         return attrs
 
     def __setstate__(self, state):
-        if state['unk_index'] is None:
+        if state.get("unk_index", None) is None:
             stoi = defaultdict()
         else:
             stoi = defaultdict(self._default_unk_index)


### PR DESCRIPTION
(Hopefully) fixes the issue mentioned in #531, after the PR was merged.

Previous instances of "Vocab" didn't have the "unk_index" attribute, which the deserialization wrongly assumes will be present. This is causing issues when loading models stored with previous versions of torchtext. I added a bandaid fix as well as a test checking whether loading works on a mocked older version of the Vocab instance.

@francoishernandez I would appreciate if you can test the patch once it's merged.