### PR TITLE
Allow longer line in flake8 for torchtext

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = E402,E722,W503,W504
-max-line-length = 90
+max-line-length = 120
 exclude = docs/source


### PR DESCRIPTION
Extend the allowable line length in flake8. Consistent with pytorch core library.