### PR TITLE
Separate test that require network access in test/data/test_field.py

### DIFF
--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -6,7 +6,6 @@ from numpy.testing import assert_allclose
 import torch
 import torchtext.data as data
 import pytest
-from torch.nn import init
 
 from ..common.torchtext_test_case import TorchtextTestCase, verify_numericalized_example
 
@@ -864,22 +863,6 @@ class TestNestedField(TorchtextTestCase):
         pickled_numericalization = loaded_field.numericalize(examples_data)
 
         assert torch.all(torch.eq(original_numericalization, pickled_numericalization))
-
-    def test_build_vocab(self):
-        nesting_field = data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
-
-        field = data.NestedField(nesting_field, init_token='<s>', eos_token='</s>',
-                                 include_lengths=True,
-                                 pad_first=True)
-
-        sources = [[['a'], ['s', 'e', 'n', 't', 'e', 'n', 'c', 'e'], ['o', 'f'],
-                    ['d', 'a', 't', 'a'], ['.']],
-                   [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
-                   [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
-
-        field.build_vocab(sources, vectors='glove.6B.50d',
-                          unk_init=init.normal_,
-                          vectors_cache=".vector_cache")
 
 
 class TestLabelField(TorchtextTestCase):

--- a/test/data/test_field_build_vocab_glove.6B.50d.py
+++ b/test/data/test_field_build_vocab_glove.6B.50d.py
@@ -1,0 +1,23 @@
+import torch.nn
+
+import torchtext.data as data
+from ..common.torchtext_test_case import TorchtextTestCase
+
+
+class TestNestedField(TorchtextTestCase):
+    def test_build_vocab(self):
+        # This test requires network access
+        nesting_field = data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
+
+        field = data.NestedField(nesting_field, init_token='<s>', eos_token='</s>',
+                                 include_lengths=True,
+                                 pad_first=True)
+
+        sources = [[['a'], ['s', 'e', 'n', 't', 'e', 'n', 'c', 'e'], ['o', 'f'],
+                    ['d', 'a', 't', 'a'], ['.']],
+                   [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
+                   [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
+
+        field.build_vocab(sources, vectors='glove.6B.50d',
+                          unk_init=torch.nn.init.normal_,
+                          vectors_cache=".vector_cache")


### PR DESCRIPTION
Separating `TestNestedField.test_build_vocab` which requires network access, from the rest so that we can exclude it when running test with `buck`.