### PR TITLE
Use  images until VC++ 14.27 issue is resolved

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
   windows-cpu:
     machine:
       resource_class: windows.xlarge
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2019-vs2019:canary
       shell: bash.exe
 
 commands:


### PR DESCRIPTION
Fix the master branch with updated Windows image. https://github.com/pytorch/pytorch/pull/43220