### PR TITLE
use 'cpu' instead of None for Iterator

### DIFF
--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -3,6 +3,7 @@ import random
 
 import logging
 
+import torch
 from .utils import RandomShuffler
 from .batch import Batch
 from .dataset import Dataset

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -69,6 +69,8 @@ class Iterator(object):
 
         if device is None:
             device = torch.device('cpu')
+        elif isinstance(device, str):
+            device = torch.device(device)
 
         self.device = device
         self.random_shuffler = RandomShuffler()

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -3,6 +3,7 @@ import random
 
 import logging
 
+import torch
 from .utils import RandomShuffler
 from .batch import Batch
 from .dataset import Dataset
@@ -64,7 +65,7 @@ class Iterator(object):
             logger.warning("The `device` argument should be set by using `torch.device`"
                            + " or passing a string as an argument. This behavior will be"
                            + " deprecated soon and currently defaults to cpu.")
-            device = None
+            device = torch.device('cpu')
         self.device = device
         self.random_shuffler = RandomShuffler()
 

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -67,7 +67,7 @@ class Iterator(object):
                            + " deprecated soon and currently defaults to cpu.")
             device = None
 
-        if(device is None):
+        if device is None:
             device = torch.device('cpu')
 
         self.device = device

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -3,7 +3,6 @@ import random
 
 import logging
 
-import torch
 from .utils import RandomShuffler
 from .batch import Batch
 from .dataset import Dataset
@@ -65,8 +64,11 @@ class Iterator(object):
             logger.warning("The `device` argument should be set by using `torch.device`"
                            + " or passing a string as an argument. This behavior will be"
                            + " deprecated soon and currently defaults to cpu.")
-            if device is None:
-            	device = torch.device('cpu')
+            device = None
+
+        if(device is None):
+        	device = torch.device('cpu')
+
         self.device = device
         self.random_shuffler = RandomShuffler()
 

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -65,7 +65,8 @@ class Iterator(object):
             logger.warning("The `device` argument should be set by using `torch.device`"
                            + " or passing a string as an argument. This behavior will be"
                            + " deprecated soon and currently defaults to cpu.")
-            device = torch.device('cpu')
+            if device is None:
+            	device = torch.device('cpu')
         self.device = device
         self.random_shuffler = RandomShuffler()
 

--- a/torchtext/data/iterator.py
+++ b/torchtext/data/iterator.py
@@ -67,7 +67,7 @@ class Iterator(object):
             device = None
 
         if(device is None):
-        	device = torch.device('cpu')
+            device = torch.device('cpu')
 
         self.device = device
         self.random_shuffler = RandomShuffler()


### PR DESCRIPTION
Fixes #376 
Points default device to torch cpu instead of None if no device is specified to be compatible with torch device types 