### PR TITLE
[DO NOT MERGE]fix Dataset.split() method

### DIFF
--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -127,7 +127,7 @@ class Dataset(torch.utils.data.Dataset):
                 val_data += group_val
 
         splits = tuple(Dataset(d, self.fields)
-                       for d in (train_data, val_data, test_data) if d)
+                       for d in (train_data, test_data, val_data) if d)
 
         # In case the parent sort key isn't none
         if self.sort_key:

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -125,7 +125,8 @@ class Dataset(torch.utils.data.Dataset):
                 train_data += group_train
                 test_data += group_test
                 val_data += group_val
-
+        
+        test_data, val_data = val_data, test_data
         splits = tuple(Dataset(d, self.fields)
                        for d in (train_data, test_data, val_data) if d)
 

--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -125,7 +125,7 @@ class Dataset(torch.utils.data.Dataset):
                 train_data += group_train
                 test_data += group_test
                 val_data += group_val
-        
+
         test_data, val_data = val_data, test_data
         splits = tuple(Dataset(d, self.fields)
                        for d in (train_data, test_data, val_data) if d)


### PR DESCRIPTION
When **Dataset.split()** method is called with **split_ratio** as a list of **[train, test, val]**,
it always switches the **test** and **val** while returning.