### PR TITLE
added xnli dataset

### DIFF
--- a/test/nli.py
+++ b/test/nli.py
@@ -64,3 +64,30 @@ batch = next(iter(train_iter))
 print("Numericalize premises:\n", batch.premise)
 print("Numericalize hypotheses:\n", batch.hypothesis)
 print("Entailment labels:\n", batch.label)
+
+# Testing XNLI
+print("Run test on XNLI...")
+TEXT = data.Field()
+LABEL = data.LabelField()
+GENRE = data.Field()
+LANGUAGE = data.Field()
+
+val, test = datasets.XNLI.splits(TEXT, LABEL, GENRE, LANGUAGE)
+
+print("Fields:", val.fields)
+print("Number of examples:\n", len(val))
+print("First Example instance:\n", vars(val[0]))
+
+TEXT.build_vocab(val)
+LABEL.build_vocab(val)
+GENRE.build_vocab(val, test)
+LANGUAGE.build_vocab(val, test)
+
+val_iter, test_iter = data.Iterator.splits((val, test), batch_size=3)
+
+batch = next(iter(val_iter))
+print("Numericalize premises:\n", batch.premise)
+print("Numericalize hypotheses:\n", batch.hypothesis)
+print("Entailment labels:\n", batch.label)
+print("Genre categories:\n", batch.genre)
+print("Languages:\n", batch.genre)

--- a/torchtext/datasets/__init__.py
+++ b/torchtext/datasets/__init__.py
@@ -1,5 +1,5 @@
 from .language_modeling import LanguageModelingDataset, WikiText2, WikiText103, PennTreebank  # NOQA
-from .nli import SNLI, MultiNLI
+from .nli import SNLI, MultiNLI, XNLI
 from .sst import SST
 from .translation import TranslationDataset, Multi30k, IWSLT, WMT14  # NOQA
 from .sequence_tagging import SequenceTaggingDataset, UDPOS, CoNLL2000Chunking  # NOQA
@@ -15,6 +15,7 @@ from .text_classification import TextClassificationDataset, \
 __all__ = ['LanguageModelingDataset',
            'SNLI',
            'MultiNLI',
+           'XNLI',
            'SST',
            'TranslationDataset',
            'Multi30k',

--- a/torchtext/datasets/nli.py
+++ b/torchtext/datasets/nli.py
@@ -161,3 +161,24 @@ class MultiNLI(NLIDataset):
                                            extra_fields=extra_fields,
                                            root=root, train=train,
                                            validation=validation, test=test)
+
+class XNLI(NLIDataset):
+    urls = ['http://www.nyu.edu/projects/bowman/xnli/XNLI-1.0.zip']
+    dirname = 'XNLI-1.0'
+    name = 'xnli'
+
+    @classmethod
+    def splits(cls, text_field, label_field, genre_field=None, language_field=None,
+               root='.data',
+               validation='xnli.dev.jsonl',
+               test='xnli.test.jsonl'):
+        extra_fields = {}
+        if genre_field is not None:
+            extra_fields["genre"] = ("genre", genre_field)
+        if language_field is not None:
+            extra_fields["language"] = ("language", language_field)
+
+        return super(XNLI, cls).splits(text_field, label_field,
+                                           extra_fields=extra_fields,
+                                           root=root, train=None,
+                                           validation=validation, test=test)


### PR DESCRIPTION
This is initial work on adding the [XNLI dataset](http://www.nyu.edu/projects/bowman/xnli/) to TorchText. 

Weirdly, the XNLI dataset only has a "dev" and a "test" set, no training set. This means I had to make some decisions that I'm not sure were for the best. 

I've either removed or hard coded the `train` argument to be `None`, which means the `XNLI` dataset works fine with `.splits`, but not with `.iters`. due to [these](https://github.com/pytorch/text/blob/master/torchtext/datasets/nli.py#L120) lines being hardcoded.

The XNLI dataset is used for "cross-language sentence encoding", so I have also added a `language_field`.