### PR TITLE
Add CCI cache for test data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
       - checkout
       - run:
           name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should refresh the cache.
+          # This will refresh cache on Sundays, nightly build should generate new cache.
           command: echo "$(date +"%Y-%U")" > .circleci-weekly
       - restore_cache:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
 
-            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,17 +240,21 @@ jobs:
     resource_class: 2xlarge+
     steps:
       - checkout
+      - run:
+          name: Generate cache key
+          # This will refresh cache on Sundays, nightly build should refresh the cache.
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly
       - restore_cache:
 
           keys:
-            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
 
       - run:
           name: Setup
           command: .circleci/unittest/scripts/setup_env.sh
       - save_cache:
 
-          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
 
           paths:
             - conda
@@ -258,28 +262,21 @@ jobs:
       - run:
           name: Install torchtext
           command: .circleci/unittest/scripts/install.sh
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build would refresh the cache.
-          command: echo "$(date +"%Y-%U")" > .circle-week
       - restore_cache:
           keys:
           # NOTE: remove .Branch once it's ready
 
-            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
 
       - run:
           name: Run tests
           # Downloading embedding vector takes long time.
           no_output_timeout: 30m
-          command: |
-              rm -rf .data
-              ls -alh .
-              .circleci/unittest/scripts/run_test.sh
+          command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
           # NOTE: remove .Branch once it's ready
 
-          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
+          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
 
           paths:
             - .vector_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,7 @@ jobs:
 
       - run:
           name: Run tests
+          # Downloading embedding vector takes long time.
           no_output_timeout: 30m
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,9 +264,8 @@ jobs:
           command: .circleci/unittest/scripts/install.sh
       - restore_cache:
           keys:
-          # NOTE: remove .Branch once it's ready
 
-            - data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+            - data-v1-{{ checksum ".circleci-weekly" }}
 
       - run:
           name: Run tests
@@ -274,9 +273,8 @@ jobs:
           no_output_timeout: 30m
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
-          # NOTE: remove .Branch once it's ready
 
-          key: data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+          key: data-v1-{{ checksum ".circleci-weekly" }}
 
           paths:
             - .vector_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,7 @@ jobs:
 
       - run:
           name: Run tests
+          no_output_timeout: 30m
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
           # NOTE: remove .Branch once it's ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
 
-            - vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
 
       - run:
           name: Run tests
@@ -274,7 +274,7 @@ jobs:
       - save_cache:
           # NOTE: remove .Branch once it's ready
 
-          key: vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+          key: vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
 
           paths:
             - .vector_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,9 +258,16 @@ jobs:
       - run:
           name: Install torchtext
           command: .circleci/unittest/scripts/install.sh
+      - restore_cache:
+          keys:
+            - vector-cache-v1
       - run:
           name: Run tests
           command: .circleci/unittest/scripts/run_test.sh
+      - save_cache:
+          key: vector-cache-v1
+          paths:
+            - .vector_cache
       - run:
           name: Post process
           command: .circleci/unittest/scripts/post_process.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,13 +266,16 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
 
-            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
 
       - run:
           name: Run tests
           # Downloading embedding vector takes long time.
           no_output_timeout: 30m
-          command: .circleci/unittest/scripts/run_test.sh
+          command: |
+              rm -rf .data
+              ls -alh .
+              .circleci/unittest/scripts/run_test.sh
       - save_cache:
           # NOTE: remove .Branch once it's ready
 
@@ -280,6 +283,7 @@ jobs:
 
           paths:
             - .vector_cache
+            - .data
       - run:
           name: Post process
           command: .circleci/unittest/scripts/post_process.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
 
-            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
 
       - run:
           name: Run tests
@@ -276,7 +276,7 @@ jobs:
       - save_cache:
           # NOTE: remove .Branch once it's ready
 
-          key: vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
+          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
 
           paths:
             - .vector_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,14 +258,24 @@ jobs:
       - run:
           name: Install torchtext
           command: .circleci/unittest/scripts/install.sh
+      - run:
+          name: Generate cache key
+          # This will refresh cache on Sundays, nightly build would refresh the cache.
+          command: echo "$(date +"%Y-%U")" > .circle-week
       - restore_cache:
           keys:
-            - vector-cache-v1
+          # NOTE: remove .Branch once it's ready
+
+            - vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+
       - run:
           name: Run tests
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
-          key: vector-cache-v1
+          # NOTE: remove .Branch once it's ready
+
+          key: vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+
           paths:
             - .vector_cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
 
-            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+            - data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
 
       - run:
           name: Run tests
@@ -276,7 +276,7 @@ jobs:
       - save_cache:
           # NOTE: remove .Branch once it's ready
 
-          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+          key: data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
 
           paths:
             - .vector_cache

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -240,17 +240,21 @@ jobs:
     resource_class: 2xlarge+
     steps:
       - checkout
+      - run:
+          name: Generate cache key
+          # This will refresh cache on Sundays, nightly build should refresh the cache.
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly
       - restore_cache:
           {% raw %}
           keys:
-            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
           {% endraw %}
       - run:
           name: Setup
           command: .circleci/unittest/scripts/setup_env.sh
       - save_cache:
           {% raw %}
-          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
           {% endraw %}
           paths:
             - conda
@@ -258,28 +262,21 @@ jobs:
       - run:
           name: Install torchtext
           command: .circleci/unittest/scripts/install.sh
-      - run:
-          name: Generate cache key
-          # This will refresh cache on Sundays, nightly build would refresh the cache.
-          command: echo "$(date +"%Y-%U")" > .circle-week
       - restore_cache:
           keys:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
           {% endraw %}
       - run:
           name: Run tests
           # Downloading embedding vector takes long time.
           no_output_timeout: 30m
-          command: |
-              rm -rf .data
-              ls -alh .
-              .circleci/unittest/scripts/run_test.sh
+          command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
+          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
           {% endraw %}
           paths:
             - .vector_cache

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -266,13 +266,16 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
           {% endraw %}
       - run:
           name: Run tests
           # Downloading embedding vector takes long time.
           no_output_timeout: 30m
-          command: .circleci/unittest/scripts/run_test.sh
+          command: |
+              rm -rf .data
+              ls -alh .
+              .circleci/unittest/scripts/run_test.sh
       - save_cache:
           # NOTE: remove .Branch once it's ready
           {% raw %}

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -264,9 +264,8 @@ jobs:
           command: .circleci/unittest/scripts/install.sh
       - restore_cache:
           keys:
-          # NOTE: remove .Branch once it's ready
           {% raw %}
-            - data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+            - data-v1-{{ checksum ".circleci-weekly" }}
           {% endraw %}
       - run:
           name: Run tests
@@ -274,9 +273,8 @@ jobs:
           no_output_timeout: 30m
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
-          # NOTE: remove .Branch once it's ready
           {% raw %}
-          key: data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+          key: data-v1-{{ checksum ".circleci-weekly" }}
           {% endraw %}
           paths:
             - .vector_cache

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
           {% endraw %}
       - run:
           name: Run tests

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -242,7 +242,7 @@ jobs:
       - checkout
       - run:
           name: Generate cache key
-          # This will refresh cache on Sundays, nightly build should refresh the cache.
+          # This will refresh cache on Sundays, nightly build should generate new cache.
           command: echo "$(date +"%Y-%U")" > .circleci-weekly
       - restore_cache:
           {% raw %}

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -280,6 +280,7 @@ jobs:
           {% endraw %}
           paths:
             - .vector_cache
+            - .data
       - run:
           name: Post process
           command: .circleci/unittest/scripts/post_process.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-            - vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
           {% endraw %}
       - run:
           name: Run tests
@@ -274,7 +274,7 @@ jobs:
       - save_cache:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-          key: vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+          key: vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
           {% endraw %}
           paths:
             - .vector_cache

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-            - vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
+            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
           {% endraw %}
       - run:
           name: Run tests
@@ -276,7 +276,7 @@ jobs:
       - save_cache:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-          key: vector-cache-v2-{{ .Branch }}-{{ checksum ".circle-week" }}
+          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circle-week" }}
           {% endraw %}
           paths:
             - .vector_cache

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -258,9 +258,16 @@ jobs:
       - run:
           name: Install torchtext
           command: .circleci/unittest/scripts/install.sh
+      - restore_cache:
+          keys:
+            - vector-cache-v1
       - run:
           name: Run tests
           command: .circleci/unittest/scripts/run_test.sh
+      - save_cache:
+          key: vector-cache-v1
+          paths:
+            - .vector_cache
       - run:
           name: Post process
           command: .circleci/unittest/scripts/post_process.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -258,14 +258,24 @@ jobs:
       - run:
           name: Install torchtext
           command: .circleci/unittest/scripts/install.sh
+      - run:
+          name: Generate cache key
+          # This will refresh cache on Sundays, nightly build would refresh the cache.
+          command: echo "$(date +"%Y-%U")" > .circle-week
       - restore_cache:
           keys:
-            - vector-cache-v1
+          # NOTE: remove .Branch once it's ready
+          {% raw %}
+            - vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+          {% endraw %}
       - run:
           name: Run tests
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
-          key: vector-cache-v1
+          # NOTE: remove .Branch once it's ready
+          {% raw %}
+          key: vector-cache-v1-{{ .Branch }}-{{ checksum ".circle-week" }}
+          {% endraw %}
           paths:
             - .vector_cache
       - run:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -266,7 +266,7 @@ jobs:
           keys:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-            - vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+            - data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
           {% endraw %}
       - run:
           name: Run tests
@@ -276,7 +276,7 @@ jobs:
       - save_cache:
           # NOTE: remove .Branch once it's ready
           {% raw %}
-          key: vector-cache-v3-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
+          key: data-v1-{{ .Branch }}-{{ checksum ".circleci-weekly" }}
           {% endraw %}
           paths:
             - .vector_cache

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -270,6 +270,7 @@ jobs:
           {% endraw %}
       - run:
           name: Run tests
+          no_output_timeout: 30m
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:
           # NOTE: remove .Branch once it's ready

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -270,6 +270,7 @@ jobs:
           {% endraw %}
       - run:
           name: Run tests
+          # Downloading embedding vector takes long time.
           no_output_timeout: 30m
           command: .circleci/unittest/scripts/run_test.sh
       - save_cache:

--- a/.circleci/unittest/scripts/run_test.sh
+++ b/.circleci/unittest/scripts/run_test.sh
@@ -6,5 +6,5 @@ eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
 python -m torch.utils.collect_env
-pytest --cov=torchtext --junitxml=test-results/junit.xml -v test
+pytest --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 test
 flake8 torchtext test

--- a/test/common/test_markers.py
+++ b/test/common/test_markers.py
@@ -1,7 +1,0 @@
-import pytest
-import os
-
-slow = pytest.mark.skipif(
-    os.getenv('RUN_SLOW', 'False') == 'False',
-    reason="This test is slow."
-)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,0 @@
-def pytest_addoption(parser):
-    parser.addoption("--runslow", action="store_true",
-                     help="Run slow tests")

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -19,8 +19,9 @@ class TestDataset(TorchtextTestCase):
         from torchtext.datasets import WikiText2
         # smoke test to ensure wikitext2 works properly
 
-        # NOTE test_wikitext2 and test_wikitext2_legacy have some cache incompatibility,
-        # and keeping one's data make the other fail. So we need to clean up the cache dir
+        # NOTE
+        # test_wikitext2 and test_wikitext2_legacy have some cache incompatibility.
+        # Keeping one's cache make the other fail. So we need to clean up the cache dir
         cachedir = os.path.join(self.project_root, ".data", "wikitext-2")
         conditional_remove(cachedir)
 
@@ -40,8 +41,9 @@ class TestDataset(TorchtextTestCase):
         from torchtext.experimental.datasets import WikiText2
         # smoke test to ensure wikitext2 works properly
 
-        # NOTE test_wikitext2 and test_wikitext2_legacy have some cache incompatibility,
-        # and keeping one's data make the other fail. So we need to clean up the cache dir
+        # NOTE
+        # test_wikitext2 and test_wikitext2_legacy have some cache incompatibility.
+        # Keeping one's cache make the other fail. So we need to clean up the cache dir
         cachedir = os.path.join(self.project_root, ".data", "wikitext-2")
         conditional_remove(cachedir)
         cachefile = os.path.join(self.project_root, ".data", "wikitext-2-v1.zip")
@@ -72,11 +74,6 @@ class TestDataset(TorchtextTestCase):
         train_iter, valid_iter, test_iter = ds.iters(batch_size=4,
                                                      bptt_len=30)
 
-        if os.environ.get("TRAVIS") == "true":
-            # Delete the dataset after we're done to save disk space on CI
-            datafile = os.path.join(self.project_root, ".data", "penn-treebank")
-            conditional_remove(datafile)
-
     def test_penntreebank(self):
         from torchtext.experimental.datasets import PennTreebank
         # smoke test to ensure wikitext2 works properly
@@ -88,15 +85,6 @@ class TestDataset(TorchtextTestCase):
         vocab = train_dataset.get_vocab()
         tokens_ids = [vocab[token] for token in 'the player characters rest'.split()]
         self.assertEqual(tokens_ids, [2, 2550, 3344, 1125])
-
-        if os.environ.get("TRAVIS") == "true":
-            # Delete the dataset after we're done to save disk space on CI
-            datafile = os.path.join(self.project_root, ".data", 'ptb.train.txt')
-            conditional_remove(datafile)
-            datafile = os.path.join(self.project_root, ".data", 'ptb.test.txt')
-            conditional_remove(datafile)
-            datafile = os.path.join(self.project_root, ".data", 'ptb.valid.txt')
-            conditional_remove(datafile)
 
     def test_text_classification(self):
         # smoke test to ensure ag_news dataset works properly
@@ -111,13 +99,6 @@ class TestDataset(TorchtextTestCase):
                         torch.tensor([3525, 319, 4053, 34, 5407, 3607, 70, 6798, 10599, 4053]).long())
         assert_allclose(ag_news_test[-1][1][:10],
                         torch.tensor([2351, 758, 96, 38581, 2351, 220, 5, 396, 3, 14786]).long())
-
-        if os.environ.get("TRAVIS") == "true":
-            # Delete the dataset after we're done to save disk space on CI
-            datafile = os.path.join(self.project_root, ".data", "ag_news_csv")
-            conditional_remove(datafile)
-            datafile = os.path.join(self.project_root, ".data", "ag_news_csv.tar.gz")
-            conditional_remove(datafile)
 
     def test_imdb(self):
         from torchtext.experimental.datasets import IMDB
@@ -139,12 +120,3 @@ class TestDataset(TorchtextTestCase):
         old_vocab = train_dataset.get_vocab()
         new_vocab = Vocab(counter=old_vocab.freqs, max_size=2500)
         new_train_data, new_test_data = IMDB(vocab=new_vocab)
-
-        if os.environ.get("TRAVIS") == "true":
-            # Delete the dataset after we're done to save disk space on CI
-            datafile = os.path.join(self.project_root, ".data", "imdb")
-            conditional_remove(datafile)
-            datafile = os.path.join(self.project_root, ".data", "aclImdb")
-            conditional_remove(datafile)
-            datafile = os.path.join(self.project_root, ".data", "aclImdb_v1.tar.gz")
-            conditional_remove(datafile)

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -9,14 +9,14 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 def conditional_remove(f):
-    if os.path.isfile(f):
-        os.remove(f)
-    elif os.path.isdir(f):
-        shutil.rmtree(f)
+    if os.environ.get("TRAVIS") == "true":
+        if os.path.isfile(f):
+            os.remove(f)
+        elif os.path.isdir(f):
+            shutil.rmtree(f)
 
 
 class TestDataset(TorchtextTestCase):
-    @slow
     def test_wikitext2_legacy(self):
         from torchtext.datasets import WikiText2
         # smoke test to ensure wikitext2 works properly
@@ -52,7 +52,6 @@ class TestDataset(TorchtextTestCase):
         datafile = os.path.join(self.project_root, ".data", "wikitext-2-v1.zip")
         conditional_remove(datafile)
 
-    @slow
     def test_penntreebank_legacy(self):
         from torchtext.datasets import PennTreebank
         # smoke test to ensure penn treebank works properly
@@ -110,7 +109,6 @@ class TestDataset(TorchtextTestCase):
         datafile = os.path.join(self.project_root, ".data", "ag_news_csv.tar.gz")
         conditional_remove(datafile)
 
-    @slow
     def test_imdb(self):
         from torchtext.experimental.datasets import IMDB
         from torchtext.vocab import Vocab

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -4,7 +4,6 @@ import torchtext.data as data
 from torchtext.datasets import AG_NEWS
 import torch
 from torch.testing import assert_allclose
-from ..common.test_markers import slow
 from ..common.torchtext_test_case import TorchtextTestCase
 
 

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -9,7 +9,6 @@ import pytest
 from torch.nn import init
 
 from ..common.torchtext_test_case import TorchtextTestCase, verify_numericalized_example
-from ..common.test_markers import slow
 
 
 class TestField(TorchtextTestCase):

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -866,7 +866,6 @@ class TestNestedField(TorchtextTestCase):
 
         assert torch.all(torch.eq(original_numericalization, pickled_numericalization))
 
-    @slow
     def test_build_vocab(self):
         nesting_field = data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
 

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -10,7 +10,6 @@ import torch
 from torchtext import vocab
 from torchtext.vocab import Vectors, FastText, GloVe, CharNGram
 
-from .common.test_markers import slow
 from .common.torchtext_test_case import TorchtextTestCase
 
 
@@ -93,7 +92,6 @@ class TestVocab(TorchtextTestCase):
                                      [0.3, 0.4]])
         assert_allclose(v.vectors.numpy(), expected_vectors)
 
-    @slow
     def test_vocab_download_fasttext_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching, then once more
@@ -131,7 +129,6 @@ class TestVocab(TorchtextTestCase):
             vec_file = os.path.join(self.project_root, ".vector_cache", "wiki.simple.vec")
             conditional_remove(vec_file)
 
-    @slow
     def test_vocab_extend(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching.
@@ -163,7 +160,6 @@ class TestVocab(TorchtextTestCase):
             vec_file = os.path.join(self.project_root, ".vector_cache", "wiki.simple.vec")
             conditional_remove(vec_file)
 
-    @slow
     def test_vocab_download_custom_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching.
@@ -192,7 +188,6 @@ class TestVocab(TorchtextTestCase):
             vec_file = os.path.join(self.project_root, ".vector_cache", "wiki.simple.vec")
             conditional_remove(vec_file)
 
-    @slow
     def test_vocab_vectors_custom_cache(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         vector_cache = os.path.join('/tmp', 'vector_cache')
@@ -225,7 +220,6 @@ class TestVocab(TorchtextTestCase):
             vec_file = os.path.join(vector_cache, "wiki.simple.vec")
             conditional_remove(vec_file)
 
-    @slow
     def test_vocab_download_glove_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
 
@@ -268,7 +262,6 @@ class TestVocab(TorchtextTestCase):
                 conditional_remove(os.path.join(self.project_root, ".vector_cache",
                                                 "glove.twitter.27B.{}d.txt".format(dim)))
 
-    @slow
     def test_vocab_download_charngram_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching, then once more
@@ -343,7 +336,6 @@ class TestVocab(TorchtextTestCase):
         v_loaded = pickle.load(open(pickle_path, "rb"))
         assert v == v_loaded
 
-    @slow
     def test_vectors_get_vecs(self):
         vec = GloVe(name='twitter.27B', dim='25')
         self.assertEqual(vec.vectors.shape[0], len(vec))


### PR DESCRIPTION
This PR adds caching mechanism for Circle CI unit tests.
 - `.vector_caches` and `.data` directories are cached.
 - `@slow` decorators (implementation and usage) are removed.
 - CI job 45 mins without cache -> 7 mins with cache, which I believe is reasonable.
 - Caches expire weekly. When we setup nightly job, new cache will be created on Sunday.
   - Note: Circle CI does not provide mechanism to bust cache.
      If one needs to refresh cache manually, update version string in cache key. 
      such as `data-v1-{{ checksum ".circleci-weekly" }}` -> `data-v2-...`
   - I also applied the same rule to `conda` environment cache.
 - The resulting cache will be used by all the CI jobs, regardless of Python version, branch etc...