### PR TITLE
Fix a bug in `torchtext.experimental.vocab.vocab_from_file` function

### DIFF
--- a/test/experimental/test_transforms.py
+++ b/test/experimental/test_transforms.py
@@ -19,10 +19,10 @@ class TestTransforms(TorchtextTestCase):
         with open(asset_path, 'r') as f:
             vocab_transform = VocabTransform(vocab_from_file(f))
             self.assertEqual(vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
-                             [[21, 26, 20], [21, 26, 20, 26]])
+                             [[7, 18, 24], [7, 18, 24, 18]])
             jit_vocab_transform = torch.jit.script(vocab_transform.to_ivalue())
             self.assertEqual(jit_vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
-                             [[21, 26, 20], [21, 26, 20, 26]])
+                             [[7, 18, 24], [7, 18, 24, 18]])
 
     def test_vector_transform(self):
         asset_name = 'wiki.en.vec'

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -216,7 +216,7 @@ class TestVocab(TorchtextTestCase):
         f = open(asset_path, 'r')
         v = vocab_from_file(f, unk_token='<new_unk>')
 
-        expected_itos = ['<new_unk>', '<unk>', '<pad>', '<MASK>', '<cls>', '<sep>', 'the', ',', '.', 'of', 'and']
+        expected_itos = ['<new_unk>', 'b', 'a', 'c']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
 
         self.assertEqual(v.get_itos(), expected_itos)

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -216,7 +216,7 @@ class TestVocab(TorchtextTestCase):
         f = open(asset_path, 'r')
         v = vocab_from_file(f, unk_token='<new_unk>')
 
-        expected_itos = ['<new_unk>', 'a', 'b', 'c']
+        expected_itos = ['<new_unk>', '<unk>', '<pad>', '<MASK>', '<cls>', '<sep>', 'the', ',', '.', 'of', 'and']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
 
         self.assertEqual(v.get_itos(), expected_itos)

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -214,7 +214,7 @@ struct CompareTokens {
 std::tuple<IndexDict, StringList>
 _concat_tokens(std::vector<std::shared_ptr<IndexDict>> chunk_counters,
                const std::string &unk_token, const int64_t min_freq,
-               const int64_t num_lines) {
+               const int64_t num_lines, const bool sort_tokens) {
   TORCH_CHECK(chunk_counters.size() > 0,
               "There must be at least 1 chunk to concatenate!");
 
@@ -249,8 +249,10 @@ _concat_tokens(std::vector<std::shared_ptr<IndexDict>> chunk_counters,
   }
 
   // sort tokens by freq
-  CompareTokens compare_tokens;
-  std::sort(token_freq_pairs.begin(), token_freq_pairs.end(), compare_tokens);
+  if (sort_tokens) {
+    CompareTokens compare_tokens;
+    std::sort(token_freq_pairs.begin(), token_freq_pairs.end(), compare_tokens);
+  }
 
   // update unique tokens with correct order
   unique_tokens.clear();
@@ -326,7 +328,7 @@ Vocab _load_vocab_from_file(const std::string &file_path,
   IndexDict stoi;
   StringList tokens;
   std::tie(stoi, tokens) =
-      _concat_tokens(chunk_counters, unk_token, min_freq, num_lines);
+      _concat_tokens(chunk_counters, unk_token, min_freq, num_lines, false);
 
   int64_t unk_index = stoi.find(unk_token)->second;
 
@@ -378,7 +380,7 @@ Vocab _load_vocab_from_raw_text_file(const std::string &file_path,
   IndexDict stoi;
   StringList tokens;
   std::tie(stoi, tokens) =
-      _concat_tokens(chunk_counters, unk_token, min_freq, num_lines);
+      _concat_tokens(chunk_counters, unk_token, min_freq, num_lines, true);
   int64_t unk_index = stoi.find(unk_token)->second;
 
   return Vocab(std::move(tokens), std::move(stoi), unk_token, unk_index);


### PR DESCRIPTION
`vocab_from_file` func calls `_concat_tokens`, which accidentally sorts the tokens by frequency. However, according to the doc of `vocab_from_file` func ([here](https://github.com/pytorch/text/blob/db31b5dc046345c2ef70a7d578757053e0bd3bd9/torchtext/experimental/vocab.py#L49-L51)),  `vocab_from_file` func read the tokens in a text file and pass them to the constructor of Vocab class as the order appears in the text file.