### PR TITLE
.circleci Bump xcode workers to 9.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - run:
@@ -166,7 +166,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -141,7 +141,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - run:
@@ -166,7 +166,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Upstream is on 9.4.1 and we were experiencing issues when conda-build
was attempting to check for overlinking and failed out due to some files
not existing in xcode 9.0

Similar to https://github.com/pytorch/audio/pull/898

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>