### PR TITLE
Temporary fix for flake8

### DIFF
--- a/.circleci/unittest/scripts/environment.yml
+++ b/.circleci/unittest/scripts/environment.yml
@@ -1,7 +1,7 @@
 channels:
   - defaults
 dependencies:
-  - flake8
+  - flake8==3.7.9
   - codecov
   - pip
   - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ sphinx_rtd_theme
 # Required for tests only:
 
 # Style-checking for PEP8
-flake8
+flake8==3.7.9
 
 # Run unit tests
 pytest


### PR DESCRIPTION
The latest version of flake8 added check for E741 and causing CI to fail.
This PR temporarily fix it by pinning the flake8 version.

```
./torchtext/datasets/translation.py:181:21: E741 ambiguous variable name 'l'
./test/common/torchtext_test_case.py:110:30: E741 ambiguous variable name 'l'
```