### PR TITLE
Updating cpp Vectors class to use order_preserving_flat_hash_map implementation

### DIFF
--- a/benchmark/benchmark_experimental_vectors.py
+++ b/benchmark/benchmark_experimental_vectors.py
@@ -19,6 +19,9 @@ def benchmark_experimental_vectors():
     for (label, text) in train:
         for id in text.tolist():
             tokens.append(vocab.itos[id])
+        
+        if len(tokens) > 1000:
+            break
 
     # existing FastText construction
     print("Existing FastText - Not Jit Mode")

--- a/benchmark/benchmark_experimental_vectors.py
+++ b/benchmark/benchmark_experimental_vectors.py
@@ -19,12 +19,9 @@ def benchmark_experimental_vectors():
     for (label, text) in train:
         for id in text.tolist():
             tokens.append(vocab.itos[id])
-        
-        if len(tokens) > 1000:
-            break
 
     # existing FastText construction
-    print("Existing FastText - Not Jit Mode")
+    print("Existing FastText - Eager Mode")
     t0 = time.monotonic()
     fast_text = FastText()
     print("Construction time:", time.monotonic() - t0)
@@ -36,8 +33,8 @@ def benchmark_experimental_vectors():
     fast_text_experimental = FastTextExperimental(validate_file=False)
     print("Construction time:", time.monotonic() - t0)
 
-    # not jit lookup
-    print("FastText Experimental - Not Jit Mode")
+    # eager lookup
+    print("FastText Experimental - Eager Mode")
     _run_benchmark_lookup(tokens, fast_text_experimental)
 
     # jit lookup

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -30,8 +30,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size())
-          + ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size()) + ", size of vectors: " +
+          std::to_string(vectors.size(0)) + ".");
     }
 
     stovec_.reserve(tokens.size());
@@ -41,7 +41,7 @@ public:
         throw std::runtime_error("Duplicate token found in tokens list: " +
                                  tokens[i]);
       }
-      stovec_[std::move(tokens[i])] = vectors_.select(0, i)]
+      stovec_[std::move(tokens[i])] = vectors_.select(0, i);
     }
   }
 
@@ -70,8 +70,7 @@ public:
       tokens_.push_back(token);
       vectors_ = torch::cat({vectors_, torch::unsqueeze(vector, /*dim=*/0)},
                             /*dim=*/0);
-      stovec_[std::move(token)] = vectors_.select(0, stovec_.size()]
-      
+      stovec_[std::move(token)] = vectors_.select(0, stovec_.size());
     }
   }
 
@@ -113,8 +112,8 @@ c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states) {
         std::move(strings), std::move(tensors[0]), std::move(tensors[1]));
   }
 
-  throw std::runtime_error(
-      "Found unexpected version for serialized Vector: " + version_str + ".");
+  throw std::runtime_error("Found unexpected version for serialized Vector: " +
+                           version_str + ".");
 }
 
 // Registers our custom class with torch.

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -17,7 +17,6 @@ public:
 
   ska_ordered::order_preserving_flat_hash_map<std::string, torch::Tensor>
       stovec_;
-  // Dict<std::string, torch::Tensor> stovec_;
   std::vector<std::string> tokens_;
   torch::Tensor vectors_;
   torch::Tensor unk_tensor_;

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -15,7 +15,9 @@ struct Vectors : torch::CustomClassHolder {
 public:
   const std::string version_str_ = "0.0.1";
 
-  Dict<std::string, torch::Tensor> stovec_;
+  ska_ordered::order_preserving_flat_hash_map<std::string, torch::Tensor>
+      stovec_;
+  // Dict<std::string, torch::Tensor> stovec_;
   std::vector<std::string> tokens_;
   torch::Tensor vectors_;
   torch::Tensor unk_tensor_;
@@ -29,8 +31,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size()) +
-          ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size()) + ", size of vectors: " +
+          std::to_string(vectors.size(0)) + ".");
     }
 
     stovec_.reserve(tokens.size());
@@ -40,14 +42,14 @@ public:
         throw std::runtime_error("Duplicate token found in tokens list: " +
                                  tokens[i]);
       }
-      stovec_.insert(std::move(tokens[i]), vectors_.select(0, i));
+      stovec_.insert_or_assign(std::move(tokens[i]), vectors_.select(0, i));
     }
   }
 
   torch::Tensor __getitem__(const std::string &token) const {
     const auto &item = stovec_.find(token);
     if (item != stovec_.end()) {
-      return item->value();
+      return item->second;
     }
     return unk_tensor_;
   }
@@ -64,7 +66,7 @@ public:
   void __setitem__(const std::string &token, const torch::Tensor &vector) {
     const auto &item = stovec_.find(token);
     if (item != stovec_.end()) {
-      item->value() = vector;
+      item->second = vector;
     } else {
       tokens_.push_back(token);
       vectors_ = torch::cat({vectors_, torch::unsqueeze(vector, /*dim=*/0)},
@@ -111,8 +113,8 @@ c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states) {
         std::move(strings), std::move(tensors[0]), std::move(tensors[1]));
   }
 
-  throw std::runtime_error(
-      "Found unexpected version for serialized Vector: " + version_str + ".");
+  throw std::runtime_error("Found unexpected version for serialized Vector: " +
+                           version_str + ".");
 }
 
 // Registers our custom class with torch.

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -30,8 +30,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size())
-          + ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size()) +
+          ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
     }
 
     stovec_.reserve(tokens.size());

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -30,8 +30,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size()) + ", size of vectors: " +
-          std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size())
+          + ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
     }
 
     stovec_.reserve(tokens.size());
@@ -41,7 +41,7 @@ public:
         throw std::runtime_error("Duplicate token found in tokens list: " +
                                  tokens[i]);
       }
-      stovec_.insert_or_assign(std::move(tokens[i]), vectors_.select(0, i));
+      stovec_[std::move(tokens[i])] = vectors_.select(0, i)]
     }
   }
 
@@ -70,7 +70,8 @@ public:
       tokens_.push_back(token);
       vectors_ = torch::cat({vectors_, torch::unsqueeze(vector, /*dim=*/0)},
                             /*dim=*/0);
-      stovec_.insert_or_assign(token, vectors_.select(0, stovec_.size()));
+      stovec_[std::move(token)] = vectors_.select(0, stovec_.size()]
+      
     }
   }
 
@@ -112,8 +113,8 @@ c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states) {
         std::move(strings), std::move(tensors[0]), std::move(tensors[1]));
   }
 
-  throw std::runtime_error("Found unexpected version for serialized Vector: " +
-                           version_str + ".");
+  throw std::runtime_error(
+      "Found unexpected version for serialized Vector: " + version_str + ".");
 }
 
 // Registers our custom class with torch.

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -30,8 +30,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size()) + ", size of vectors: " +
-          std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size())
+          + ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
     }
 
     stovec_.reserve(tokens.size());
@@ -112,8 +112,8 @@ c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states) {
         std::move(strings), std::move(tensors[0]), std::move(tensors[1]));
   }
 
-  throw std::runtime_error("Found unexpected version for serialized Vector: " +
-                           version_str + ".");
+  throw std::runtime_error(
+      "Found unexpected version for serialized Vector: " + version_str + ".");
 }
 
 // Registers our custom class with torch.


### PR DESCRIPTION
## Description
- Updating Vectors class to use order_preserving_flat_hash_map 

## Benchmarking Results

### Existing FastText - Eager Mode
```
Construction time from file: 778.5076372753829
Construction time from cache: 4.878308408195153

Lookup time: 173.31978496885858
```

### FastText Experimental - `c10::dict`
```
FastText Experimental
Construction time: 670.8132877256721
Construction time from cache: 39.3408519141376

FastText Experimental - Eager Mode
Lookup time: 113.68280134536326

FastText Experimental - Jit Mode
Lookup time: 224.18116508424282
```

### FastText Experimental - `order_preserving_flat_hash_map`
```
Construction time: 824.6348864280153
Construction time from cache: 54.51048343884759

FastText Experimental - Eager Mode
Lookup time: 92.03254385315813

FastText Experimental - Jit Mode
Lookup time: 213.60061646718532
```