### PR TITLE
Fix extension import path for buck

### DIFF
--- a/torchtext/__init__.py
+++ b/torchtext/__init__.py
@@ -14,9 +14,23 @@ __all__ = ['data',
 
 
 def _init_extension():
+    import os
+    import importlib
     import torch
-    torch.ops.load_library('torchtext/_torchtext.so')
-    torch.classes.load_library('torchtext/_torchtext.so')
+
+    # load the custom_op_library and register the custom ops
+    lib_dir = os.path.dirname(__file__)
+    loader_details = (
+        importlib.machinery.ExtensionFileLoader,
+        importlib.machinery.EXTENSION_SUFFIXES
+    )
+
+    extfinder = importlib.machinery.FileFinder(lib_dir, loader_details)
+    ext_specs = extfinder.find_spec("_torchtext")
+    if ext_specs is None:
+        raise ImportError
+    torch.ops.load_library(ext_specs.origin)
+    torch.classes.load_library(ext_specs.origin)
 
 
 _init_extension()


### PR DESCRIPTION
When building `torchtext` with buck, the path to `_torchtext.so` has to be normalized.
The fix was taken from [`torchvision`'s equivalent](https://github.com/pytorch/vision/blob/4e138bd5602d7e1b3713998ad213c5e1f16e25ce/torchvision/extension.py#L4-L20)