### PR TITLE
Consider min frequency when create new vocab

### DIFF
--- a/torchtext/datasets/text_classification.py
+++ b/torchtext/datasets/text_classification.py
@@ -113,7 +113,8 @@ class TextClassificationDataset(torch.utils.data.Dataset):
         return self._vocab
 
 
-def _setup_datasets(dataset_name, root='.data', ngrams=1, vocab=None, include_unk=False, min_freq=1):
+def _setup_datasets(dataset_name, root='.data', ngrams=1, vocab=None,
+                    include_unk=False, min_freq=1):
     dataset_tar = download_from_url(URLS[dataset_name], root=root)
     extracted_files = extract_archive(dataset_tar)
 
@@ -125,7 +126,8 @@ def _setup_datasets(dataset_name, root='.data', ngrams=1, vocab=None, include_un
 
     if vocab is None:
         logging.info('Building Vocab based on {}'.format(train_csv_path))
-        vocab = build_vocab_from_iterator(_csv_iterator(train_csv_path, ngrams), min_freq=min_freq)
+        vocab = build_vocab_from_iterator(_csv_iterator(train_csv_path, ngrams),
+                                          min_freq=min_freq)
     else:
         if not isinstance(vocab, Vocab):
             raise TypeError("Passed vocabulary is not of type Vocab")

--- a/torchtext/datasets/text_classification.py
+++ b/torchtext/datasets/text_classification.py
@@ -113,7 +113,7 @@ class TextClassificationDataset(torch.utils.data.Dataset):
         return self._vocab
 
 
-def _setup_datasets(dataset_name, root='.data', ngrams=1, vocab=None, include_unk=False):
+def _setup_datasets(dataset_name, root='.data', ngrams=1, vocab=None, include_unk=False, min_freq=1):
     dataset_tar = download_from_url(URLS[dataset_name], root=root)
     extracted_files = extract_archive(dataset_tar)
 
@@ -125,7 +125,7 @@ def _setup_datasets(dataset_name, root='.data', ngrams=1, vocab=None, include_un
 
     if vocab is None:
         logging.info('Building Vocab based on {}'.format(train_csv_path))
-        vocab = build_vocab_from_iterator(_csv_iterator(train_csv_path, ngrams))
+        vocab = build_vocab_from_iterator(_csv_iterator(train_csv_path, ngrams), min_freq=min_freq)
     else:
         if not isinstance(vocab, Vocab):
             raise TypeError("Passed vocabulary is not of type Vocab")

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -74,7 +74,7 @@ def _get_datafile_path(key, extracted_files):
 
 def _setup_datasets(dataset_name, tokenizer=get_tokenizer("basic_english"),
                     root='.data', vocab=None, removed_tokens=[],
-                    data_select=('train', 'test', 'valid')):
+                    data_select=('train', 'test', 'valid'), min_freq=1):
 
     if isinstance(data_select, str):
         data_select = [data_select]
@@ -100,7 +100,7 @@ def _setup_datasets(dataset_name, tokenizer=get_tokenizer("basic_english"),
         logging.info('Building Vocab based on {}'.format(_path['train']))
         txt_iter = iter(tokenizer(row) for row in io.open(_path['train'],
                                                           encoding="utf8"))
-        vocab = build_vocab_from_iterator(txt_iter)
+        vocab = build_vocab_from_iterator(txt_iter, min_freq=min_freq)
         logging.info('Vocab has {} entries'.format(len(vocab)))
     else:
         if not isinstance(vocab, Vocab):

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -544,7 +544,7 @@ pretrained_aliases = {
 """Mapping from string name to factory function"""
 
 
-def build_vocab_from_iterator(iterator, min_freq):
+def build_vocab_from_iterator(iterator, min_freq=1):
     """
     Build a Vocab from an iterator.
 

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -544,7 +544,7 @@ pretrained_aliases = {
 """Mapping from string name to factory function"""
 
 
-def build_vocab_from_iterator(iterator):
+def build_vocab_from_iterator(iterator, min_freq):
     """
     Build a Vocab from an iterator.
 
@@ -557,5 +557,5 @@ def build_vocab_from_iterator(iterator):
         for tokens in iterator:
             counter.update(tokens)
             t.update(1)
-    word_vocab = Vocab(counter)
+    word_vocab = Vocab(counter, min_freq=min_freq)
     return word_vocab


### PR DESCRIPTION
User can not adjust min frequency to create new vocab when load a data from TextClassificationDataset and LanguageModelingDataset such as DBpedia, YelpReviewPolarity, AmazonReviewFull, WikiText103, PennTreebank, etc. 

I propose add 'min frequency' parameter so that users can adjust min frequency when they calling those datasets.

Thanks.