### PR TITLE
Specify torch dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup_info = dict(
     license='BSD',
 
     install_requires=[
-        'tqdm', 'requests', 'torch', 'numpy', 'sentencepiece'
+        'tqdm', 'requests', 'torch == 1.6.0', 'numpy', 'sentencepiece'
     ],
     python_requires='>=3.5',
     classifiers=[


### PR DESCRIPTION
Since torchtext is built against specific torch versions, they need to be specified in the setup.py. Otherwise pip will install incompatible versions.

Fixes #902 