### PR TITLE
update README file for conda installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,10 @@ Make sure you have Python 2.7 or 3.5+ and PyTorch 0.4.0 or newer. You can then i
     
 For PyTorch versions before 0.4.0, please use `pip install torchtext==0.2.3`.
 
+Or you can install torchtext using conda::
+    conda install -c pytorch torchtext
+    conda install -c powerai sentencepiece
+
 Optional requirements
 ---------------------
 

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,7 @@ Make sure you have Python 2.7 or 3.5+ and PyTorch 0.4.0 or newer. You can then i
 For PyTorch versions before 0.4.0, please use `pip install torchtext==0.2.3`.
 
 Or you can install torchtext using conda::
-    conda install -c pytorch torchtext
-    conda install -c powerai sentencepiece
+    conda install -c pytorch -c powerai torchtext sentencepiece
 
 Optional requirements
 ---------------------


### PR DESCRIPTION
Since one of the dependency libraries `sentencepiece` is not distributed via conda, we advice users to install `sentencepiece` from `powerai` channel. Fix https://github.com/pytorch/text/pull/726
