### PR TITLE
.circleci: Only use the channel we want for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,12 +225,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
       - run:
           name: install binaries
           command: |
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-nightly pytorch
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
             conda install -v -y -c file://$HOME/workspace/conda-bld torchtext
       - run:
           name: smoke test

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -225,12 +225,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
       - run:
           name: install binaries
           command: |
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-nightly pytorch
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
             conda install -v -y -c file://$HOME/workspace/conda-bld torchtext
       - run:
           name: smoke test


### PR DESCRIPTION
Issues were arising when testing release candidates where we would
segfault based on binaries installed from an incorrect channel. This
makes it so that we install from the pytorch-test channel on tags

Similar to https://github.com/pytorch/audio/pull/859

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>