### PR TITLE
Modify the default parameters of csv reader owing the unreasonable case.

### DIFF
--- a/torchtext/data/dataset.py
+++ b/torchtext/data/dataset.py
@@ -247,6 +247,11 @@ class TabularDataset(Dataset):
         make_example = {
             'json': Example.fromJSON, 'dict': Example.fromdict,
             'tsv': Example.fromCSV, 'csv': Example.fromCSV}[format]
+        
+        
+        # Because most of case are dealing with text, the default double quotes may cause some problems.
+        if not 'quotechar' in csv_reader_params:
+            csv_reader_params['quotechar'] = None
 
         with io.open(os.path.expanduser(path), encoding="utf8") as f:
             if format == 'csv':


### PR DESCRIPTION
In the default settings of csv reader, the double quote is the default quote symbol which may cause some problems when dealing with sentences, because the corpus usually has a double quote as an inner symbol in the sentence such as conversations.