### PR TITLE
add test and update error message for functional.py::load_sp_model

### DIFF
--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -83,9 +83,10 @@ class TestFunctional(TorchtextTestCase):
     def test_sentencepiece_unsupported_input_type(self):
         with self.assertRaisesRegex(
             TypeError,
-            'Unsupported type for spm argument: dict. ' + \
-            'Supported types are: str, io.BufferedReader'):
-            sp_model = load_sp_model(dict())
+            'Unsupported type for spm argument: dict. '
+            'Supported types are: str, io.BufferedReader'
+        ):
+            load_sp_model(dict())
 
     # TODO(Nayef211): remove decorator once https://github.com/pytorch/pytorch/issues/38207 is closed
     @unittest.skipIf(platform.system() == "Windows", "Test is known to fail on Windows.")

--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -82,7 +82,7 @@ class TestFunctional(TorchtextTestCase):
 
     def test_sentencepiece_unsupported_input_type(self):
         with self.assertRaisesRegex(
-            RuntimeError,
+            TypeError,
             'Unsupported type for spm argument: dict. ' + \
             'Supported types are: str, io.BufferedReader'):
             sp_model = load_sp_model(dict())

--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -80,7 +80,7 @@ class TestFunctional(TorchtextTestCase):
         self.assertEqual(list(spm_generator([test_sample]))[0],
                          ref_results)
 
-    def test_sentencepiece_unsupported_input(self):
+    def test_sentencepiece_unsupported_input_type(self):
         with self.assertRaisesRegex(
             RuntimeError,
             'Unsupported type for spm argument: dict. ' + \

--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -80,6 +80,13 @@ class TestFunctional(TorchtextTestCase):
         self.assertEqual(list(spm_generator([test_sample]))[0],
                          ref_results)
 
+    def test_sentencepiece_unsupported_input(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'Unsupported type for spm argument: dict. ' + \
+            'Supported types are: str, io.BufferedReader'):
+            sp_model = load_sp_model(dict())
+
     # TODO(Nayef211): remove decorator once https://github.com/pytorch/pytorch/issues/38207 is closed
     @unittest.skipIf(platform.system() == "Windows", "Test is known to fail on Windows.")
     def test_BasicEnglishNormalize(self):

--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -58,7 +58,7 @@ def load_sp_model(spm):
     elif isinstance(spm, io.BufferedReader):
         return torch.ops.torchtext.load_sp_model_string(spm.read())
     else:
-        raise RuntimeError(
+        raise TypeError(
             f'Unsupported type for spm argument: {type(spm).__name__}. ' + \
             'Supported types are: ' + \
             ', '.join([

--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -58,7 +58,12 @@ def load_sp_model(spm):
     elif isinstance(spm, io.BufferedReader):
         return torch.ops.torchtext.load_sp_model_string(spm.read())
     else:
-        raise RuntimeError('the input of the load_sp_model func is not supported.')
+        raise RuntimeError(
+            f'Unsupported type for spm argument: {type(spm).__name__}. ' + \
+            'Supported types are: ' + \
+            ', '.join([
+                'str', 'io.BufferedReader'
+            ]))
 
 
 def sentencepiece_numericalizer(sp_model):

--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -59,8 +59,8 @@ def load_sp_model(spm):
         return torch.ops.torchtext.load_sp_model_string(spm.read())
     else:
         raise TypeError(
-            f'Unsupported type for spm argument: {type(spm).__name__}. ' + \
-            'Supported types are: ' + \
+            f'Unsupported type for spm argument: {type(spm).__name__}. ' +
+            'Supported types are: ' +
             ', '.join([
                 'str', 'io.BufferedReader'
             ]))


### PR DESCRIPTION
This PR:
- adds test for unsupported input type `test_sentencepiece_unsupported_input_type` ([review comment](https://github.com/pytorch/text/pull/965#discussion_r485065199))
- updates error message listing valid input types and type of input given. ([review comment](https://github.com/pytorch/text/pull/965#discussion_r485064957))

Notes:
- Should we raise [TypeError](https://docs.python.org/3/library/exceptions.html#TypeError) instead of [RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError)?
- Type annotation and static type checking is another option to do that.