### PR TITLE
[Bug Fixing][BC Breaking] Unify tar and zip handling with extract_archive

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -30,6 +30,11 @@ class TestUtils(TorchtextTestCase):
         assert files == [os.path.join(root, 'val.de'),
                          os.path.join(root, 'val.en')]
 
+        # extract files with overwrite option True
+        files = utils.extract_archive(archive_path, overwrite=True)
+        assert files == [os.path.join(root, 'val.de'),
+                         os.path.join(root, 'val.en')]
+
         # remove files and archive
         for f in files:
             conditional_remove(f)
@@ -57,6 +62,10 @@ class TestUtils(TorchtextTestCase):
                          'en-ud-v2/README.txt']
         # extract files and ensure they are correct
         files = utils.extract_archive(archive_path)
+        assert files == [os.path.join(root, f) for f in correct_files]
+
+        # extract files with overwrite option True
+        files = utils.extract_archive(archive_path, overwrite=True)
         assert files == [os.path.join(root, f) for f in correct_files]
 
         # remove files and archive
@@ -87,6 +96,11 @@ class TestUtils(TorchtextTestCase):
 
         # extract files and ensure they are in the to_path directory
         files = utils.extract_archive(archive_path, to_path)
+        assert files == [os.path.join(to_path, 'val.de'),
+                         os.path.join(to_path, 'val.en')]
+
+        # extract files with overwrite option True
+        files = utils.extract_archive(archive_path, to_path, overwrite=True)
         assert files == [os.path.join(to_path, 'val.de'),
                          os.path.join(to_path, 'val.en')]
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -50,18 +50,18 @@ class TestUtils(TorchtextTestCase):
         archive_path = utils.download_from_url(url)
         assert target_archive_path == archive_path
 
-        # extract files and ensure they are correct
-        files = utils.extract_archive(archive_path)
-        assert files == ['en-ud-v2/',
-                         'en-ud-v2/en-ud-tag.v2.dev.txt',
+        correct_files = ['en-ud-v2/en-ud-tag.v2.dev.txt',
                          'en-ud-v2/en-ud-tag.v2.test.txt',
                          'en-ud-v2/en-ud-tag.v2.train.txt',
                          'en-ud-v2/LICENSE.txt',
                          'en-ud-v2/README.txt']
+        # extract files and ensure they are correct
+        files = utils.extract_archive(archive_path)
+        assert files == [os.path.join(root, f) for f in correct_files]
 
         # remove files and archive
         for f in files:
-            conditional_remove(os.path.join(root, f))
+            conditional_remove(f)
         os.rmdir(os.path.join(root, 'en-ud-v2'))
         conditional_remove(archive_path)
 

--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -3,7 +3,8 @@ import re
 
 __all__ = [
     "generate_sp_model", "load_sp_model",
-    "sentencepiece_numericalizer", "sentencepiece_tokenizer"
+    "sentencepiece_numericalizer", "sentencepiece_tokenizer",
+    "numericalize_tokens_from_iterator"
 ]
 
 

--- a/torchtext/datasets/unsupervised_learning.py
+++ b/torchtext/datasets/unsupervised_learning.py
@@ -106,7 +106,7 @@ class EnWik9(torch.utils.data.Dataset):
                                             path=os.path.join(root, 'enwik9.zip'),
                                             root=root)
             extracted_file = extract_archive(dataset_zip)
-            raw_file = os.path.join(root, extracted_file[0])
+            raw_file = extracted_file[0]
             preprocess_raw_enwik9(raw_file, processed_file)
 
         # Meta information

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -1,6 +1,5 @@
 import torch
 import logging
-import os
 import io
 from torchtext.utils import download_from_url, extract_archive
 from torchtext.vocab import build_vocab_from_iterator
@@ -88,7 +87,7 @@ def _setup_datasets(dataset_name, tokenizer=get_tokenizer("basic_english"),
                                              root=root) for key in data_select]
     else:
         dataset_tar = download_from_url(URLS[dataset_name], root=root)
-        extracted_files = [os.path.join(root, d) for d in extract_archive(dataset_tar)]
+        extracted_files = extract_archive(dataset_tar)
 
     _path = {}
     for item in data_select:

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -193,23 +193,15 @@ def extract_archive(from_path, to_path=None, overwrite=False):
             files = []
             for file_ in zfile.namelist():
                 file_path = os.path.join(to_path, file_)
+                files.append(file_path)
                 if os.path.exists(file_path):
                     logging.info('{} already extracted.'.format(file_path))
                     if not overwrite:
                         continue
                 zfile.extract(file_, to_path)
-                if os.path.isfile(file_path):
-                    files.append(file_path)
+        files = [f for f in files if os.path.isfile(f)]
         return files
 
     else:
         raise NotImplementedError(
             "We currently only support tar.gz, .tgz and zip achives.")
-
-
-if __name__ == "__main__":
-    import os
-    os.makedirs(".data/")
-    download_from_url("https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip")
-    files = extract_archive(".data/wikitext-2-v1.zip")
-    print(files)

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -190,16 +190,26 @@ def extract_archive(from_path, to_path=None, overwrite=False):
         assert zipfile.is_zipfile(from_path), from_path
         logging.info('Opening zip file {}.'.format(from_path))
         with zipfile.ZipFile(from_path, 'r') as zfile:
-            files = zfile.namelist()
-            for file_ in files:
+            files = []
+            for file_ in zfile.namelist():
                 file_path = os.path.join(to_path, file_)
                 if os.path.exists(file_path):
                     logging.info('{} already extracted.'.format(file_path))
                     if not overwrite:
                         continue
                 zfile.extract(file_, to_path)
+                if os.path.isfile(file_path):
+                    files.append(file_path)
         return files
 
     else:
         raise NotImplementedError(
             "We currently only support tar.gz, .tgz and zip achives.")
+
+
+if __name__ == "__main__":
+    import os
+    os.makedirs(".data/")
+    download_from_url("https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip")
+    files = extract_archive(".data/wikitext-2-v1.zip")
+    print(files)

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -154,7 +154,7 @@ def extract_archive(from_path, to_path=None, overwrite=False):
 
     Arguments:
         from_path: the path of the archive.
-        to_path: the root path of the extraced files (directory of from_path)
+        to_path: the root path of the extracted files (directory of from_path)
         overwrite: overwrite existing files (False)
 
     Returns:
@@ -166,6 +166,7 @@ def extract_archive(from_path, to_path=None, overwrite=False):
         >>> to_path = './'
         >>> torchtext.utils.download_from_url(url, from_path)
         >>> torchtext.utils.extract_archive(from_path, to_path)
+        >>> ['.data/val.de', '.data/val.en']
     """
 
     if to_path is None:


### PR DESCRIPTION
Corrected behavior described in this [PR](https://github.com/pytorch/text/pull/688#issuecomment-582543743) 

Before this PR:
```python
import os
from torchtext.utils import extract_archive, donwload_from_url

os.mkdir('.data')
download_from_url('https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip')
# '.data/wikitext-2-v1.zip'

extract_archive('.data/wikitext-2-v1.zip')
# ['wikitext-2/', 'wikitext-2/wiki.test.tokens', 'wikitext-2/wiki.valid.tokens', 'wikitext-2/wiki.train.tokens']
```

After this PR
```python
import os
from torchtext.utils import extract_archive, donwload_from_url

os.mkdir('.data')

download_from_url('https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip')
# '.data/wikitext-2-v1.zip'

extract_archive('.data/wikitext-2-v1.zip')
# ['.data/wikitext-2/wiki.test.tokens', '.data/wikitext-2/wiki.valid.tokens', '.data/wikitext-2/wiki.train.tokens']
```

**NOTE**: This PR is BC Breaking, if you are using this function to build custom datasets, there is no need to write code to join the root and extracted filenames. The outputted filenames have the root folder prepended to the extracted filenames. 