### PR TITLE
Removing specials tuple from experimental Vocab

### DIFF
--- a/test/asset/vocab_test.txt
+++ b/test/asset/vocab_test.txt
@@ -1,3 +1,4 @@
+<new_unk>
 a
 b
 c

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -18,7 +18,7 @@ class TestVocab(TorchtextTestCase):
         torch.jit._recursive.concrete_type_store = torch.jit._recursive.ConcreteTypeStore()
 
     def test_has_unk(self):
-        c = OrderedDict({})
+        c = OrderedDict()
         v = Vocab(c)
 
         # check if unk is mapped to the first index
@@ -26,52 +26,49 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v['<unk>'], 0)
 
     def test_new_unk(self):
-        c = OrderedDict({})
-        v = Vocab(c, specials=('<new_unk>',), unk_token="<new_unk>")
+        c = OrderedDict()
+        v = Vocab(c, unk_token="<new_unk>")
 
         # check if new_unk is mapped to the first index
         self.assertEqual(v['<new_unk>'], 0)
         self.assertEqual(v['not_in_it'], 0)
 
     def test_vocab_get_item(self):
-        token_to_freq = {'a': 2, 'b': 2}
+        token_to_freq = {'<unk>': 2, 'a': 2, 'b': 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
-        v = Vocab(c)
+        v = Vocab(c, min_freq=2)
 
         self.assertEqual(v['<unk>'], 0)
-        self.assertEqual(v['<pad>'], 1)
-        self.assertEqual(v['a'], 2)
-        self.assertEqual(v['b'], 3)
+        self.assertEqual(v['a'], 1)
+        self.assertEqual(v['b'], 2)
 
     def test_vocab_set_item(self):
-        c = OrderedDict({'a': 2})
+        c = OrderedDict({'<unk>': 2, 'a': 2})
 
         # add item to end
         v = Vocab(c)
-        v.insert_token('b', 3)
+        v.insert_token('b', 2)
 
         self.assertEqual(v['<unk>'], 0)
-        self.assertEqual(v['<pad>'], 1)
-        self.assertEqual(v['a'], 2)
-        self.assertEqual(v['b'], 3)
+        self.assertEqual(v['a'], 1)
+        self.assertEqual(v['b'], 2)
 
         # add item to middle
-        v = Vocab(c, specials_first=False)
+        v = Vocab(c)
         v.insert_token('b', 0)
 
         self.assertEqual(v['b'], 0)
-        self.assertEqual(v['a'], 1)
-        self.assertEqual(v['<unk>'], 2)
-        self.assertEqual(v['<pad>'], 3)
+        self.assertEqual(v['<unk>'], 1)
+        self.assertEqual(v['a'], 2)
 
     def test_vocab_append_token(self):
         c = OrderedDict({'a': 2})
         v = Vocab(c)
         v.append_token('b')
 
-        self.assertEqual(len(v), 4)
-        self.assertEqual(v['b'], 3)
+        self.assertEqual(len(v), 3)
+        self.assertEqual(v['b'], 2)
 
     def test_vocab_len(self):
         token_to_freq = {'a': 2, 'b': 2, 'c': 2}
@@ -79,17 +76,16 @@ class TestVocab(TorchtextTestCase):
         c = OrderedDict(sorted_by_freq_tuples)
         v = Vocab(c)
 
-        self.assertEqual(len(v), 5)
+        self.assertEqual(len(v), 4)
 
     def test_vocab_basic(self):
         token_to_freq = {'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
 
         c = OrderedDict(sorted_by_freq_tuples)
-        v = Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'])
+        v = Vocab(c, min_freq=3)
 
-        expected_itos = ['<unk>', '<pad>', '<bos>',
-                         'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
+        expected_itos = ['ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world', '<unk>']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
 
         self.assertEqual(v.get_itos(), expected_itos)
@@ -100,42 +96,20 @@ class TestVocab(TorchtextTestCase):
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
 
         c = OrderedDict(sorted_by_freq_tuples)
-        v = Vocab(c, min_freq=3, specials=['<unk>', '<pad>', '<bos>'])
+        v = Vocab(c, min_freq=3)
         jit_v = torch.jit.script(v)
 
-        expected_itos = ['<unk>', '<pad>', '<bos>',
-                         'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
+        expected_itos = ['ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world', '<unk>']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
 
         self.assertEqual(jit_v.get_itos(), expected_itos)
         self.assertEqual(dict(jit_v.get_stoi()), expected_stoi)
 
-    def test_vocab_specials_order(self):
-        token_to_freq = {'a': 2, 'b': 2, 'c': 2}
-        sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
-        c = OrderedDict(sorted_by_freq_tuples)
-
-        # add specials into vocabulary at first
-        v = Vocab(c, specials=['<pad>', '<unk>'])
-        expected_itos = ['<pad>', '<unk>', 'a', 'b', 'c']
-        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
-
-        self.assertEqual(v.get_itos(), expected_itos)
-        self.assertEqual(dict(v.get_stoi()), expected_stoi)
-
-        # add specials into vocabulary at last
-        v = Vocab(c, specials=['<pad>', '<unk>'], specials_first=False)
-        expected_itos = ['a', 'b', 'c', '<pad>', '<unk>']
-        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
-
-        self.assertEqual(v.get_itos(), expected_itos)
-        self.assertEqual(dict(v.get_stoi()), expected_stoi)
-
     def test_vocab_lookup_token(self):
         token_to_freq = {'a': 2, 'b': 2, 'c': 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
-        v = Vocab(c, specials_first=False)
+        v = Vocab(c)
 
         self.assertEqual(v.lookup_token(0), 'a')
 
@@ -143,7 +117,7 @@ class TestVocab(TorchtextTestCase):
         token_to_freq = {'a': 2, 'b': 2, 'c': 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
-        v = Vocab(c, specials_first=False)
+        v = Vocab(c)
 
         indices = [1, 0, 2]
         expected_tokens = ['b', 'a', 'c']
@@ -154,7 +128,7 @@ class TestVocab(TorchtextTestCase):
         token_to_freq = {'a': 2, 'b': 2, 'c': 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
-        v = Vocab(c, specials_first=False)
+        v = Vocab(c)
 
         tokens = ['b', 'a', 'c']
         expected_indices = [1, 0, 2]
@@ -168,18 +142,7 @@ class TestVocab(TorchtextTestCase):
 
         with self.assertRaises(ValueError):
             # Test proper error raised when setting unk token to None
-            Vocab(c, specials=['<unk>', '<bos>'], unk_token=None)
-
-        with self.assertRaises(ValueError):
-            # Test proper error raised when specials token doesn't contain unk_token
-            Vocab(c, specials=['<pad>', '<bos>'])
-
-        with self.assertRaises(ValueError):
-            # Test proper error raised when ordered_dict contains a special token
-            updated_token_to_freq = {'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2, '<pad>': 1}
-            updated_sorted_by_freq_tuples = sorted(updated_token_to_freq.items(), key=lambda x: x[1], reverse=True)
-            updated_c = OrderedDict(updated_sorted_by_freq_tuples)
-            Vocab(updated_c, specials=['<unk>', '<pad>', '<bos>'])
+            Vocab(c, unk_token=None)
 
         with self.assertRaises(RuntimeError):
             # Test proper error raised when setting a token out of bounds
@@ -198,8 +161,7 @@ class TestVocab(TorchtextTestCase):
         c = OrderedDict(sorted_by_freq_tuples)
         v = Vocab(c, min_freq=3)
 
-        expected_itos = ['<unk>', '<pad>',
-                         'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
+        expected_itos = ['ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world', '<unk>']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
 
         self.assertEqual(v.get_itos(), expected_itos)
@@ -216,9 +178,9 @@ class TestVocab(TorchtextTestCase):
         asset_name = 'vocab_test.txt'
         asset_path = get_asset_path(asset_name)
         f = open(asset_path, 'r')
-        v = vocab_from_file_object(f, specials=('<unk>', '<pad>', '<eos>'), specials_first=False)
+        v = vocab_from_file_object(f, unk_token='<new_unk>')
 
-        expected_itos = ['a', 'b', 'c', '<unk>', '<pad>', '<eos>']
+        expected_itos = ['<new_unk>', 'a', 'b', 'c']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
 
         self.assertEqual(v.get_itos(), expected_itos)

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -20,8 +20,8 @@ def _infer_shape(f):
 def vocab_from_file_object(file_like_object, **kwargs):
     r"""Create a `Vocab` object from a file like object.
 
-    Note that the tensor corresponding to each vector is of type `torch.float`.
-    The `file_like_object` should contain tokens seperated by new lines.
+    The `file_like_object` should contain tokens seperated by new lines. Note that the vocab
+    will be created in the order that the tokens first appear in the file (and not by the frequency of tokens).
 
     Format for txt file:
         token1
@@ -58,15 +58,14 @@ class Vocab(nn.Module):
 
     Note that the ordering in which key value pairs were inserted in the `ordered_dict` will be respected when building the vocab.
     Therefore if sorting by token frequency is important to the user, the `ordered_dict` should be created in a way to reflect this.
+    Additionally, the if the `unk_token` isn't found inside of the `ordered_dict`, it will be added to the end of the vocab.
 
     Arguments:
         ordered_dict (collections.OrderedDict): object holding the frequencies of each token found in the data.
         min_freq: The minimum frequency needed to include a token in the vocabulary.
             Values less than 1 will be set to 1. Default: 1.
-        specials: The tuple of special tokens (e.g., padding or eos) that will be prepended/postpended to the vocabulary.
-            based on the `specials_first` flag. The ordering of the tuple will be preserved. Default: ('<unk>', '<pad>')
-        specials_first: Whether to add special tokens into the vocabulary at first. If it is False,
-            they are added into the vocabulary at last. Default: True.
+        unk_token: The default unknown token to use. Default: '<unk>'.
+
 
     Raises:
         ValueError: if a default `unk_token` isn't provided.
@@ -82,28 +81,21 @@ class Vocab(nn.Module):
         >>> v2 = Vocab(OrderedDict([(token, 1) for token in tokens]))
     """
 
-    def __init__(self, ordered_dict, min_freq=1, unk_token='<unk>', specials=('<unk>', '<pad>'), specials_first=True):
+    def __init__(self, ordered_dict, min_freq=1, unk_token='<unk>'):
         super(Vocab, self).__init__()
 
         if not unk_token:
             raise ValueError("A default unk token wasn't provided.")
 
-        if unk_token not in specials:
-            raise ValueError("The unk token wasn't found in the `specials` tuple.")
-
         tokens = []
         for token, freq in ordered_dict.items():
             if freq >= min_freq:
-                if token in specials:
-                    raise ValueError("A `specials` token {} was found inside of `ordered_dict`."
-                                     "Please ensure that the `ordered_dict` doesn't contain any special tokens.".format(token))
                 tokens.append(token)
 
-        # assume special tokens dont appear in ordered_dict
-        if specials_first:
-            tokens = list(specials) + tokens
-        else:
-            tokens += list(specials)
+        if unk_token not in tokens:
+            tokens.append(unk_token)
+            logger.warning("The `unk_token` '{}' wasn't found in the `ordered_dict`."
+                           "Adding the `unk_token` to the end of the Vocab.".format(unk_token))
 
         self.vocab = torch.classes.torchtext.Vocab(tokens, unk_token)
 

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -1,10 +1,12 @@
 from collections import OrderedDict
 import logging
 from typing import Dict, List
+import warnings
 
 import torch
 import torch.nn as nn
 from tqdm import tqdm
+
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +40,7 @@ def vocab_from_file_object(file_like_object, **kwargs):
 
     Examples:
         >>> from torchtext.experimental.vocab import vocab_from_file_object
-        >>> f = open('vocab.csv', 'r')
+        >>> f = open('vocab.txt', 'r')
         >>> v = vocab_from_file_object(f, specials=('<unk>', '<pad>', '<eos>'), specials_first=False)
     """
     ordered_dict = OrderedDict()
@@ -94,9 +96,8 @@ class Vocab(nn.Module):
 
         if unk_token not in tokens:
             tokens.append(unk_token)
-            logger.warning("The `unk_token` '{}' wasn't found in the `ordered_dict`."
-                           "Adding the `unk_token` to the end of the Vocab.".format(unk_token))
-
+            warnings.warn("The `unk_token` '{}' wasn't found in the `ordered_dict`. Adding the `unk_token` "
+                          "to the end of the Vocab.".format(unk_token), RuntimeWarning)
         self.vocab = torch.classes.torchtext.Vocab(tokens, unk_token)
 
     @torch.jit.export


### PR DESCRIPTION
## Description
- Removing `special` tuple from Vocab parameters since it's common that special tokens are defined in `ordered_dict`
- Refer to #890 for more info