### PR TITLE
Update vocab.py

### DIFF
--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -447,7 +447,7 @@ class Vectors(object):
         Examples:
             >>> examples = ['chip', 'baby', 'Beautiful']
             >>> vec = text.vocab.GloVe(name='6B', dim=50)
-            >>> ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True)
+            >>> ret = vec.get_vecs_by_tokens(examples, lower_case_backup=True)
         """
         to_reduce = False
 


### PR DESCRIPTION
### Documentation variable error

`ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True) `
to
` ret = vec.get_vecs_by_tokens(examples, lower_case_backup=True)`

"tokens" variable not defined in the example.