### PR TITLE
Fixing bug with vocab token insertion

### DIFF
--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -43,24 +43,28 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v['a'], 1)
         self.assertEqual(v['b'], 2)
 
-    def test_vocab_set_item(self):
+    def test_vocab_insert_token(self):
         c = OrderedDict({'<unk>': 2, 'a': 2})
 
         # add item to end
         v = Vocab(c)
         v.insert_token('b', 2)
 
-        self.assertEqual(v['<unk>'], 0)
-        self.assertEqual(v['a'], 1)
-        self.assertEqual(v['b'], 2)
+        expected_itos = ['<unk>', 'a', 'b']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+
+        self.assertEqual(v.get_itos(), expected_itos)
+        self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
         # add item to middle
         v = Vocab(c)
         v.insert_token('b', 0)
 
-        self.assertEqual(v['b'], 0)
-        self.assertEqual(v['<unk>'], 1)
-        self.assertEqual(v['a'], 2)
+        expected_itos = ['b', '<unk>', 'a']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+
+        self.assertEqual(v.get_itos(), expected_itos)
+        self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
     def test_vocab_append_token(self):
         c = OrderedDict({'a': 2})

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -68,12 +68,11 @@ public:
     }
 
     // need to offset all tokens greater than or equal index by 1
-    for (auto &entry : stoi_) {
-      if (entry.value() >= index) {
-        stoi_.insert_or_assign(entry.key(), std::move(entry.value() + 1));
-      }
+    for (size_t i = index; i < itos_.size(); i++) {
+      stoi_.insert_or_assign(itos_[i], std::move(i + 1));
     }
     stoi_.insert(std::move(token), std::move(index));
+    itos_.insert(itos_.begin() + index, std::move(token));
 
     // need to update unk_index in case token equals unk_token or token inserted
     // before unk_token

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -189,6 +189,6 @@ class Vocab(nn.Module):
     def get_itos(self) -> List[str]:
         r"""
         Returns:
-            stoi (dict): dictionary mapping indices to tokens.
+            itos (dict): dictionary mapping indices to tokens.
         """
         return self.vocab.get_itos()


### PR DESCRIPTION
## Description
- Previously, `itos_` was not being updated when a token was inserted into the Vocab
- Also improved efficiency of offsetting token indices by 1 using `itos_`
- Updated tests to catch bug in the future