### PR TITLE
Bugfix: custom UNK token conversion error

### DIFF
--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -81,6 +81,31 @@ class TestVocab(TorchtextTestCase):
         self.assertRaises(KeyError, v_first.stoi.__getitem__, oov_word)
         self.assertRaises(KeyError, v_last.stoi.__getitem__, oov_word)
 
+    def test_vocab_with_unk(self):
+        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
+        oov_word = 'OOVWORD'
+        self.assertNotIn(oov_word, c)
+
+        # check default UNK.
+        v_default = vocab.Vocab(c, min_freq=3, specials=["<unk>", '<pad>'])
+        expected_itos_default = ["<unk>", "<pad>", "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T", "hello", "world"]
+        expected_stoi_default = {x: index for index, x in enumerate(expected_itos_default)}
+        self.assertEqual(v_default.itos, expected_itos_default)
+        self.assertEqual(dict(v_default.stoi), expected_stoi_default)
+        self.assertNotIn(oov_word, v_default.itos)
+        self.assertNotIn(oov_word, v_default.stoi)
+        assert v_default.stoi[oov_word] == 0
+
+        # check custom UNK.
+        v_custom = vocab.Vocab(c, min_freq=3, specials=["<cunk>", '<pad>'], unk_token="<cunk>")
+        expected_itos_custom = ["<cunk>", "<pad>", "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T", "hello", "world"]
+        expected_stoi_custom = {x: index for index, x in enumerate(expected_itos_custom)}
+        self.assertEqual(v_custom.itos, expected_itos_custom)
+        self.assertEqual(dict(v_custom.stoi), expected_stoi_custom)
+        self.assertNotIn(oov_word, v_custom.itos)
+        self.assertNotIn(oov_word, v_custom.stoi)
+        assert v_custom.stoi[oov_word] == 0
+
     def test_vocab_set_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5,
                      'ｔｅｓｔ': 4, 'freq_too_low': 2})

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -89,7 +89,8 @@ class TestVocab(TorchtextTestCase):
         # check default UNK.
         v_default = vocab.Vocab(c, min_freq=3, specials=["<unk>", '<pad>'])
         expected_itos_default = ["<unk>", "<pad>", "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T", "hello", "world"]
-        expected_stoi_default = {x: index for index, x in enumerate(expected_itos_default)}
+        expected_stoi_default = {
+            x: index for index, x in enumerate(expected_itos_default)}
         self.assertEqual(v_default.itos, expected_itos_default)
         self.assertEqual(dict(v_default.stoi), expected_stoi_default)
         self.assertNotIn(oov_word, v_default.itos)
@@ -97,7 +98,8 @@ class TestVocab(TorchtextTestCase):
         assert v_default.stoi[oov_word] == 0
 
         # check custom UNK.
-        v_custom = vocab.Vocab(c, min_freq=3, specials=["<cunk>", '<pad>'], unk_token="<cunk>")
+        v_custom = vocab.Vocab(c, min_freq=3, specials=["<cunk>", '<pad>'],
+                               unk_token="<cunk>")
         expected_itos_custom = ["<cunk>", "<pad>", "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T", "hello", "world"]
         expected_stoi_custom = {x: index for index, x in enumerate(expected_itos_custom)}
         self.assertEqual(v_custom.itos, expected_itos_custom)

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -306,7 +306,7 @@ class Field(RawField):
             tok for tok in [self.unk_token, self.pad_token, self.init_token,
                             self.eos_token] + kwargs.pop('specials', [])
             if tok is not None))
-        self.vocab = self.vocab_cls(counter, specials=specials, **kwargs)
+        self.vocab = self.vocab_cls(counter, specials=specials, unk_token=self.unk_token, **kwargs)
 
     def numericalize(self, arr, device=None):
         """Turn a batch of examples that use this field into a Variable.

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -306,7 +306,8 @@ class Field(RawField):
             tok for tok in [self.unk_token, self.pad_token, self.init_token,
                             self.eos_token] + kwargs.pop('specials', [])
             if tok is not None))
-        self.vocab = self.vocab_cls(counter, specials=specials, unk_token=self.unk_token, **kwargs)
+        self.vocab = self.vocab_cls(counter, specials=specials,
+                                    unk_token=self.unk_token, **kwargs)
 
     def numericalize(self, arr, device=None):
         """Turn a batch of examples that use this field into a Variable.


### PR DESCRIPTION
Bugfix: https://github.com/pytorch/text/issues/618

Newly, this changes adds `unk_token` argument to build_vocab method for set by Field.
Also, for backward compatibility, this PR leaves `Vocab.UNK` as  default token.