### PR TITLE
Separate tests which require external resource

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -1,3 +1,5 @@
+#!/user/bin/env python3
+# Note that all the tests in this module require dataset (either network access or cached)
 import os
 import shutil
 import torchtext.data as data

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -59,40 +59,6 @@ class TestDataset(TorchtextTestCase):
                 self.assertEqual(example.q2, expected_examples[i][1])
                 self.assertEqual(example.label, expected_examples[i][2])
 
-    def test_json_dataset_one_key_multiple_fields(self):
-        self.write_test_ppid_dataset(data_format="json")
-
-        question_field = data.Field(sequential=True)
-        spacy_tok_question_field = data.Field(sequential=True, tokenize="spacy")
-        label_field = data.Field(sequential=False)
-        fields = {"question1": [("q1", question_field),
-                                ("q1_spacy", spacy_tok_question_field)],
-                  "question2": [("q2", question_field),
-                                ("q2_spacy", spacy_tok_question_field)],
-                  "label": ("label", label_field)}
-        dataset = data.TabularDataset(
-            path=self.test_ppid_dataset_path, format="json", fields=fields)
-        expected_examples = [
-            (["When", "do", "you", "use", "シ", "instead", "of", "し?"],
-             ["When", "do", "you", "use", "シ", "instead", "of", "し", "?"],
-             ["When", "do", "you", "use", "\"&\"",
-              "instead", "of", "\"and\"?"],
-             ["When", "do", "you", "use", "\"", "&", "\"",
-              "instead", "of", "\"", "and", "\"", "?"], "0"),
-            (["Where", "was", "Lincoln", "born?"],
-             ["Where", "was", "Lincoln", "born", "?"],
-             ["Which", "location", "was", "Abraham", "Lincoln", "born?"],
-             ["Which", "location", "was", "Abraham", "Lincoln", "born", "?"],
-             "1"),
-            (["What", "is", "2+2"], ["What", "is", "2", "+", "2"],
-             ["2+2=?"], ["2", "+", "2=", "?"], "1")]
-        for i, example in enumerate(dataset):
-            self.assertEqual(example.q1, expected_examples[i][0])
-            self.assertEqual(example.q1_spacy, expected_examples[i][1])
-            self.assertEqual(example.q2, expected_examples[i][2])
-            self.assertEqual(example.q2_spacy, expected_examples[i][3])
-            self.assertEqual(example.label, expected_examples[i][4])
-
     def test_json_valid_and_invalid_nested_key(self):
         self.write_test_nested_key_json_dataset()
         valid_fields = {'foods.vegetables.name': ('vegs', data.Field()),

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -200,43 +200,6 @@ class TestDataset(TorchtextTestCase):
                                       sort_within_batch=False, repeat=False)
             next(data_iter.__iter__())
 
-    def test_csv_file_no_header_one_col_multiple_fields(self):
-        self.write_test_ppid_dataset(data_format="csv")
-
-        question_field = data.Field(sequential=True)
-        spacy_tok_question_field = data.Field(sequential=True, tokenize="spacy")
-        label_field = data.Field(sequential=False)
-        # Field name/value as nested tuples
-        fields = [("ids", None),
-                  (("q1", "q1_spacy"), (question_field, spacy_tok_question_field)),
-                  (("q2", "q2_spacy"), (question_field, spacy_tok_question_field)),
-                  ("label", label_field)]
-        dataset = data.TabularDataset(
-            path=self.test_ppid_dataset_path, format="csv", fields=fields)
-        expected_examples = [
-            (["When", "do", "you", "use", "シ", "instead", "of", "し?"],
-             ["When", "do", "you", "use", "シ", "instead", "of", "し", "?"],
-             ["When", "do", "you", "use", "\"&\"",
-              "instead", "of", "\"and\"?"],
-             ["When", "do", "you", "use", "\"", "&", "\"",
-              "instead", "of", "\"", "and", "\"", "?"], "0"),
-            (["Where", "was", "Lincoln", "born?"],
-             ["Where", "was", "Lincoln", "born", "?"],
-             ["Which", "location", "was", "Abraham", "Lincoln", "born?"],
-             ["Which", "location", "was", "Abraham", "Lincoln", "born", "?"],
-             "1"),
-            (["What", "is", "2+2"], ["What", "is", "2", "+", "2"],
-             ["2+2=?"], ["2", "+", "2=", "?"], "1")]
-        for i, example in enumerate(dataset):
-            self.assertEqual(example.q1, expected_examples[i][0])
-            self.assertEqual(example.q1_spacy, expected_examples[i][1])
-            self.assertEqual(example.q2, expected_examples[i][2])
-            self.assertEqual(example.q2_spacy, expected_examples[i][3])
-            self.assertEqual(example.label, expected_examples[i][4])
-
-        # 6 Fields including None for ids
-        assert len(dataset.fields) == 6
-
     @unittest.skipIf(sys.platform == "win32", "FIXME: tempfile could not be opened twice on Windows")
     def test_csv_dataset_quotechar(self):
         # Based on issue #349

--- a/test/data/test_field.py
+++ b/test/data/test_field.py
@@ -6,7 +6,6 @@ from numpy.testing import assert_allclose
 import torch
 import torchtext.data as data
 import pytest
-from torch.nn import init
 
 from ..common.torchtext_test_case import TorchtextTestCase, verify_numericalized_example
 
@@ -864,22 +863,6 @@ class TestNestedField(TorchtextTestCase):
         pickled_numericalization = loaded_field.numericalize(examples_data)
 
         assert torch.all(torch.eq(original_numericalization, pickled_numericalization))
-
-    def test_build_vocab(self):
-        nesting_field = data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
-
-        field = data.NestedField(nesting_field, init_token='<s>', eos_token='</s>',
-                                 include_lengths=True,
-                                 pad_first=True)
-
-        sources = [[['a'], ['s', 'e', 'n', 't', 'e', 'n', 'c', 'e'], ['o', 'f'],
-                    ['d', 'a', 't', 'a'], ['.']],
-                   [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
-                   [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]]
-
-        field.build_vocab(sources, vectors='glove.6B.50d',
-                          unk_init=init.normal_,
-                          vectors_cache=".vector_cache")
 
 
 class TestLabelField(TorchtextTestCase):

--- a/test/data/test_subword.py
+++ b/test/data/test_subword.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Note that all the tests in this module require dataset (either network access or cached)
 import unittest
 
 from torchtext import data

--- a/test/data/test_utils.py
+++ b/test/data/test_utils.py
@@ -15,12 +15,6 @@ class TestUtils(TorchtextTestCase):
         assert data.get_tokenizer(str.split) == str.split
         assert data.get_tokenizer(str.split)(self.TEST_STR) == str.split(self.TEST_STR)
 
-    def test_get_tokenizer_spacy(self):
-        # Test SpaCy option, and verify it properly handles punctuation.
-        assert data.get_tokenizer("spacy")(str(self.TEST_STR)) == [
-            "A", "string", ",", "particularly", "one", "with", "slightly",
-            "complex", "punctuation", "."]
-
     def test_get_tokenizer_moses(self):
         # Test Moses option.
         # Note that internally, MosesTokenizer converts to unicode if applicable

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -130,8 +130,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(token_one_vec.shape[0], vec.dim)
         torch.testing.assert_allclose(vec[tokens[0].lower()].numpy(), token_one_vec)
 
-
-    def test_vocab_download_charngram_vectors(self):
+    def test_download_charngram_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching, then once more
         # to test string aliases.
@@ -163,7 +162,7 @@ class TestVocab(TorchtextTestCase):
             torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(100))
             torch.testing.assert_allclose(vectors[v.stoi['OOV token']], np.zeros(100))
 
-    def test_vocab_download_custom_vectors(self):
+    def test_download_custom_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching.
         for _ in range(2):
@@ -191,7 +190,7 @@ class TestVocab(TorchtextTestCase):
 
             torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
 
-    def test_vocab_download_fasttext_vectors(self):
+    def test_download_fasttext_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching, then once more
         # to test string aliases.
@@ -224,7 +223,7 @@ class TestVocab(TorchtextTestCase):
             torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
             torch.testing.assert_allclose(vectors[v.stoi['OOV token']], np.zeros(300))
 
-    def test_vocab_download_glove_vectors(self):
+    def test_download_glove_vectors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
 
         # Build a vocab and get vectors twice to test caching, then once more
@@ -258,7 +257,7 @@ class TestVocab(TorchtextTestCase):
             torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(25))
             torch.testing.assert_allclose(vectors[v.stoi['OOV token']], np.zeros(25))
 
-    def test_vocab_extend(self):
+    def test_extend(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching.
         for _ in range(2):
@@ -285,7 +284,7 @@ class TestVocab(TorchtextTestCase):
 
             torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
 
-    def test_vocab_vectors_custom_cache(self):
+    def test_vectors_custom_cache(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         vector_cache = os.path.join('/tmp', 'vector_cache')
         # Build a vocab and get vectors twice to test caching.

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Tests that requires external resources (Network access to fetch dataset)"""
+import os
 from collections import Counter
 
 import numpy as np
@@ -270,6 +271,37 @@ class TestVocab(TorchtextTestCase):
 
             self.assertEqual(v.itos[:6], ['<unk>', '<pad>', '<bos>',
                                           'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world'])
+            vectors = v.vectors.numpy()
+
+            # The first 5 entries in each vector.
+            expected_fasttext_simple_en = {
+                'hello': [0.39567, 0.21454, -0.035389, -0.24299, -0.095645],
+                'world': [0.10444, -0.10858, 0.27212, 0.13299, -0.33165],
+            }
+
+            for word in expected_fasttext_simple_en:
+                torch.testing.assert_allclose(
+                    vectors[v.stoi[word], :5], expected_fasttext_simple_en[word])
+
+            torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
+
+    def test_vocab_vectors_custom_cache(self):
+        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
+        vector_cache = os.path.join('/tmp', 'vector_cache')
+        # Build a vocab and get vectors twice to test caching.
+        for i in range(2):
+            if i == 1:
+                self.assertTrue(os.path.exists(vector_cache))
+
+            v = torchtext.vocab.Vocab(
+                c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'],
+                vectors=torchtext.vocab.Vectors(
+                    'wiki.simple.vec', cache=vector_cache,
+                    url=torchtext.vocab.FastText.url_base.format('simple'))
+            )
+
+            self.assertEqual(v.itos, ['<unk>', '<pad>', '<bos>',
+                                      'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world'])
             vectors = v.vectors.numpy()
 
             # The first 5 entries in each vector.

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Tests that requires external resources (Network access to fetch dataset)"""
+
+import torch
+import torchtext.data
+
+from common.torchtext_test_case import TorchtextTestCase
+
+
+class TestNestedField(TorchtextTestCase):
+    def test_build_vocab(self):
+        nesting_field = torchtext.data.Field(tokenize=list, init_token="<w>", eos_token="</w>")
+
+        field = torchtext.data.NestedField(
+            nesting_field, init_token='<s>', eos_token='</s>',
+            include_lengths=True,
+            pad_first=True)
+
+        sources = [
+            [['a'], ['s', 'e', 'n', 't', 'e', 'n', 'c', 'e'], ['o', 'f'], ['d', 'a', 't', 'a'], ['.']],
+            [['y', 'e', 't'], ['a', 'n', 'o', 't', 'h', 'e', 'r']],
+            [['o', 'n', 'e'], ['l', 'a', 's', 't'], ['s', 'e', 'n', 't']]
+        ]
+
+        field.build_vocab(
+            sources, vectors='glove.6B.50d',
+            unk_init=torch.nn.init.normal_, vectors_cache=".vector_cache")
+

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -256,3 +256,30 @@ class TestVocab(TorchtextTestCase):
 
             torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(25))
             torch.testing.assert_allclose(vectors[v.stoi['OOV token']], np.zeros(25))
+
+    def test_vocab_extend(self):
+        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
+        # Build a vocab and get vectors twice to test caching.
+        for _ in range(2):
+            f = torchtext.vocab.FastText(language='simple')
+            v = torchtext.vocab.Vocab(
+                c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'], vectors=f)
+            n_vocab = len(v)
+            v.extend(f)  # extend the vocab with the words contained in f.itos
+            self.assertGreater(len(v), n_vocab)
+
+            self.assertEqual(v.itos[:6], ['<unk>', '<pad>', '<bos>',
+                                          'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world'])
+            vectors = v.vectors.numpy()
+
+            # The first 5 entries in each vector.
+            expected_fasttext_simple_en = {
+                'hello': [0.39567, 0.21454, -0.035389, -0.24299, -0.095645],
+                'world': [0.10444, -0.10858, 0.27212, 0.13299, -0.33165],
+            }
+
+            for word in expected_fasttext_simple_en:
+                torch.testing.assert_allclose(
+                    vectors[v.stoi[word], :5], expected_fasttext_simple_en[word])
+
+            torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -98,3 +98,13 @@ class TestDataset(TorchtextTestCase):
             self.assertEqual(example.q2, expected_examples[i][2])
             self.assertEqual(example.q2_spacy, expected_examples[i][3])
             self.assertEqual(example.label, expected_examples[i][4])
+
+
+class TestDataUtils(TorchtextTestCase):
+    TEST_STR = "A string, particularly one with slightly complex punctuation."
+
+    def test_get_tokenizer_spacy(self):
+        # Test SpaCy option, and verify it properly handles punctuation.
+        assert torchtext.data.get_tokenizer("spacy")(str(self.TEST_STR)) == [
+            "A", "string", ",", "particularly", "one", "with", "slightly",
+            "complex", "punctuation", "."]

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Tests that requires external resources (Network access to fetch dataset)"""
+from collections import Counter
 
+import numpy as np
 import torch
 import torchtext.data
 
@@ -126,3 +128,36 @@ class TestVocab(TorchtextTestCase):
         token_one_vec = vec.get_vecs_by_tokens(tokens[0], lower_case_backup=True).numpy()
         self.assertEqual(token_one_vec.shape[0], vec.dim)
         torch.testing.assert_allclose(vec[tokens[0].lower()].numpy(), token_one_vec)
+
+
+    def test_vocab_download_charngram_vectors(self):
+        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
+        # Build a vocab and get vectors twice to test caching, then once more
+        # to test string aliases.
+        for i in range(3):
+            if i == 2:
+                vectors = "charngram.100d"
+            else:
+                vectors = torchtext.vocab.CharNGram()
+            v = torchtext.vocab.Vocab(
+                c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'], vectors=vectors)
+            expected_itos = ['<unk>', '<pad>', '<bos>',
+                             'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
+            expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+            self.assertEqual(v.itos, expected_itos)
+            self.assertEqual(dict(v.stoi), expected_stoi)
+            vectors = v.vectors.numpy()
+
+            # The first 5 entries in each vector.
+            expected_charngram = {
+                'hello': [-0.44782442, -0.08937783, -0.34227219,
+                          -0.16233221, -0.39343098],
+                'world': [-0.29590717, -0.05275926, -0.37334684, 0.27117205, -0.3868292],
+            }
+
+            for word in expected_charngram:
+                torch.testing.assert_allclose(
+                    vectors[v.stoi[word], :5], expected_charngram[word])
+
+            torch.testing.assert_allclose(vectors[v.stoi['<unk>']], np.zeros(100))
+            torch.testing.assert_allclose(vectors[v.stoi['OOV token']], np.zeros(100))

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -108,3 +108,21 @@ class TestDataUtils(TorchtextTestCase):
         assert torchtext.data.get_tokenizer("spacy")(str(self.TEST_STR)) == [
             "A", "string", ",", "particularly", "one", "with", "slightly",
             "complex", "punctuation", "."]
+
+
+class TestVocab(TorchtextTestCase):
+    def test_vectors_get_vecs(self):
+        vec = torchtext.vocab.GloVe(name='twitter.27B', dim='25')
+        self.assertEqual(vec.vectors.shape[0], len(vec))
+
+        tokens = ['chip', 'baby', 'Beautiful']
+        token_vecs = vec.get_vecs_by_tokens(tokens).numpy()
+        self.assertEqual(token_vecs.shape[0], len(tokens))
+        self.assertEqual(token_vecs.shape[1], vec.dim)
+        torch.testing.assert_allclose(vec[tokens[0]].numpy(), token_vecs[0])
+        torch.testing.assert_allclose(vec[tokens[1]].numpy(), token_vecs[1])
+        torch.testing.assert_allclose(vec['<unk>'].numpy(), token_vecs[2])
+
+        token_one_vec = vec.get_vecs_by_tokens(tokens[0], lower_case_backup=True).numpy()
+        self.assertEqual(token_one_vec.shape[0], vec.dim)
+        torch.testing.assert_allclose(vec[tokens[0].lower()].numpy(), token_one_vec)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Note that all the tests in this module require dataset (either network access or cached)
 import os
 from torchtext import utils
 from .common.torchtext_test_case import TorchtextTestCase

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import torch
 from torchtext import vocab
-from torchtext.vocab import Vectors, FastText, GloVe
+from torchtext.vocab import Vectors, FastText
 
 from .common.torchtext_test_case import TorchtextTestCase
 
@@ -154,48 +154,6 @@ class TestVocab(TorchtextTestCase):
         if os.environ.get("TRAVIS") == "true":
             vec_file = os.path.join(vector_cache, "wiki.simple.vec")
             conditional_remove(vec_file)
-
-    def test_vocab_download_glove_vectors(self):
-        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
-
-        # Build a vocab and get vectors twice to test caching, then once more
-        # to test string aliases.
-        for i in range(3):
-            if i == 2:
-                vectors = "glove.twitter.27B.25d"
-            else:
-                vectors = GloVe(name='twitter.27B', dim='25')
-            v = vocab.Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'],
-                            vectors=vectors)
-
-            expected_itos = ['<unk>', '<pad>', '<bos>',
-                             'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
-            expected_stoi = {x: index for index, x in enumerate(expected_itos)}
-            self.assertEqual(v.itos, expected_itos)
-            self.assertEqual(dict(v.stoi), expected_stoi)
-
-            vectors = v.vectors.numpy()
-
-            # The first 5 entries in each vector.
-            expected_twitter = {
-                'hello': [-0.77069, 0.12827, 0.33137, 0.0050893, -0.47605],
-                'world': [0.10301, 0.095666, -0.14789, -0.22383, -0.14775],
-            }
-
-            for word in expected_twitter:
-                assert_allclose(vectors[v.stoi[word], :5],
-                                expected_twitter[word])
-
-            assert_allclose(vectors[v.stoi['<unk>']], np.zeros(25))
-            assert_allclose(vectors[v.stoi['OOV token']], np.zeros(25))
-        # Delete the vectors after we're done to save disk space on CI
-        if os.environ.get("TRAVIS") == "true":
-            zip_file = os.path.join(self.project_root, ".vector_cache",
-                                    "glove.twitter.27B.zip")
-            conditional_remove(zip_file)
-            for dim in ["25", "50", "100", "200"]:
-                conditional_remove(os.path.join(self.project_root, ".vector_cache",
-                                                "glove.twitter.27B.{}d.txt".format(dim)))
 
     def test_errors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import torch
 from torchtext import vocab
-from torchtext.vocab import Vectors, FastText, GloVe, CharNGram
+from torchtext.vocab import Vectors, FastText, GloVe
 
 from .common.torchtext_test_case import TorchtextTestCase
 
@@ -261,45 +261,6 @@ class TestVocab(TorchtextTestCase):
             for dim in ["25", "50", "100", "200"]:
                 conditional_remove(os.path.join(self.project_root, ".vector_cache",
                                                 "glove.twitter.27B.{}d.txt".format(dim)))
-
-    def test_vocab_download_charngram_vectors(self):
-        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
-        # Build a vocab and get vectors twice to test caching, then once more
-        # to test string aliases.
-        for i in range(3):
-            if i == 2:
-                vectors = "charngram.100d"
-            else:
-                vectors = CharNGram()
-            v = vocab.Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'],
-                            vectors=vectors)
-            expected_itos = ['<unk>', '<pad>', '<bos>',
-                             'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
-            expected_stoi = {x: index for index, x in enumerate(expected_itos)}
-            self.assertEqual(v.itos, expected_itos)
-            self.assertEqual(dict(v.stoi), expected_stoi)
-            vectors = v.vectors.numpy()
-
-            # The first 5 entries in each vector.
-            expected_charngram = {
-                'hello': [-0.44782442, -0.08937783, -0.34227219,
-                          -0.16233221, -0.39343098],
-                'world': [-0.29590717, -0.05275926, -0.37334684, 0.27117205, -0.3868292],
-            }
-
-            for word in expected_charngram:
-                assert_allclose(vectors[v.stoi[word], :5],
-                                expected_charngram[word])
-
-            assert_allclose(vectors[v.stoi['<unk>']], np.zeros(100))
-            assert_allclose(vectors[v.stoi['OOV token']], np.zeros(100))
-        # Delete the vectors after we're done to save disk space on CI
-        if os.environ.get("TRAVIS") == "true":
-            conditional_remove(
-                os.path.join(self.project_root, ".vector_cache", "charNgram.txt"))
-            conditional_remove(
-                os.path.join(self.project_root, ".vector_cache",
-                             "jmt_pre-trained_embeddings.tar.gz"))
 
     def test_errors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import torch
 from torchtext import vocab
-from torchtext.vocab import Vectors, FastText
 
 from .common.torchtext_test_case import TorchtextTestCase
 
@@ -91,38 +90,6 @@ class TestVocab(TorchtextTestCase):
                                      [0.0, 0.0], [0.1, 0.2], [0.5, 0.6],
                                      [0.3, 0.4]])
         assert_allclose(v.vectors.numpy(), expected_vectors)
-
-    def test_vocab_vectors_custom_cache(self):
-        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
-        vector_cache = os.path.join('/tmp', 'vector_cache')
-        # Build a vocab and get vectors twice to test caching.
-        for i in range(2):
-            if i == 1:
-                self.assertTrue(os.path.exists(vector_cache))
-
-            v = vocab.Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'],
-                            vectors=Vectors('wiki.simple.vec', cache=vector_cache,
-                                            url=FastText.url_base.format('simple')))
-
-            self.assertEqual(v.itos, ['<unk>', '<pad>', '<bos>',
-                                      'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world'])
-            vectors = v.vectors.numpy()
-
-            # The first 5 entries in each vector.
-            expected_fasttext_simple_en = {
-                'hello': [0.39567, 0.21454, -0.035389, -0.24299, -0.095645],
-                'world': [0.10444, -0.10858, 0.27212, 0.13299, -0.33165],
-            }
-
-            for word in expected_fasttext_simple_en:
-                assert_allclose(vectors[v.stoi[word], :5],
-                                expected_fasttext_simple_en[word])
-
-            assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
-        # Delete the vectors after we're done to save disk space on CI
-        if os.environ.get("TRAVIS") == "true":
-            vec_file = os.path.join(vector_cache, "wiki.simple.vec")
-            conditional_remove(vec_file)
 
     def test_errors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -92,37 +92,6 @@ class TestVocab(TorchtextTestCase):
                                      [0.3, 0.4]])
         assert_allclose(v.vectors.numpy(), expected_vectors)
 
-    def test_vocab_extend(self):
-        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
-        # Build a vocab and get vectors twice to test caching.
-        for _ in range(2):
-            f = FastText(language='simple')
-            v = vocab.Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'],
-                            vectors=f)
-            n_vocab = len(v)
-            v.extend(f)  # extend the vocab with the words contained in f.itos
-            self.assertGreater(len(v), n_vocab)
-
-            self.assertEqual(v.itos[:6], ['<unk>', '<pad>', '<bos>',
-                                          'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world'])
-            vectors = v.vectors.numpy()
-
-            # The first 5 entries in each vector.
-            expected_fasttext_simple_en = {
-                'hello': [0.39567, 0.21454, -0.035389, -0.24299, -0.095645],
-                'world': [0.10444, -0.10858, 0.27212, 0.13299, -0.33165],
-            }
-
-            for word in expected_fasttext_simple_en:
-                assert_allclose(vectors[v.stoi[word], :5],
-                                expected_fasttext_simple_en[word])
-
-            assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
-        # Delete the vectors after we're done to save disk space on CI
-        if os.environ.get("TRAVIS") == "true":
-            vec_file = os.path.join(self.project_root, ".vector_cache", "wiki.simple.vec")
-            conditional_remove(vec_file)
-
     def test_vocab_vectors_custom_cache(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         vector_cache = os.path.join('/tmp', 'vector_cache')

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -160,34 +160,6 @@ class TestVocab(TorchtextTestCase):
             vec_file = os.path.join(self.project_root, ".vector_cache", "wiki.simple.vec")
             conditional_remove(vec_file)
 
-    def test_vocab_download_custom_vectors(self):
-        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
-        # Build a vocab and get vectors twice to test caching.
-        for _ in range(2):
-            v = vocab.Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'],
-                            vectors=Vectors('wiki.simple.vec',
-                                            url=FastText.url_base.format('simple')))
-
-            self.assertEqual(v.itos, ['<unk>', '<pad>', '<bos>',
-                                      'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world'])
-            vectors = v.vectors.numpy()
-
-            # The first 5 entries in each vector.
-            expected_fasttext_simple_en = {
-                'hello': [0.39567, 0.21454, -0.035389, -0.24299, -0.095645],
-                'world': [0.10444, -0.10858, 0.27212, 0.13299, -0.33165],
-            }
-
-            for word in expected_fasttext_simple_en:
-                assert_allclose(vectors[v.stoi[word], :5],
-                                expected_fasttext_simple_en[word])
-
-            assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
-        # Delete the vectors after we're done to save disk space on CI
-        if os.environ.get("TRAVIS") == "true":
-            vec_file = os.path.join(self.project_root, ".vector_cache", "wiki.simple.vec")
-            conditional_remove(vec_file)
-
     def test_vocab_vectors_custom_cache(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         vector_cache = os.path.join('/tmp', 'vector_cache')

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -336,31 +336,6 @@ class TestVocab(TorchtextTestCase):
         v_loaded = pickle.load(open(pickle_path, "rb"))
         assert v == v_loaded
 
-    def test_vectors_get_vecs(self):
-        vec = GloVe(name='twitter.27B', dim='25')
-        self.assertEqual(vec.vectors.shape[0], len(vec))
-
-        tokens = ['chip', 'baby', 'Beautiful']
-        token_vecs = vec.get_vecs_by_tokens(tokens).numpy()
-        self.assertEqual(token_vecs.shape[0], len(tokens))
-        self.assertEqual(token_vecs.shape[1], vec.dim)
-        assert_allclose(vec[tokens[0]].numpy(), token_vecs[0])
-        assert_allclose(vec[tokens[1]].numpy(), token_vecs[1])
-        assert_allclose(vec['<unk>'].numpy(), token_vecs[2])
-
-        token_one_vec = vec.get_vecs_by_tokens(tokens[0], lower_case_backup=True).numpy()
-        self.assertEqual(token_one_vec.shape[0], vec.dim)
-        assert_allclose(vec[tokens[0].lower()].numpy(), token_one_vec)
-
-        # Delete the vectors after we're done to save disk space on CI
-        if os.environ.get("TRAVIS") == "true":
-            zip_file = os.path.join(self.project_root, ".vector_cache",
-                                    "glove.6B.zip")
-            conditional_remove(zip_file)
-            for dim in ["50", "100", "200", "300"]:
-                conditional_remove(os.path.join(self.project_root, ".vector_cache",
-                                                "glove.6B.{}d.txt".format(dim)))
-
     def test_has_unk(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         v = vocab.Vocab(c)

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -92,43 +92,6 @@ class TestVocab(TorchtextTestCase):
                                      [0.3, 0.4]])
         assert_allclose(v.vectors.numpy(), expected_vectors)
 
-    def test_vocab_download_fasttext_vectors(self):
-        c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
-        # Build a vocab and get vectors twice to test caching, then once more
-        # to test string aliases.
-        for i in range(3):
-            if i == 2:
-                vectors = "fasttext.simple.300d"
-            else:
-                vectors = FastText(language='simple')
-
-            v = vocab.Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'],
-                            vectors=vectors)
-
-            expected_itos = ['<unk>', '<pad>', '<bos>',
-                             'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
-            expected_stoi = {x: index for index, x in enumerate(expected_itos)}
-            self.assertEqual(v.itos, expected_itos)
-            self.assertEqual(dict(v.stoi), expected_stoi)
-            vectors = v.vectors.numpy()
-
-            # The first 5 entries in each vector.
-            expected_fasttext_simple_en = {
-                'hello': [0.39567, 0.21454, -0.035389, -0.24299, -0.095645],
-                'world': [0.10444, -0.10858, 0.27212, 0.13299, -0.33165],
-            }
-
-            for word in expected_fasttext_simple_en:
-                assert_allclose(vectors[v.stoi[word], :5],
-                                expected_fasttext_simple_en[word])
-
-            assert_allclose(vectors[v.stoi['<unk>']], np.zeros(300))
-            assert_allclose(vectors[v.stoi['OOV token']], np.zeros(300))
-        # Delete the vectors after we're done to save disk space on CI
-        if os.environ.get("TRAVIS") == "true":
-            vec_file = os.path.join(self.project_root, ".vector_cache", "wiki.simple.vec")
-            conditional_remove(vec_file)
-
     def test_vocab_extend(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         # Build a vocab and get vectors twice to test caching.


### PR DESCRIPTION
Tests that require dataset (either via network access or cache) as following are moved to `test/test_build.py`.

```
test_vocab_vectors_custom_cache (test.test_vocab.TestVocab)
test_vocab_extend (test.test_vocab.TestVocab)
test_vocab_download_glove_vectors (test.test_vocab.TestVocab)
test_vocab_download_fasttext_vectors (test.test_vocab.TestVocab)
test_vocab_download_custom_vectors (test.test_vocab.TestVocab)
test_vocab_download_charngram_vectors (test.test_vocab.TestVocab)
test_vectors_get_vecs (test.test_vocab.TestVocab)
test_get_tokenizer_spacy (test.data.test_utils.TestUtils)
test_json_dataset_one_key_multiple_fields (test.data.test_dataset.TestDataset)
test_csv_file_no_header_one_col_multiple_fields (test.data.test_dataset.TestDataset)
test_build_vocab (test.data.test_field.TestNestedField)
```

In addition to that, the following test modules contain only such tests. so they can simply exclude in `fbcode`.
- `test/test_utils.py` (unchanged)
- `test/data/test_subword.py` (unchanged)

