### PR TITLE
conda build with sentencepiece from powerai channel

### DIFF
--- a/build_tools/conda/torchtext/meta.yaml
+++ b/build_tools/conda/torchtext/meta.yaml
@@ -1,14 +1,15 @@
 package:
   name: torchtext
-  version: 0.4.0
+  version: 0.6.0
 
 source:
-   url: https://github.com/pytorch/text/archive/0.4.0.zip
+   url: https://github.com/pytorch/text/archive/0.6.0.zip
 
 requirements:
   build:
     - python
     - setuptools
+    - powerai::sentencepiece
 
   run:
     - python

--- a/build_tools/conda/torchtext/meta.yaml
+++ b/build_tools/conda/torchtext/meta.yaml
@@ -9,7 +9,6 @@ requirements:
   build:
     - python
     - setuptools
-    - powerai::sentencepiece
 
   run:
     - python
@@ -18,6 +17,7 @@ requirements:
     - pytorch >=1.2
     - requests
     - six
+    - sentencepiece
 
 build:
   number: 1


### PR DESCRIPTION
Build the conda torchtext package with sentencepiece from channel powerai. This is a walkaround  since sentencepiece is not released through the main channel

Able to build the conda package from powerai channel for sentencepiece
```
conda build . -c powerai
```

Then, as a temporary fix, users should install sentencepiece library from the same channel
```
conda install -c powerai sentencepiece
```