### PR TITLE
Move `test_get_tokenizer_moses` to test_build

### DIFF
--- a/test/data/test_utils.py
+++ b/test/data/test_utils.py
@@ -15,17 +15,6 @@ class TestUtils(TorchtextTestCase):
         assert data.get_tokenizer(str.split) == str.split
         assert data.get_tokenizer(str.split)(self.TEST_STR) == str.split(self.TEST_STR)
 
-    def test_get_tokenizer_moses(self):
-        # Test Moses option.
-        # Note that internally, MosesTokenizer converts to unicode if applicable
-        moses_tokenizer = data.get_tokenizer("moses")
-        assert moses_tokenizer(self.TEST_STR) == [
-            "A", "string", ",", "particularly", "one", "with", "slightly",
-            "complex", "punctuation", "."]
-
-        # Nonbreaking prefixes should tokenize the final period.
-        assert moses_tokenizer("abc def.") == ["abc", "def", "."]
-
     def test_get_tokenizer_toktokt(self):
         # Test Toktok option. Test strings taken from NLTK doctests.
         # Note that internally, MosesTokenizer converts to unicode if applicable

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -112,6 +112,17 @@ class TestDataUtils(TorchtextTestCase):
             "A", "string", ",", "particularly", "one", "with", "slightly",
             "complex", "punctuation", "."]
 
+    def test_get_tokenizer_moses(self):
+        # Test Moses option.
+        # Note that internally, MosesTokenizer converts to unicode if applicable
+        moses_tokenizer = torchtext.data.get_tokenizer("moses")
+        assert moses_tokenizer(self.TEST_STR) == [
+            "A", "string", ",", "particularly", "one", "with", "slightly",
+            "complex", "punctuation", "."]
+
+        # Nonbreaking prefixes should tokenize the final period.
+        assert moses_tokenizer("abc def.") == ["abc", "def", "."]
+
 
 class TestVocab(TorchtextTestCase):
     def test_vectors_get_vecs(self):


### PR DESCRIPTION
Follow up of #783 . `sacremoses` is not available in fbcode. This is the last piece. 