### PR TITLE
Fix csrc header for autodeps

### DIFF
--- a/torchtext/csrc/sentencepiece.cpp
+++ b/torchtext/csrc/sentencepiece.cpp
@@ -1,3 +1,4 @@
+#include <sentencepiece_processor.h>
 #include <sentencepiece_trainer.h>
 #include <torch/script.h>
 


### PR DESCRIPTION
Fix for `fbcode autodeps`.
Although the header file `sentencepiece_processor.h` is included by `sentencepiece_trainer.h`, without explicitly including `sentencepiece_processor.h`, `autodeps` cannot find the dependencies properly.