### PR TITLE
Add BLEU score metric

### DIFF
--- a/docs/source/data/metrics.rst
+++ b/docs/source/data/metrics.rst
@@ -6,3 +6,8 @@ torchtext.data.metrics
 
 .. automodule:: torchtext.data.metrics
 .. currentmodule:: torchtext.data.metrics
+
+:hidden:`bleu_score `
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: bleu_score

--- a/docs/source/data/metrics.rst
+++ b/docs/source/data/metrics.rst
@@ -1,0 +1,8 @@
+.. role:: hidden
+    :class: hidden-section
+
+torchtext.data.metrics
+===========================
+
+.. automodule:: torchtext.data.metrics
+.. currentmodule:: torchtext.data.metrics

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -1,4 +1,5 @@
 from torchtext.data import metrics
+from torch.testing import assert_allclose
 from ..common.torchtext_test_case import TorchtextTestCase
 
 
@@ -18,19 +19,19 @@ class TestUtils(TorchtextTestCase):
         # Partial match
         candidate = [['My', 'full', 'pytorch', 'test']]
         refs = [[['My', 'full', 'pytorch', 'test', '!'], ['Different']]]
-        assert round(metrics.bleu_score(candidate, refs), 4) == 0.7788
+        assert_allclose(bleu_score(candidate, refs), 0.7788)
 
         # Bigrams and unigrams only
         candidate = [['My', 'pytorch', 'test']]
         refs = [[['My', 'full', 'pytorch', 'test'], ['Different']]]
-        assert round(metrics.bleu_score(candidate, refs, max_n=2,
-                     weights=[0.5, 0.5]), 4) == 0.5067
+        assert_allclose(bleu_score(candidate, refs, max_n=2,
+                                   weights=[0.5, 0.5]), 0.5067)
 
         # Multi-sentence corpus
         candidate = [['My', 'full', 'pytorch', 'test'], ['Another', 'Sentence']]
         refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']],
                 [['No', 'Match']]]
-        assert round(metrics.bleu_score(candidate, refs), 4) == 0.8409
+        assert_allclose(bleu_score(candidate, refs), 0.8409)
 
         # Empty input
         candidate = [[]]
@@ -49,10 +50,10 @@ class TestUtils(TorchtextTestCase):
                 [['I', 'have', 'made', 'a', 'terrible', 'mistake'], ['Big', 'mistake']]]
 
         # Value computed using nltk.translate.bleu_score.corpus_bleu(refs, candidate)
-        assert round(metrics.bleu_score(candidate, refs), 4) == 0.4573
-        assert round(metrics.bleu_score(candidate, refs, 3,
-                     weights=[0.33, 0.33, 0.33]), 4) == 0.4901
-        assert round(metrics.bleu_score(candidate, refs, 2,
-                     weights=[0.5, 0.5]), 4) == 0.5120
-        assert round(metrics.bleu_score(candidate, refs, 1,
-                     weights=[1]), 4) == 0.5516
+        assert_allclose(bleu_score(candidate, refs), 0.4573)
+        assert_allclose(bleu_score(candidate, refs, 3,
+                     weights=[0.33, 0.33, 0.33]), 0.4901)
+        assert_allclose(bleu_score(candidate, refs, 2,
+                     weights=[0.5, 0.5]), 0.5120)
+        assert_allclose(bleu_score(candidate, refs, 1,
+                     weights=[1]), 0.5516)

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -49,11 +49,15 @@ class TestUtils(TorchtextTestCase):
                 ['She', 'loves', 'all', 'her', 'children', 'equally']],
                 [['I', 'have', 'made', 'a', 'terrible', 'mistake'], ['Big', 'mistake']]]
 
-        # Value computed using nltk.translate.bleu_score.corpus_bleu(refs, candidate)
+        # The comments below give the code used to get each hardcoded bleu score
+        # nltk.translate.bleu_score.corpus_bleu(refs, candidate)
         assert_allclose(bleu_score(candidate, refs), 0.4573199)
+        # nltk.translate.bleu_score.corpus_bleu(refs, candidate, weights=[0.33]*3)
         assert_allclose(bleu_score(candidate, refs, 3,
                      weights=[0.33, 0.33, 0.33]), 0.4901113)
+        # nltk.translate.bleu_score.corpus_bleu(refs, candidate, weights=[0.5]*2)
         assert_allclose(bleu_score(candidate, refs, 2,
                      weights=[0.5, 0.5]), 0.5119535)
+        # nltk.translate.bleu_score.corpus_bleu(refs, candidate, weights=[1])
         assert_allclose(bleu_score(candidate, refs, 1,
                      weights=[1]), 0.5515605)

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -19,19 +19,19 @@ class TestUtils(TorchtextTestCase):
         # Partial match
         candidate = [['My', 'full', 'pytorch', 'test']]
         refs = [[['My', 'full', 'pytorch', 'test', '!'], ['Different']]]
-        assert_allclose(bleu_score(candidate, refs), 0.7788)
+        assert_allclose(bleu_score(candidate, refs), 0.7788007)
 
         # Bigrams and unigrams only
         candidate = [['My', 'pytorch', 'test']]
         refs = [[['My', 'full', 'pytorch', 'test'], ['Different']]]
         assert_allclose(bleu_score(candidate, refs, max_n=2,
-                                   weights=[0.5, 0.5]), 0.5067)
+                                   weights=[0.5, 0.5]), 0.5066641)
 
         # Multi-sentence corpus
         candidate = [['My', 'full', 'pytorch', 'test'], ['Another', 'Sentence']]
         refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']],
                 [['No', 'Match']]]
-        assert_allclose(bleu_score(candidate, refs), 0.8409)
+        assert_allclose(bleu_score(candidate, refs), 0.8408964)
 
         # Empty input
         candidate = [[]]
@@ -39,7 +39,7 @@ class TestUtils(TorchtextTestCase):
         assert metrics.bleu_score(candidate, refs) == 0
 
         # Long input, compared to NLTK implementation score
-        candidate = [['Lucille', 'Bluth', 'has', '3', 'sons'],
+        candidate = [['Lucille', 'B', 'has', '3', 'sons'],
                      ['She', 'loves', 'all', 'her', 'children', 'equally'],
                      ['No', 'match', 'here', 'at', 'all']]
 
@@ -50,10 +50,10 @@ class TestUtils(TorchtextTestCase):
                 [['I', 'have', 'made', 'a', 'terrible', 'mistake'], ['Big', 'mistake']]]
 
         # Value computed using nltk.translate.bleu_score.corpus_bleu(refs, candidate)
-        assert_allclose(bleu_score(candidate, refs), 0.4573)
+        assert_allclose(bleu_score(candidate, refs), 0.4573199)
         assert_allclose(bleu_score(candidate, refs, 3,
-                     weights=[0.33, 0.33, 0.33]), 0.4901)
+                     weights=[0.33, 0.33, 0.33]), 0.4901113)
         assert_allclose(bleu_score(candidate, refs, 2,
-                     weights=[0.5, 0.5]), 0.5120)
+                     weights=[0.5, 0.5]), 0.5119535)
         assert_allclose(bleu_score(candidate, refs, 1,
-                     weights=[1]), 0.5516)
+                     weights=[1]), 0.5515605)

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -39,6 +39,7 @@ class TestUtils(TorchtextTestCase):
         assert bleu_score(candidate, refs) == 0
 
         # Long input, compared to NLTK implementation score
+        # nltl version used: 3.4.5
         candidate = [['Lucille', 'B', 'has', '3', 'sons'],
                      ['She', 'loves', 'all', 'her', 'children', 'equally'],
                      ['No', 'match', 'here', 'at', 'all']]

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -31,3 +31,28 @@ class TestUtils(TorchtextTestCase):
         refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']],
                 [['No', 'Match']]]
         assert round(metrics.bleu_score(candidate, refs), 4) == 0.8409
+
+        # Empty input
+        candidate = [[]]
+        refs = [[[]]]
+        assert metrics.bleu_score(candidate, refs) == 0
+
+        # Long input, compared to NLTK implementation score
+        candidate = [['Lucille', 'Bluth', 'has', '3', 'sons'],
+                     ['She', 'loves', 'all', 'her', 'children', 'equally'],
+                     ['No', 'match', 'here', 'at', 'all']]
+
+        refs = [[['I', 'heard', 'Lucille', 'has', 'three', 'sons'],
+                ['Rumor', 'has', 'it', 'Lucille', 'has', '3', 'sons', '!']],
+                [['I', 'love', 'all', 'my', 'children', 'equally'],
+                ['She', 'loves', 'all', 'her', 'children', 'equally']],
+                [['I', 'have', 'made', 'a', 'terrible', 'mistake'], ['Big', 'mistake']]]
+
+        # Value computed using nltk.translate.bleu_score.corpus_bleu(refs, candidate)
+        assert round(metrics.bleu_score(candidate, refs), 4) == 0.4573
+        assert round(metrics.bleu_score(candidate, refs, 3,
+                     weights=[0.33, 0.33, 0.33]), 4) == 0.4901
+        assert round(metrics.bleu_score(candidate, refs, 2,
+                     weights=[0.5, 0.5]), 4) == 0.5120
+        assert round(metrics.bleu_score(candidate, refs, 1,
+                     weights=[1]), 4) == 0.5516

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -1,4 +1,4 @@
-from torchtext.data import metrics
+from torchtext.data.metrics import bleu_score
 from torch.testing import assert_allclose
 from ..common.torchtext_test_case import TorchtextTestCase
 
@@ -9,12 +9,12 @@ class TestUtils(TorchtextTestCase):
         # Full match
         candidate = [['My', 'full', 'pytorch', 'test']]
         refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']]]
-        assert metrics.bleu_score(candidate, refs) == 1
+        assert bleu_score(candidate, refs) == 1
 
         # No 4-gram
         candidate = [['My', 'full', 'pytorch']]
         refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']]]
-        assert metrics.bleu_score(candidate, refs) == 0
+        assert bleu_score(candidate, refs) == 0
 
         # Partial match
         candidate = [['My', 'full', 'pytorch', 'test']]
@@ -36,7 +36,7 @@ class TestUtils(TorchtextTestCase):
         # Empty input
         candidate = [[]]
         refs = [[[]]]
-        assert metrics.bleu_score(candidate, refs) == 0
+        assert bleu_score(candidate, refs) == 0
 
         # Long input, compared to NLTK implementation score
         candidate = [['Lucille', 'B', 'has', '3', 'sons'],
@@ -54,10 +54,10 @@ class TestUtils(TorchtextTestCase):
         assert_allclose(bleu_score(candidate, refs), 0.4573199)
         # nltk.translate.bleu_score.corpus_bleu(refs, candidate, weights=[0.33]*3)
         assert_allclose(bleu_score(candidate, refs, 3,
-                     weights=[0.33, 0.33, 0.33]), 0.4901113)
+                        weights=[0.33, 0.33, 0.33]), 0.4901113)
         # nltk.translate.bleu_score.corpus_bleu(refs, candidate, weights=[0.5]*2)
         assert_allclose(bleu_score(candidate, refs, 2,
-                     weights=[0.5, 0.5]), 0.5119535)
+                        weights=[0.5, 0.5]), 0.5119535)
         # nltk.translate.bleu_score.corpus_bleu(refs, candidate, weights=[1])
         assert_allclose(bleu_score(candidate, refs, 1,
-                     weights=[1]), 0.5515605)
+                        weights=[1]), 0.5515605)

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -1,0 +1,33 @@
+from torchtext.data import metrics
+from .common.torchtext_test_case import TorchtextTestCase
+
+
+class TestUtils(TorchtextTestCase):
+
+    def test_bleu_score(self):
+        # Full match
+        candidate = [['My', 'full', 'pytorch', 'test']]
+        refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']]]
+        assert metrics.bleu_score(candidate, refs) == 1
+
+        # No 4-gram
+        candidate = [['My', 'full', 'pytorch']]
+        refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']]]
+        assert metrics.bleu_score(candidate, refs) == 0
+
+        # Partial match
+        candidate = [['My', 'full', 'pytorch', 'test']]
+        refs = [[['My', 'full', 'pytorch', 'test', '!'], ['Different']]]
+        assert round(metrics.bleu_score(candidate, refs), 4) == 0.7788
+
+        # Bigrams and unigrams only
+        candidate = [['My', 'pytorch', 'test']]
+        refs = [[['My', 'full', 'pytorch', 'test'], ['Different']]]
+        assert round(metrics.bleu_score(candidate, refs, max_n=2,
+                     weights=[0.5, 0.5]), 4) == 0.5067
+
+        # Multi-sentence corpus
+        candidate = [['My', 'full', 'pytorch', 'test'], ['Another', 'Sentence']]
+        refs = [[['My', 'full', 'pytorch', 'test'], ['Completely', 'Different']],
+                [['No', 'Match']]]
+        assert round(metrics.bleu_score(candidate, refs), 4) == 0.8409

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -1,5 +1,5 @@
 from torchtext.data import metrics
-from .common.torchtext_test_case import TorchtextTestCase
+from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestUtils(TorchtextTestCase):

--- a/torchtext/data/__init__.py
+++ b/torchtext/data/__init__.py
@@ -4,8 +4,9 @@ from .example import Example
 from .field import RawField, Field, ReversibleField, SubwordField, NestedField, LabelField
 from .iterator import (batch, BucketIterator, Iterator, BPTTIterator,
                        pool)
+from .metrics import bleu_score
 from .pipeline import Pipeline
-from .utils import get_tokenizer, interleave_keys
+from .utils import get_tokenizer, interleave_keys, ngrams_iterator
 from .functional import generate_sp_model, \
     load_sp_model, \
     sentencepiece_numericalizer, \
@@ -18,8 +19,9 @@ __all__ = ["Batch",
            "LabelField",
            "batch", "BucketIterator", "Iterator", "BPTTIterator",
            "pool",
+           "bleu_score",
            "Pipeline",
-           "get_tokenizer", "interleave_keys",
+           "get_tokenizer", "interleave_keys", "ngrams_iterator"
            "generate_sp_model", "load_sp_model",
            "sentencepiece_numericalizer", "sentencepiece_tokenizer",
            "custom_replace", "simple_space_split"]

--- a/torchtext/data/__init__.py
+++ b/torchtext/data/__init__.py
@@ -6,7 +6,7 @@ from .iterator import (batch, BucketIterator, Iterator, BPTTIterator,
                        pool)
 from .metrics import bleu_score
 from .pipeline import Pipeline
-from .utils import get_tokenizer, interleave_keys, ngrams_iterator
+from .utils import get_tokenizer, interleave_keys
 from .functional import generate_sp_model, \
     load_sp_model, \
     sentencepiece_numericalizer, \
@@ -21,7 +21,7 @@ __all__ = ["Batch",
            "pool",
            "bleu_score",
            "Pipeline",
-           "get_tokenizer", "interleave_keys", "ngrams_iterator"
+           "get_tokenizer", "interleave_keys",
            "generate_sp_model", "load_sp_model",
            "sentencepiece_numericalizer", "sentencepiece_tokenizer",
            "custom_replace", "simple_space_split"]

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -15,7 +15,7 @@ def _compute_ngram_counter(tokens, max_n):
             associated count
 
     Examples:
-        >>> from torchtext.data.functional import _compute_ngram_counter
+        >>> from torchtext.data.metrics import _compute_ngram_counter
         >>> tokens = ['me', 'me', 'you']
         >>> _compute_ngram_counter(tokens, 2)
             Counter({('me',): 2,
@@ -35,20 +35,21 @@ def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4)
     translation corpus. Based on https://www.aclweb.org/anthology/P02-1040.pdf
 
     Arguments:
-        candidate_corpus: a list of candidate translations. Each translation is a list of
-            tokens
-        references_corpus: a list of lists of reference translations. Each translation
-            is a list of tokens
+        candidate_corpus: an iterable of candidate translations. Each translation is an
+            iterable of tokens
+        references_corpus: an iterable of iterables of reference translations. Each
+            translation is an iterable of tokens
         max_n: the maximum n-gram we want to use. E.g. if max_n=3, we will use unigrams,
             bigrams and trigrams
-        weights: weights used for each n-gram category (uniform by default)
+        weights: a list of weights used for each n-gram category (uniform by default)
 
     Examples:
+        >>> from torchtext.data.metrics import bleu_score
         >>> candidate_corpus = [['I', 'ate', 'the', 'apple'], ['I', 'did']]
         >>> references_corpus = [[['I', 'ate', 'it'], ['I', 'ate', 'apples']],
                 [['I', 'did']]]
         >>> bleu_score(candidate_corpus, references_corpus)
-        >>> 0.7598356856515925
+            0.7598356856515925
     """
 
     assert max_n == len(weights), 'Length of the "weights" list has be equal to max_n'

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -1,0 +1,93 @@
+import math
+import collections
+from utils import ngrams_iterator
+
+
+def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4):
+    """Computes the BLEU score between a candidate translation corpus and a references
+    translation corpus. Based on https://www.aclweb.org/anthology/P02-1040.pdf
+
+    Arguments:
+        candidate_corpus: a list of candidate translations. Each translation is a list of
+            tokens
+        references_corpus: a list of lists of reference translations. Each translation
+            is a list of tokens
+        max_n: the maximum n-gram we want to use. E.g. if max_n=3, we will use unigrams,
+            bigrams and trigrams
+        weights: weights used for each n-gram category (uniform by default)
+
+    Examples:
+        >>> candidate_corpus = [['I', 'ate', 'the', 'apple'], ['I', 'did']]
+        >>> references_corpus = [[['I', 'ate', 'it'], ['I', 'ate', 'apples']],
+                [['I', 'did']]]
+        >>> bleu_score(candidate_corpus, references_corpus)
+        >>> 0.7598356856515925
+    """
+
+    def _compute_ngram_counter(tokens, max_n):
+        """ Create a Counter with a count of unique n-grams in the tokens list
+
+        Arguments:
+            tokens: a list of tokens (typically a string split on whitespaces)
+            max_n: the maximum order of n-gram wanted
+
+        Outputs:
+            output: a collections.Counter object with the unique n-grams and their
+                associated count
+
+        Examples:
+            >>> from torchtext.data.functional import _compute_ngram_counter
+            >>> tokens = ['me', 'me', 'you']
+            >>> _compute_ngram_counter(tokens, 2)
+                Counter({('me',): 2,
+                 ('you',): 1,
+                 ('me', 'me'): 1,
+                 ('me', 'you'): 1,
+                 ('me', 'me', 'you'): 1})
+        """
+        assert max_n > 0
+
+        ngrams = [tuple(x.split(' ')) for x in ngrams_iterator(tokens, max_n)]
+        ngrams_counter = collections.Counter(ngrams)
+
+        return ngrams_counter
+
+    assert max_n == len(weights), 'Length of the "weights" list has be equal to max_n'
+
+    clipped_counts = [0.0] * max_n
+    total_counts = [0.0] * max_n
+
+    candidate_len = 0.0
+    refs_len = 0.0
+
+    for (candidate, refs) in zip(candidate_corpus, references_corpus):
+        candidate_len += len(candidate)
+
+        # Get the length of the reference that's closest in length to the candidate
+        refs_len_list = [float(len(ref)) for ref in refs]
+        refs_len = min(refs_len_list, key=lambda x: abs(len(candidate) - x))
+
+        reference_counters = collections.Counter()
+        for ref in refs:
+            reference_counters = reference_counters | _compute_ngram_counter(ref, max_n)
+
+        candidate_counter = _compute_ngram_counter(candidate, max_n)
+
+        clipped_counter = candidate_counter & reference_counters
+
+        for ngram in clipped_counter:
+            clipped_counts[len(ngram) - 1] += clipped_counter[ngram]
+
+        for ngram in candidate_counter:  # TODO: no need to loop through the whole counter
+            total_counts[len(ngram) - 1] += candidate_counter[ngram]
+
+    if min(clipped_counts) == 0:
+        return 0.0
+    else:
+        pn = [clipped_counts[i] / total_counts[i] for i in range(max_n)]
+        log_pn = [weights[i] * math.log(pn[i]) for i in range(max_n)]
+        score = math.exp(sum(log_pn))
+
+        bp = math.exp(min(1 - refs_len / candidate_len, 0))
+
+        return bp * score

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -25,9 +25,7 @@ def _compute_ngram_counter(tokens, max_n):
              ('me', 'me', 'you'): 1})
     """
     assert max_n > 0
-
-    ngrams = [tuple(x.split(' ')) for x in ngrams_iterator(tokens, max_n)]
-    ngrams_counter = collections.Counter(ngrams)
+    ngrams_counter = collections.Counter(tuple(x.split(' ')) for x in ngrams_iterator(tokens, max_n))
 
     return ngrams_counter
 

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -3,6 +3,35 @@ import collections
 from torchtext.data.utils import ngrams_iterator
 
 
+def _compute_ngram_counter(tokens, max_n):
+    """ Create a Counter with a count of unique n-grams in the tokens list
+
+    Arguments:
+        tokens: a list of tokens (typically a string split on whitespaces)
+        max_n: the maximum order of n-gram wanted
+
+    Outputs:
+        output: a collections.Counter object with the unique n-grams and their
+            associated count
+
+    Examples:
+        >>> from torchtext.data.functional import _compute_ngram_counter
+        >>> tokens = ['me', 'me', 'you']
+        >>> _compute_ngram_counter(tokens, 2)
+            Counter({('me',): 2,
+             ('you',): 1,
+             ('me', 'me'): 1,
+             ('me', 'you'): 1,
+             ('me', 'me', 'you'): 1})
+    """
+    assert max_n > 0
+
+    ngrams = [tuple(x.split(' ')) for x in ngrams_iterator(tokens, max_n)]
+    ngrams_counter = collections.Counter(ngrams)
+
+    return ngrams_counter
+
+
 def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4):
     """Computes the BLEU score between a candidate translation corpus and a references
     translation corpus. Based on https://www.aclweb.org/anthology/P02-1040.pdf
@@ -23,34 +52,6 @@ def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4)
         >>> bleu_score(candidate_corpus, references_corpus)
         >>> 0.7598356856515925
     """
-
-    def _compute_ngram_counter(tokens, max_n):
-        """ Create a Counter with a count of unique n-grams in the tokens list
-
-        Arguments:
-            tokens: a list of tokens (typically a string split on whitespaces)
-            max_n: the maximum order of n-gram wanted
-
-        Outputs:
-            output: a collections.Counter object with the unique n-grams and their
-                associated count
-
-        Examples:
-            >>> from torchtext.data.functional import _compute_ngram_counter
-            >>> tokens = ['me', 'me', 'you']
-            >>> _compute_ngram_counter(tokens, 2)
-                Counter({('me',): 2,
-                 ('you',): 1,
-                 ('me', 'me'): 1,
-                 ('me', 'you'): 1,
-                 ('me', 'me', 'you'): 1})
-        """
-        assert max_n > 0
-
-        ngrams = [tuple(x.split(' ')) for x in ngrams_iterator(tokens, max_n)]
-        ngrams_counter = collections.Counter(ngrams)
-
-        return ngrams_counter
 
     assert max_n == len(weights), 'Length of the "weights" list has be equal to max_n'
 

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -1,6 +1,6 @@
 import math
 import collections
-from utils import ngrams_iterator
+from torchtext.data.utils import ngrams_iterator
 
 
 def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4):

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -65,7 +65,7 @@ def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4)
 
         # Get the length of the reference that's closest in length to the candidate
         refs_len_list = [float(len(ref)) for ref in refs]
-        refs_len = min(refs_len_list, key=lambda x: abs(len(candidate) - x))
+        refs_len += min(refs_len_list, key=lambda x: abs(len(candidate) - x))
 
         reference_counters = collections.Counter()
         for ref in refs:

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -67,8 +67,8 @@ def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4)
         refs_len_list = [float(len(ref)) for ref in refs]
         refs_len += min(refs_len_list, key=lambda x: abs(len(candidate) - x))
 
-        reference_counters = collections.Counter()
-        for ref in refs:
+        reference_counters = _compute_ngram_counter(refs[0], max_n)
+        for ref in refs[1:]:
             reference_counters = reference_counters | _compute_ngram_counter(ref, max_n)
 
         candidate_counter = _compute_ngram_counter(candidate, max_n)

--- a/torchtext/data/metrics.py
+++ b/torchtext/data/metrics.py
@@ -25,7 +25,8 @@ def _compute_ngram_counter(tokens, max_n):
              ('me', 'me', 'you'): 1})
     """
     assert max_n > 0
-    ngrams_counter = collections.Counter(tuple(x.split(' ')) for x in ngrams_iterator(tokens, max_n))
+    ngrams_counter = collections.Counter(tuple(x.split(' '))
+                                         for x in ngrams_iterator(tokens, max_n))
 
     return ngrams_counter
 
@@ -53,6 +54,8 @@ def bleu_score(candidate_corpus, references_corpus, max_n=4, weights=[0.25] * 4)
     """
 
     assert max_n == len(weights), 'Length of the "weights" list has be equal to max_n'
+    assert len(candidate_corpus) == len(references_corpus),\
+        'The length of candidate and reference corpus should be the same'
 
     clipped_counts = [0.0] * max_n
     total_counts = [0.0] * max_n


### PR DESCRIPTION
A quick review of MT quality scores:

**[BLEU]( https://www.aclweb.org/anthology/P02-1040.pdf) (Bilingual Evaluation Understudy)**, also called N-Gram Co-Occurence, was developed by IBM in 2001. It is a measure of similarity between a candidate translation and a set of reference translations, where each reference translation is equally valid. The essence of it is the following: we check how many n-grams the candidate and reference translation have in common (up to 4-grams). The idea is to focus on *precision*: how much of my candidate translation has correct words? However, if we only relied on precision, the machine could only output one word and precision would be super high but the translation (and recall) very bad. That’s why BLEU adds a “brevity penalty” to penalize for too short translations and improve recall.

* Pros: 
    * easy and fast to compute
    * reasonable estimate of Machine Translation (MT) quality, although limited
    * way more scalable than having humans do it
* Cons: 
    * doesn’t take meaning or grammar into account: if the references are not exhaustive (lack of synonyms) then the score is not accurate
    * no focus on sentence structure or order
    * score can be biased at sentence-level - BLEU is only meant to be used at corpus-level

**[NIST](http://www.mt-archive.info/HLT-2002-Doddington.pdf)** is an extension of BLEU, where we weigh the penalties of mis-matched n-grams: if we mis-match “rare” n-grams, the penalty will be higher than mis-matching common n-grams. The idea is to not give weight to usual, “stop word”-type of n-grams.

* Pros: 
    * less weight put on unimportant words compared to BLEU, leading to potentially more accurate scores
* Cons: 
    * still doesn’t take meaning into account, and this is potentially worse than BLEU: if the candidate translation has a valid synonym that’s not in the reference translations, then the penalty will be artificially higher

**[ROUGE](https://www.aclweb.org/anthology/W04-1013.pdf) (Recall-Oriented Understudy for Gisting Evaluation)** has the same idea as BLEU but focuses on recall instead of precision: we look at how many n-grams in the reference translations are in the candidate translation (instead of the reverse with BLEU). There are 5 different ROUGE variants: ROUGE-N, ROUGE-L, ROUGE-W, ROUGE-S, ROUGE-SU.

**[METEOR](https://www.cs.cmu.edu/~alavie/papers/BanerjeeLavie2005-final.pdf)**
Similar to BLEU, but considering synonyms and stemming. This is heavier to compute.
