### PR TITLE
Vectors lazy tensor view construction

### DIFF
--- a/benchmark/benchmark_experimental_vectors.py
+++ b/benchmark/benchmark_experimental_vectors.py
@@ -19,9 +19,6 @@ def benchmark_experimental_vectors():
     for (label, text) in train:
         for id in text.tolist():
             tokens.append(vocab.itos[id])
-        
-        if len(tokens) > 100:
-            break
 
     # existing FastText construction
     print("Existing FastText - Not Jit Mode")

--- a/benchmark/benchmark_experimental_vectors.py
+++ b/benchmark/benchmark_experimental_vectors.py
@@ -19,6 +19,9 @@ def benchmark_experimental_vectors():
     for (label, text) in train:
         for id in text.tolist():
             tokens.append(vocab.itos[id])
+        
+        if len(tokens) > 100:
+            break
 
     # existing FastText construction
     print("Existing FastText - Not Jit Mode")

--- a/test/experimental/test_vectors.py
+++ b/test/experimental/test_vectors.py
@@ -204,59 +204,59 @@ class TestVectors(TorchtextTestCase):
                 self.assertEqual(jit_vectors_obj[word][:3], expected_fasttext_simple_en[word])
 
     def test_glove(self):
-       # copy the asset file into the expected download location
-       # note that this is just a zip file with the first 100 entries of the GloVe 840B dataset
-       asset_name = 'glove.840B.300d.zip'
-       asset_path = get_asset_path(asset_name)
+        # copy the asset file into the expected download location
+        # note that this is just a zip file with the first 100 entries of the GloVe 840B dataset
+        asset_name = 'glove.840B.300d.zip'
+        asset_path = get_asset_path(asset_name)
 
-       with tempfile.TemporaryDirectory() as dir_name:
-           data_path = os.path.join(dir_name, asset_name)
-           shutil.copy(asset_path, data_path)
-           vectors_obj = GloVe(root=dir_name, validate_file=False)
-           jit_vectors_obj = torch.jit.script(vectors_obj)
+        with tempfile.TemporaryDirectory() as dir_name:
+            data_path = os.path.join(dir_name, asset_name)
+            shutil.copy(asset_path, data_path)
+            vectors_obj = GloVe(root=dir_name, validate_file=False)
+            jit_vectors_obj = torch.jit.script(vectors_obj)
 
-           # The first 3 entries in each vector.
-           expected_glove = {
-               'the': [0.27204, -0.06203, -0.1884],
-               'people': [-0.19686, 0.11579, -0.41091],
-           }
+            # The first 3 entries in each vector.
+            expected_glove = {
+                'the': [0.27204, -0.06203, -0.1884],
+                'people': [-0.19686, 0.11579, -0.41091],
+            }
 
-           for word in expected_glove.keys():
-               self.assertEqual(vectors_obj[word][:3], expected_glove[word])
-               self.assertEqual(jit_vectors_obj[word][:3], expected_glove[word])
+            for word in expected_glove.keys():
+                self.assertEqual(vectors_obj[word][:3], expected_glove[word])
+                self.assertEqual(jit_vectors_obj[word][:3], expected_glove[word])
 
     def test_glove_different_dims(self):
-       # copy the asset file into the expected download location
-       # note that this is just a zip file with 1 line txt files used to test that the
-       # correct files are being loaded
-       asset_name = 'glove.6B.zip'
-       asset_path = get_asset_path(asset_name)
+        # copy the asset file into the expected download location
+        # note that this is just a zip file with 1 line txt files used to test that the
+        # correct files are being loaded
+        asset_name = 'glove.6B.zip'
+        asset_path = get_asset_path(asset_name)
 
-       with tempfile.TemporaryDirectory() as dir_name:
-           data_path = os.path.join(dir_name, asset_name)
-           shutil.copy(asset_path, data_path)
+        with tempfile.TemporaryDirectory() as dir_name:
+            data_path = os.path.join(dir_name, asset_name)
+            shutil.copy(asset_path, data_path)
 
-           glove_50d = GloVe(name='6B', dim=50, root=dir_name, validate_file=False)
-           glove_100d = GloVe(name='6B', dim=100, root=dir_name, validate_file=False)
-           glove_200d = GloVe(name='6B', dim=200, root=dir_name, validate_file=False)
-           glove_300d = GloVe(name='6B', dim=300, root=dir_name, validate_file=False)
-           vectors_objects = [glove_50d, glove_100d, glove_200d, glove_300d]
+            glove_50d = GloVe(name='6B', dim=50, root=dir_name, validate_file=False)
+            glove_100d = GloVe(name='6B', dim=100, root=dir_name, validate_file=False)
+            glove_200d = GloVe(name='6B', dim=200, root=dir_name, validate_file=False)
+            glove_300d = GloVe(name='6B', dim=300, root=dir_name, validate_file=False)
+            vectors_objects = [glove_50d, glove_100d, glove_200d, glove_300d]
 
-           # The first 3 entries in each vector.
-           expected_glove_50d = {
-               'the': [0.418, 0.24968, -0.41242],
-           }
-           expected_glove_100d = {
-               'the': [-0.038194, -0.24487, 0.72812],
-           }
-           expected_glove_200d = {
-               'the': [-0.071549, 0.093459, 0.023738],
-           }
-           expected_glove_300d = {
-               'the': [0.04656, 0.21318, -0.0074364],
-           }
-           expected_gloves = [expected_glove_50d, expected_glove_100d, expected_glove_200d, expected_glove_300d]
+            # The first 3 entries in each vector.
+            expected_glove_50d = {
+                'the': [0.418, 0.24968, -0.41242],
+            }
+            expected_glove_100d = {
+                'the': [-0.038194, -0.24487, 0.72812],
+            }
+            expected_glove_200d = {
+                'the': [-0.071549, 0.093459, 0.023738],
+            }
+            expected_glove_300d = {
+                'the': [0.04656, 0.21318, -0.0074364],
+            }
+            expected_gloves = [expected_glove_50d, expected_glove_100d, expected_glove_200d, expected_glove_300d]
 
-           for vectors_obj, expected_glove in zip(vectors_objects, expected_gloves):
-               for word in expected_glove.keys():
-                   self.assertEqual(vectors_obj[word][:3], expected_glove[word])
+            for vectors_obj, expected_glove in zip(vectors_objects, expected_gloves):
+                for word in expected_glove.keys():
+                    self.assertEqual(vectors_obj[word][:3], expected_glove[word])

--- a/test/experimental/test_vectors.py
+++ b/test/experimental/test_vectors.py
@@ -87,7 +87,6 @@ class TestVectors(TorchtextTestCase):
 
         tokens = ['a']
         vectors = tensorA.unsqueeze(0)
-        print(vectors)
         vectors_obj = Vectors(tokens, vectors, unk_tensor=unk_tensor)
 
         tensorB = torch.tensor([0, 1], dtype=torch.float)
@@ -99,17 +98,22 @@ class TestVectors(TorchtextTestCase):
 
     def test_vectors_load_and_save(self):
         tensorA = torch.tensor([1, 0], dtype=torch.float)
+        tensorB = torch.tensor([0, 1], dtype=torch.float)
         expected_unk_tensor = torch.tensor([0, 0], dtype=torch.float)
 
-        tokens = ['a']
-        vectors = tensorA.unsqueeze(0)
+        tokens = ['a', 'b']
+        vectors = torch.stack((tensorA, tensorB), 0)
         vectors_obj = Vectors(tokens, vectors)
+
+        tensorC = torch.tensor([1, 1], dtype=torch.float)
+        vectors_obj['b'] = tensorC
 
         vector_path = os.path.join(self.test_dir, 'vectors.pt')
         torch.save(vectors_obj, vector_path)
         loaded_vectors_obj = torch.load(vector_path)
 
         self.assertEqual(loaded_vectors_obj['a'], tensorA)
+        self.assertEqual(loaded_vectors_obj['b'], tensorC)
         self.assertEqual(loaded_vectors_obj['not_in_it'], expected_unk_tensor)
 
     def test_errors(self):
@@ -199,61 +203,60 @@ class TestVectors(TorchtextTestCase):
                 self.assertEqual(vectors_obj[word][:3], expected_fasttext_simple_en[word])
                 self.assertEqual(jit_vectors_obj[word][:3], expected_fasttext_simple_en[word])
 
-    # TODO: reenable test once the GloVe dataset url starts working
-    # def test_glove(self):
-    #    # copy the asset file into the expected download location
-    #    # note that this is just a zip file with the first 100 entries of the GloVe 840B dataset
-    #    asset_name = 'glove.840B.300d.zip'
-    #    asset_path = get_asset_path(asset_name)
+    def test_glove(self):
+       # copy the asset file into the expected download location
+       # note that this is just a zip file with the first 100 entries of the GloVe 840B dataset
+       asset_name = 'glove.840B.300d.zip'
+       asset_path = get_asset_path(asset_name)
 
-    #    with tempfile.TemporaryDirectory() as dir_name:
-    #        data_path = os.path.join(dir_name, asset_name)
-    #        shutil.copy(asset_path, data_path)
-    #        vectors_obj = GloVe(root=dir_name, validate_file=False)
-    #        jit_vectors_obj = torch.jit.script(vectors_obj)
+       with tempfile.TemporaryDirectory() as dir_name:
+           data_path = os.path.join(dir_name, asset_name)
+           shutil.copy(asset_path, data_path)
+           vectors_obj = GloVe(root=dir_name, validate_file=False)
+           jit_vectors_obj = torch.jit.script(vectors_obj)
 
-    #        # The first 3 entries in each vector.
-    #        expected_glove = {
-    #            'the': [0.27204, -0.06203, -0.1884],
-    #            'people': [-0.19686, 0.11579, -0.41091],
-    #        }
+           # The first 3 entries in each vector.
+           expected_glove = {
+               'the': [0.27204, -0.06203, -0.1884],
+               'people': [-0.19686, 0.11579, -0.41091],
+           }
 
-    #        for word in expected_glove.keys():
-    #            self.assertEqual(vectors_obj[word][:3], expected_glove[word])
-    #            self.assertEqual(jit_vectors_obj[word][:3], expected_glove[word])
+           for word in expected_glove.keys():
+               self.assertEqual(vectors_obj[word][:3], expected_glove[word])
+               self.assertEqual(jit_vectors_obj[word][:3], expected_glove[word])
 
-    # def test_glove_different_dims(self):
-    #    # copy the asset file into the expected download location
-    #    # note that this is just a zip file with 1 line txt files used to test that the
-    #    # correct files are being loaded
-    #    asset_name = 'glove.6B.zip'
-    #    asset_path = get_asset_path(asset_name)
+    def test_glove_different_dims(self):
+       # copy the asset file into the expected download location
+       # note that this is just a zip file with 1 line txt files used to test that the
+       # correct files are being loaded
+       asset_name = 'glove.6B.zip'
+       asset_path = get_asset_path(asset_name)
 
-    #    with tempfile.TemporaryDirectory() as dir_name:
-    #        data_path = os.path.join(dir_name, asset_name)
-    #        shutil.copy(asset_path, data_path)
+       with tempfile.TemporaryDirectory() as dir_name:
+           data_path = os.path.join(dir_name, asset_name)
+           shutil.copy(asset_path, data_path)
 
-    #        glove_50d = GloVe(name='6B', dim=50, root=dir_name, validate_file=False)
-    #        glove_100d = GloVe(name='6B', dim=100, root=dir_name, validate_file=False)
-    #        glove_200d = GloVe(name='6B', dim=200, root=dir_name, validate_file=False)
-    #        glove_300d = GloVe(name='6B', dim=300, root=dir_name, validate_file=False)
-    #        vectors_objects = [glove_50d, glove_100d, glove_200d, glove_300d]
+           glove_50d = GloVe(name='6B', dim=50, root=dir_name, validate_file=False)
+           glove_100d = GloVe(name='6B', dim=100, root=dir_name, validate_file=False)
+           glove_200d = GloVe(name='6B', dim=200, root=dir_name, validate_file=False)
+           glove_300d = GloVe(name='6B', dim=300, root=dir_name, validate_file=False)
+           vectors_objects = [glove_50d, glove_100d, glove_200d, glove_300d]
 
-    #        # The first 3 entries in each vector.
-    #        expected_glove_50d = {
-    #            'the': [0.418, 0.24968, -0.41242],
-    #        }
-    #        expected_glove_100d = {
-    #            'the': [-0.038194, -0.24487, 0.72812],
-    #        }
-    #        expected_glove_200d = {
-    #            'the': [-0.071549, 0.093459, 0.023738],
-    #        }
-    #        expected_glove_300d = {
-    #            'the': [0.04656, 0.21318, -0.0074364],
-    #        }
-    #        expected_gloves = [expected_glove_50d, expected_glove_100d, expected_glove_200d, expected_glove_300d]
+           # The first 3 entries in each vector.
+           expected_glove_50d = {
+               'the': [0.418, 0.24968, -0.41242],
+           }
+           expected_glove_100d = {
+               'the': [-0.038194, -0.24487, 0.72812],
+           }
+           expected_glove_200d = {
+               'the': [-0.071549, 0.093459, 0.023738],
+           }
+           expected_glove_300d = {
+               'the': [0.04656, 0.21318, -0.0074364],
+           }
+           expected_gloves = [expected_glove_50d, expected_glove_100d, expected_glove_200d, expected_glove_300d]
 
-    #        for vectors_obj, expected_glove in zip(vectors_objects, expected_gloves):
-    #            for word in expected_glove.keys():
-    #                self.assertEqual(vectors_obj[word][:3], expected_glove[word])
+           for vectors_obj, expected_glove in zip(vectors_objects, expected_gloves):
+               for word in expected_glove.keys():
+                   self.assertEqual(vectors_obj[word][:3], expected_glove[word])

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -33,8 +33,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size()) + ", size of vectors: " +
-          std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size()) +
+          ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
     }
 
     stoindex_.reserve(tokens.size());
@@ -133,8 +133,8 @@ c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states) {
         std::move(strings), std::move(tensors[0]), std::move(tensors[1]));
   }
 
-  throw std::runtime_error("Found unexpected version for serialized Vector: " +
-                           version_str + ".");
+  throw std::runtime_error(
+      "Found unexpected version for serialized Vector: " + version_str + ".");
 }
 
 // Registers our custom class with torch.

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -31,8 +31,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size()) + ", size of vectors: " +
-          std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size())
+          + ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
     }
 
     stoindex_.reserve(tokens.size());
@@ -130,8 +130,8 @@ c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states) {
         std::move(strings), std::move(tensors[0]), std::move(tensors[1]));
   }
 
-  throw std::runtime_error("Found unexpected version for serialized Vector: " +
-                           version_str + ".");
+  throw std::runtime_error(
+      "Found unexpected version for serialized Vector: " + version_str + ".");
 }
 
 // Registers our custom class with torch.

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -31,8 +31,8 @@ public:
     if (static_cast<int>(tokens.size()) != vectors.size(0)) {
       throw std::runtime_error(
           "Mismatching sizes for tokens and vectors. Size of tokens: " +
-          std::to_string(tokens.size())
-          + ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
+          std::to_string(tokens.size()) +
+          ", size of vectors: " + std::to_string(vectors.size(0)) + ".");
     }
 
     stoindex_.reserve(tokens.size());


### PR DESCRIPTION
## Description
- Updating Vectors class to use lazy view construction
- Fixed bug where the underlying `vectors_` tensor wasn't being updated on `__setitem__` calls 
- Updated tests to reflect new changes
- Reenabling `GloVe` and `FastText` tests

## Benchmarking Results
### Existing FastText - Eager Mode
```
Construction time from file: 778.5076372753829
Construction time from cache: 4.878308408195153

Lookup time: 173.31978496885858
```

### FastText Experimental - Full Tensor View Construction
```
FastText Experimental
Construction time: 670.8132877256721
Construction time from cache: 39.3408519141376

FastText Experimental - Eager Mode
Lookup time: 113.68280134536326

FastText Experimental - Jit Mode
Lookup time: 224.18116508424282
```

### FastText Experimental - Lazy Tensor View Construction
```
Construction time: 781.7042375288438
Construction time from cache: 54.51048343884759

FastText Experimental - Eager Mode
Lookup time: 92.08985158009455

FastText Experimental - Jit Mode
Lookup time: 222.7318581941072
```

### FastText Experimental - Lazy Tensor View Construction with `order_preserving_flat_hash_map`
```
Construction time: 749.2489242199808
Construction time from cache: 8.490331144072115

FastText Experimental - Eager Mode
Lookup time: 89.18504063109867

FastText Experimental - Jit Mode
Lookup time: 201.71587374410592
```