### PR TITLE
Add methods defined on SentencePieceProcessor

### DIFF
--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -257,7 +257,7 @@ class TestScriptableSP(unittest.TestCase):
             '▁to', 'ken', 'izer', '▁and',
             '▁de', 'to', 'ken', 'izer',
         ]
-        output = self.model.encode(input)
+        output = self.model.encode(self.raw_text)
         self.assertEqual(expected, output)
 
     def test_encode_as_ids(self):
@@ -269,48 +269,19 @@ class TestScriptableSP(unittest.TestCase):
         self.assertEqual(self.pieces, output)
 
     def test_piece_to_id(self):
-        inputs = [
-            '\u2581Sent', 'ence', 'P', 'ie', 'ce', '\u2581is',
-            '\u2581an', '\u2581un', 'super', 'vis', 'ed', '\u2581text',
-            '\u2581to', 'ken', 'izer', '\u2581and',
-            '\u2581de', 'to', 'ken', 'izer',
-        ]
-        expecteds = [
-            15340, 4286, 981, 1207, 1681, 17, 84, 684, 8896, 5366,
-            144, 3689, 9, 5602, 12114, 6, 560, 649, 5602, 12114]
-        for input, expected in zip(inputs, expecteds):
-            output = self.model.piece_to_id(input)
+        for piece, expected in zip(self.pieces, self.ids):
+            output = self.model.piece_to_id(piece)
             self.assertEqual(expected, output)
 
     def test_id_to_piece(self):
-        inputs = [
-            15340, 4286, 981, 1207, 1681, 17, 84, 684, 8896, 5366,
-            144, 3689, 9, 5602, 12114, 6, 560, 649, 5602, 12114]
-        expecteds = [
-            '\u2581Sent', 'ence', 'P', 'ie', 'ce', '\u2581is',
-            '\u2581an', '\u2581un', 'super', 'vis', 'ed', '\u2581text',
-            '\u2581to', 'ken', 'izer', '\u2581and',
-            '\u2581de', 'to', 'ken', 'izer',
-        ]
-        for input, expected in zip(inputs, expecteds):
-            output = self.model.id_to_piece(input)
+        for id_, expected in zip(self.ids, self.pieces):
+            output = self.model.id_to_piece(id_)
             self.assertEqual(expected, output)
 
     def test_decode_pieces(self):
-        input = [
-            '\u2581Sent', 'ence', 'P', 'ie', 'ce', '\u2581is',
-            '\u2581an', '\u2581un', 'super', 'vis', 'ed', '\u2581text',
-            '\u2581to', 'ken', 'izer', '\u2581and',
-            '\u2581de', 'to', 'ken', 'izer',
-        ]
-        expected = 'SentencePiece is an unsupervised text tokenizer and detokenizer'
-        output = self.model.decode_pieces(input)
-        self.assertEqual(expected, output)
+        output = self.model.decode_pieces(self.pieces)
+        self.assertEqual(self.raw_text, output)
 
     def test_decode_ids(self):
-        input = [
-            15340, 4286, 981, 1207, 1681, 17, 84, 684, 8896, 5366,
-            144, 3689, 9, 5602, 12114, 6, 560, 649, 5602, 12114]
-        expected = 'SentencePiece is an unsupervised text tokenizer and detokenizer'
-        output = self.model.decode_ids(input)
-        self.assertEqual(expected, output)
+        output = self.model.decode_ids(self.ids)
+        self.assertEqual(self.raw_text, output)

--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -55,7 +55,7 @@ class TestFunctional(TorchtextTestCase):
         test_sample = 'SentencePiece is an unsupervised text tokenizer and detokenizer'
         model_path = get_asset_path('spm_example.model')
         sp_model = load_sp_model(model_path)
-        self.assertEqual(sp_model.GetPieceSize(), 20000)
+        self.assertEqual(len(sp_model), 20000)
         spm_generator = sentencepiece_numericalizer(sp_model)
 
         ref_results = [15340, 4286, 981, 1207, 1681, 17, 84, 684, 8896, 5366,
@@ -68,7 +68,7 @@ class TestFunctional(TorchtextTestCase):
         test_sample = 'SentencePiece is an unsupervised text tokenizer and detokenizer'
         model_path = get_asset_path('spm_example.model')
         sp_model = load_sp_model(model_path)
-        self.assertEqual(sp_model.GetPieceSize(), 20000)
+        self.assertEqual(len(sp_model), 20000)
         spm_generator = sentencepiece_tokenizer(sp_model)
 
         ref_results = ['\u2581Sent', 'ence', 'P', 'ie', 'ce', '\u2581is',

--- a/torchtext/csrc/sentencepiece.cpp
+++ b/torchtext/csrc/sentencepiece.cpp
@@ -49,7 +49,107 @@ public:
     return processor_.EncodeAsPieces(input);
   }
 
+  std::vector<std::vector<std::string>>
+  NBestEncodeAsPieces(const std::string &input,
+                      const int64_t nbest_size) const {
+    return processor_.NBestEncodeAsPieces(input, nbest_size);
+  }
+
+  std::vector<std::vector<int64_t>>
+  NBestEncodeAsIds(const std::string &input, const int64_t nbest_size) const {
+    const auto vals = processor_.NBestEncodeAsIds(input, nbest_size);
+    std::vector<std::vector<std::int64_t>> ret;
+    for (const auto &vec : vals) {
+      ret.emplace_back(std::vector<std::int64_t>(vec.begin(), vec.end()));
+    }
+    return ret;
+  }
+
+  std::vector<std::string> SampleEncodeAsPieces(const std::string &input,
+                                                const int64_t nbest_size,
+                                                const double alpha) const {
+    return processor_.SampleEncodeAsPieces(input, nbest_size, alpha);
+  }
+
+  std::vector<int64_t> SampleEncodeAsIds(const std::string &input,
+                                         const int64_t nbest_size,
+                                         const double alpha) const {
+    const auto val = processor_.SampleEncodeAsIds(input, nbest_size, alpha);
+    return std::vector<int64_t>(val.begin(), val.end());
+  }
+
+  std::string DecodePieces(const std::vector<std::string> &input) const {
+    return processor_.DecodePieces(input);
+  }
+
+  std::string DecodeIds(const std::vector<int64_t> &input) const {
+    const std::vector<int> val(input.begin(), input.end());
+    return processor_.DecodeIds(val);
+  }
+
   int64_t GetPieceSize() const { return processor_.GetPieceSize(); }
+
+  int64_t PieceToId(const std::string &piece) const {
+    return processor_.PieceToId(piece);
+  }
+
+  std::string IdToPiece(const int64_t id) const {
+    return processor_.IdToPiece(id);
+  }
+
+  double GetScore(const int64_t id) const { return processor_.GetScore(id); }
+
+  bool IsUnknown(const int64_t id) const { return processor_.IsUnknown(id); }
+
+  bool IsUnused(const int64_t id) const { return processor_.IsUnused(id); }
+
+  int64_t unk_id() const { return processor_.unk_id(); }
+
+  int64_t bos_id() const { return processor_.bos_id(); }
+
+  int64_t eos_id() const { return processor_.eos_id(); }
+
+  int64_t pad_id() const { return processor_.pad_id(); }
+
+  void SetEncodeExtraOptions(const std::string &extra_option) {
+    const auto status = processor_.SetEncodeExtraOptions(extra_option);
+    if (!status.ok()) {
+      throw std::runtime_error("Failed to set encode extra options. Error: " +
+                               status.ToString());
+    }
+  }
+
+  void SetDecodeExtraOptions(const std::string &extra_option) {
+    const auto status = processor_.SetDecodeExtraOptions(extra_option);
+    if (!status.ok()) {
+      throw std::runtime_error("Failed to set decode extra options. Error: " +
+                               status.ToString());
+    }
+  }
+
+  void SetVocabulary(const std::vector<std::string> &valid_vocab) {
+    const auto status = processor_.SetVocabulary(valid_vocab);
+    if (!status.ok()) {
+      throw std::runtime_error("Failed to set vocabulary. Error: " +
+                               status.ToString());
+    }
+  }
+
+  void ResetVocabulary() {
+    const auto status = processor_.ResetVocabulary();
+    if (!status.ok()) {
+      throw std::runtime_error("Failed to reset vocabulary. Error: " +
+                               status.ToString());
+    }
+  }
+
+  void LoadVocabulary(const std::string &filename, int64_t threshold) {
+    const auto status = processor_.LoadVocabulary(filename, threshold);
+    if (!status.ok()) {
+      throw std::runtime_error("Failed to load vocabulary. Error: " +
+                               status.ToString());
+    }
+  }
 };
 
 // Registers our custom class with torch.
@@ -58,7 +158,29 @@ static auto sentencepiece =
         .def("Encode", &SentencePiece::Encode)
         .def("EncodeAsIds", &SentencePiece::EncodeAsIds)
         .def("EncodeAsPieces", &SentencePiece::EncodeAsPieces)
+        .def("NBestEncodeAsPieces", &SentencePiece::NBestEncodeAsPieces)
+        .def("NBestEncodeAsIds", &SentencePiece::NBestEncodeAsIds)
+        .def("SampleEncodeAsPieces", &SentencePiece::SampleEncodeAsPieces)
+        .def("SampleEncodeAsIds", &SentencePiece::SampleEncodeAsIds)
+        .def("DecodePieces", &SentencePiece::DecodePieces)
+        .def("DecodeIds", &SentencePiece::DecodeIds)
         .def("GetPieceSize", &SentencePiece::GetPieceSize)
+        .def("PieceToId", &SentencePiece::PieceToId)
+        .def("IdToPiece", &SentencePiece::IdToPiece)
+        .def("GetScore", &SentencePiece::GetScore)
+        .def("IsUnknown", &SentencePiece::IsUnknown)
+        .def("IsUnused", &SentencePiece::IsUnused)
+        .def("unk_id", &SentencePiece::unk_id)
+        .def("bos_id", &SentencePiece::bos_id)
+        .def("eos_id", &SentencePiece::eos_id)
+        .def("pad_id", &SentencePiece::pad_id)
+        .def("SetEncodeExtraOptions", &SentencePiece::SetEncodeExtraOptions)
+        .def("SetDecodeExtraOptions", &SentencePiece::SetDecodeExtraOptions)
+        .def("SetVocabulary", &SentencePiece::SetVocabulary)
+        .def("ResetVocabulary", &SentencePiece::ResetVocabulary)
+        .def("LoadVocabulary", &SentencePiece::LoadVocabulary)
+        .def("__len__", &SentencePiece::GetPieceSize)
+        .def("__getitem__", &SentencePiece::PieceToId)
         .def_pickle(
             // __setstate__
             [](const c10::intrusive_ptr<SentencePiece> &self) -> std::string {

--- a/torchtext/csrc/sentencepiece.cpp
+++ b/torchtext/csrc/sentencepiece.cpp
@@ -103,6 +103,8 @@ public:
 
   bool IsUnused(const int64_t id) const { return processor_.IsUnused(id); }
 
+  bool IsControl(const int64_t id) const { return processor_.IsControl(id); }
+
   int64_t unk_id() const { return processor_.unk_id(); }
 
   int64_t bos_id() const { return processor_.bos_id(); }
@@ -170,6 +172,7 @@ static auto sentencepiece =
         .def("GetScore", &SentencePiece::GetScore)
         .def("IsUnknown", &SentencePiece::IsUnknown)
         .def("IsUnused", &SentencePiece::IsUnused)
+        .def("IsControl", &SentencePiece::IsControl)
         .def("unk_id", &SentencePiece::unk_id)
         .def("bos_id", &SentencePiece::bos_id)
         .def("eos_id", &SentencePiece::eos_id)


### PR DESCRIPTION
This PR adds most of methods define in SentencePieceProcessor Python wrapper.
~~Blocked by https://github.com/pytorch/pytorch/pull/38167~~

- `NBestEncodeAsPieces`
- `NBestEncodeAsIds`
- `SampleEncodeAsPieces`
- `SampleEncodeAsIds`
- `DecodePieces`
- `DecodeIds`
- `GetPieceSize`
- `PieceToId`
- `IdToPiece`
- `GetScore`
- `IsUnknown`
- `IsUnused`
- `IsControl`
- `unk_id`
- `bos_id`
- `eos_id`
- `pad_id`
- `SetEncodeExtraOptions`
- `SetDecodeExtraOptions`
- `SetVocabulary`
- `ResetVocabulary`
- `LoadVocabulary`
- `__len__`
- `__getitem__`