### PR TITLE
Fix documentation and naming of torchtext.experimental.vocab factory functions.

### DIFF
--- a/benchmark/benchmark_experimental_vocab.py
+++ b/benchmark/benchmark_experimental_vocab.py
@@ -68,11 +68,11 @@ def benchmark_experimental_vocab_construction(vocab_file_path, is_raw_text=True,
             for _ in range(num_iters):
                 tokenizer = basic_english_normalize()
                 jited_tokenizer = torch.jit.script(tokenizer.to_ivalue())
-                vocab_from_raw_text_file(f, jited_tokenizer, num_cpus=1)
+                build_vocab_from_text_file(f, jited_tokenizer, num_cpus=1)
             print("Construction time:", time.monotonic() - t0)
     else:
         for _ in range(num_iters):
-            vocab_from_file(f)
+            load_vocab_from_text_file(vocab_file_path)
         print("Construction time:", time.monotonic() - t0)
 
 

--- a/benchmark/benchmark_experimental_vocab.py
+++ b/benchmark/benchmark_experimental_vocab.py
@@ -6,8 +6,8 @@ import torch
 from torchtext.experimental.datasets import AG_NEWS
 from torchtext.experimental.vocab import (
     vocab as VocabExperimental,
-    vocab_from_file,
-    vocab_from_raw_text_file
+    load_vocab_from_text_file,
+    build_vocab_from_text_file
 )
 from torchtext.vocab import (
     Vocab,

--- a/benchmark/benchmark_experimental_vocab.py
+++ b/benchmark/benchmark_experimental_vocab.py
@@ -120,8 +120,7 @@ def benchmark_experimental_vocab_lookup(vocab_file_path=None):
         # experimental Vocab construction
         print("Vocab Experimental")
         t0 = time.monotonic()
-        f = open(vocab_file_path, 'r')
-        v_experimental = vocab_from_file(f)
+        v_experimental = load_vocab_from_text_file(vocab_file_path)
         print("Construction time:", time.monotonic() - t0)
     else:
         print("Loading Vocab from AG News")

--- a/docs/source/experimental_vocab.rst
+++ b/docs/source/experimental_vocab.rst
@@ -19,12 +19,12 @@ torchtext.experimental.vocab
 
 .. autofunction:: vocab
 
-:hidden:`vocab_from_file`
+:hidden:`load_vocab_from_text_file`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: vocab_from_file
+.. autofunction:: load_vocab_from_text_file
 
-:hidden:`vocab_from_raw_text_file`
+:hidden:`build_vocab_from_text_file`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: vocab_from_raw_text_file
+.. autofunction:: build_vocab_from_text_file

--- a/examples/data_pipeline/pipelines.py
+++ b/examples/data_pipeline/pipelines.py
@@ -19,7 +19,7 @@ from torchtext.experimental.functional import (
     sequential_transforms,
 )
 from torchtext.experimental.vectors import FastText as FastTextExperimental
-from torchtext.experimental.vocab import vocab_from_file
+from torchtext.experimental.vocab import load_vocab_from_text_file
 from torchtext.vocab import FastText
 
 import argparse
@@ -58,12 +58,11 @@ def build_legacy_torchtext_vocab_pipeline(vocab_file):
 
 def build_experimental_torchtext_pipeline(hf_vocab_file):
     tokenizer = basic_english_normalize()
-    with open(hf_vocab_file, 'r') as f:
-        vocab = vocab_from_file(f)
-        pipeline = TextSequentialTransforms(tokenizer, vocab)
-        jit_pipeline = torch.jit.script(pipeline.to_ivalue())
-        print('jit experimental torchtext pipeline success!')
-        return pipeline, pipeline.to_ivalue(), jit_pipeline
+    vocab = load_vocab_from_text_file(hf_vocab_file)
+    pipeline = TextSequentialTransforms(tokenizer, vocab)
+    jit_pipeline = torch.jit.script(pipeline.to_ivalue())
+    print('jit experimental torchtext pipeline success!')
+    return pipeline, pipeline.to_ivalue(), jit_pipeline
 
 
 def build_legacy_batch_torchtext_vocab_pipeline(vocab_file):

--- a/test/experimental/test_transforms.py
+++ b/test/experimental/test_transforms.py
@@ -5,7 +5,7 @@ from torchtext.experimental.transforms import (
     VectorTransform,
     VocabTransform,
 )
-from torchtext.experimental.vocab import vocab_from_file
+from torchtext.experimental.vocab import load_vocab_from_file
 from torchtext.experimental.vectors import FastText
 import shutil
 import tempfile
@@ -16,13 +16,12 @@ class TestTransforms(TorchtextTestCase):
     def test_vocab_transform(self):
         asset_name = 'vocab_test2.txt'
         asset_path = get_asset_path(asset_name)
-        with open(asset_path, 'r') as f:
-            vocab_transform = VocabTransform(vocab_from_file(f))
-            self.assertEqual(vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
-                             [[7, 18, 24], [7, 18, 24, 18]])
-            jit_vocab_transform = torch.jit.script(vocab_transform.to_ivalue())
-            self.assertEqual(jit_vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
-                             [[7, 18, 24], [7, 18, 24, 18]])
+        vocab_transform = VocabTransform(vocab_from_file(asset_path))
+        self.assertEqual(vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
+                         [[7, 18, 24], [7, 18, 24, 18]])
+        jit_vocab_transform = torch.jit.script(vocab_transform.to_ivalue())
+        self.assertEqual(jit_vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
+                         [[7, 18, 24], [7, 18, 24, 18]])
 
     def test_vector_transform(self):
         asset_name = 'wiki.en.vec'

--- a/test/experimental/test_transforms.py
+++ b/test/experimental/test_transforms.py
@@ -5,7 +5,7 @@ from torchtext.experimental.transforms import (
     VectorTransform,
     VocabTransform,
 )
-from torchtext.experimental.vocab import load_vocab_from_file
+from torchtext.experimental.vocab import load_vocab_from_text_file
 from torchtext.experimental.vectors import FastText
 import shutil
 import tempfile
@@ -16,7 +16,7 @@ class TestTransforms(TorchtextTestCase):
     def test_vocab_transform(self):
         asset_name = 'vocab_test2.txt'
         asset_path = get_asset_path(asset_name)
-        vocab_transform = VocabTransform(vocab_from_file(asset_path))
+        vocab_transform = VocabTransform(vocab_from_text_file(asset_path))
         self.assertEqual(vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
                          [[7, 18, 24], [7, 18, 24, 18]])
         jit_vocab_transform = torch.jit.script(vocab_transform.to_ivalue())

--- a/test/experimental/test_transforms.py
+++ b/test/experimental/test_transforms.py
@@ -16,7 +16,7 @@ class TestTransforms(TorchtextTestCase):
     def test_vocab_transform(self):
         asset_name = 'vocab_test2.txt'
         asset_path = get_asset_path(asset_name)
-        vocab_transform = VocabTransform(vocab_from_text_file(asset_path))
+        vocab_transform = VocabTransform(load_vocab_from_text_file(asset_path))
         self.assertEqual(vocab_transform([['of', 'that', 'new'], ['of', 'that', 'new', 'that']]),
                          [[7, 18, 24], [7, 18, 24, 18]])
         jit_vocab_transform = torch.jit.script(vocab_transform.to_ivalue())

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -213,24 +213,22 @@ class TestVocab(TorchtextTestCase):
     def test_load_vocab_from_text_file(self):
         asset_name = 'vocab_test.txt'
         asset_path = get_asset_path(asset_name)
-        with open(asset_path, 'r') as f:
-            v = load_vocab_from_text_file(f, unk_token='<new_unk>')
-            expected_itos = ['<new_unk>', 'b', 'a', 'c']
-            expected_stoi = {x: index for index, x in enumerate(expected_itos)}
-            self.assertEqual(v.get_itos(), expected_itos)
-            self.assertEqual(dict(v.get_stoi()), expected_stoi)
+        v = load_vocab_from_text_file(asset_path, unk_token='<new_unk>')
+        expected_itos = ['<new_unk>', 'b', 'a', 'c']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+        self.assertEqual(v.get_itos(), expected_itos)
+        self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
     def test_build_vocab_from_text_file(self):
         asset_name = 'vocab_raw_text_test.txt'
         asset_path = get_asset_path(asset_name)
-        with open(asset_path, 'r') as f:
-            tokenizer = basic_english_normalize()
-            jit_tokenizer = torch.jit.script(tokenizer.to_ivalue())
-            v = build_vocab_from_text_file(f, jit_tokenizer, unk_token='<new_unk>')
-            expected_itos = ['<new_unk>', "'", 'after', 'talks', '.', 'are', 'at', 'disappointed',
-                             'fears', 'federal', 'firm', 'for', 'mogul', 'n', 'newall', 'parent',
-                             'pension', 'representing', 'say', 'stricken', 't', 'they', 'turner',
-                             'unions', 'with', 'workers']
-            expected_stoi = {x: index for index, x in enumerate(expected_itos)}
-            self.assertEqual(v.get_itos(), expected_itos)
-            self.assertEqual(dict(v.get_stoi()), expected_stoi)
+        tokenizer = basic_english_normalize()
+        jit_tokenizer = torch.jit.script(tokenizer.to_ivalue())
+        v = build_vocab_from_text_file(asset_path, jit_tokenizer, unk_token='<new_unk>')
+        expected_itos = ['<new_unk>', "'", 'after', 'talks', '.', 'are', 'at', 'disappointed',
+                         'fears', 'federal', 'firm', 'for', 'mogul', 'n', 'newall', 'parent',
+                         'pension', 'representing', 'say', 'stricken', 't', 'they', 'turner',
+                         'unions', 'with', 'workers']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+        self.assertEqual(v.get_itos(), expected_itos)
+        self.assertEqual(dict(v.get_stoi()), expected_stoi)

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -10,8 +10,8 @@ from test.common.torchtext_test_case import TorchtextTestCase
 from torchtext.experimental.transforms import basic_english_normalize
 from torchtext.experimental.vocab import (
     vocab,
-    vocab_from_file,
-    vocab_from_raw_text_file
+    load_vocab_from_text_file,
+    build_vocab_from_text_file
 )
 
 
@@ -210,23 +210,23 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
 
-    def test_vocab_from_file(self):
+    def test_load_vocab_from_text_file(self):
         asset_name = 'vocab_test.txt'
         asset_path = get_asset_path(asset_name)
         with open(asset_path, 'r') as f:
-            v = vocab_from_file(f, unk_token='<new_unk>')
+            v = load_vocab_from_text_file(f, unk_token='<new_unk>')
             expected_itos = ['<new_unk>', 'b', 'a', 'c']
             expected_stoi = {x: index for index, x in enumerate(expected_itos)}
             self.assertEqual(v.get_itos(), expected_itos)
             self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-    def test_vocab_from_raw_text_file(self):
+    def test_build_vocab_from_text_file(self):
         asset_name = 'vocab_raw_text_test.txt'
         asset_path = get_asset_path(asset_name)
         with open(asset_path, 'r') as f:
             tokenizer = basic_english_normalize()
             jit_tokenizer = torch.jit.script(tokenizer.to_ivalue())
-            v = vocab_from_raw_text_file(f, jit_tokenizer, unk_token='<new_unk>')
+            v = build_vocab_from_text_file(f, jit_tokenizer, unk_token='<new_unk>')
             expected_itos = ['<new_unk>', "'", 'after', 'talks', '.', 'are', 'at', 'disappointed',
                              'fears', 'federal', 'firm', 'for', 'mogul', 'n', 'newall', 'parent',
                              'pension', 'representing', 'say', 'stricken', 't', 'they', 'turner',

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -63,7 +63,7 @@ PYBIND11_MODULE(_torchtext, m) {
   m.def("_load_token_and_vectors_from_file",
         &_load_token_and_vectors_from_file);
   m.def("_load_vocab_from_file", &_load_vocab_from_file);
-  m.def("_load_vocab_from_raw_text_file", _load_vocab_from_raw_text_file);
+  m.def("_build_vocab_from_text_file", _build_vocab_from_text_file);
 }
 
 // Registers our custom classes with torch.

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -336,9 +336,9 @@ Vocab _load_vocab_from_file(const std::string &file_path,
 }
 
 Vocab _build_vocab_from_text_file(const std::string &file_path,
-                                     const std::string &unk_token,
-                                     const int64_t min_freq,
-                                     const int64_t num_cpus, py::object fn) {
+                                  const std::string &unk_token,
+                                  const int64_t min_freq,
+                                  const int64_t num_cpus, py::object fn) {
   std::cerr << "[INFO] Reading file " << file_path << std::endl;
 
   torch::jit::script::Module module(*torch::jit::as_module(fn));

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -335,7 +335,7 @@ Vocab _load_vocab_from_file(const std::string &file_path,
   return Vocab(std::move(tokens), std::move(stoi), unk_token, unk_index);
 }
 
-Vocab _load_vocab_from_raw_text_file(const std::string &file_path,
+Vocab _build_vocab_from_text_file(const std::string &file_path,
                                      const std::string &unk_token,
                                      const int64_t min_freq,
                                      const int64_t num_cpus, py::object fn) {

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -42,9 +42,8 @@ Vocab _load_vocab_from_file(const std::string &file_path,
                             const std::string &unk_token,
                             const int64_t min_freq, const int64_t num_cpus);
 Vocab _build_vocab_from_text_file(const std::string &file_path,
-                                     const std::string &unk_token,
-                                     const int64_t min_freq,
-                                     const int64_t num_cpus,
-                                     py::object tokenizer);
+                                  const std::string &unk_token,
+                                  const int64_t min_freq,
+                                  const int64_t num_cpus, py::object tokenizer);
 
 } // namespace torchtext

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -41,7 +41,7 @@ VocabStates _set_vocab_states(const c10::intrusive_ptr<Vocab> &self);
 Vocab _load_vocab_from_file(const std::string &file_path,
                             const std::string &unk_token,
                             const int64_t min_freq, const int64_t num_cpus);
-Vocab _load_vocab_from_raw_text_file(const std::string &file_path,
+Vocab _build_vocab_from_text_file(const std::string &file_path,
                                      const std::string &unk_token,
                                      const int64_t min_freq,
                                      const int64_t num_cpus,

--- a/torchtext/experimental/transforms.py
+++ b/torchtext/experimental/transforms.py
@@ -184,9 +184,8 @@ class VocabTransform(nn.Module):
 
     Example:
         >>> import torch
-        >>> from torchtext.experimental.vocab import vocab_from_file_object
-        >>> f = open('vocab.txt', 'r')
-        >>> vocab_transform = VocabTransform(vocab_from_file_object(f))
+        >>> from torchtext.experimental.vocab import load_vocab_from_text_file
+        >>> vocab_transform = VocabTransform(load_vocab_from_text_file('vocab.txt'))
         >>> jit_vocab_transform = torch.jit.script(vocab_transform.to_ivalue())
     """
 

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -43,7 +43,7 @@ def build_vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token
 
 
 def load_vocab_from_text_file(file_path, min_freq=1, unk_token='<unk>', num_cpus=4):
-    r"""Create a `Vocab` object from a text file.
+    r"""Create a `Vocab` object from a text file of tokens.
     The `file_path` should point to a text file where each line represents a token. The vocab
     will be created in the order that the tokens first appear in the file.
     Format for txt file:
@@ -61,9 +61,8 @@ def load_vocab_from_text_file(file_path, min_freq=1, unk_token='<unk>', num_cpus
     Returns:
         Vocab: a `Vocab` object.
     Examples:
-        >>> from torchtext.experimental.vocab import vocab_from_file
-        >>> f = open('vocab.txt', 'r')
-        >>> v = vocab_from_file(f)
+        >>> from torchtext.experimental.vocab import load_vocab_from_text_file
+        >>> v = load_vocab_from_text_file('vocab.txt')
     """
     vocab_obj = _load_vocab_from_file(file_path, unk_token, min_freq, num_cpus)
     return Vocab(vocab_obj)

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -13,34 +13,31 @@ from torchtext._torchtext import (
 logger = logging.getLogger(__name__)
 
 
-def vocab_from_raw_text_file(file_object, jited_tokenizer, min_freq=1, unk_token='<unk>', num_cpus=4):
-    r"""Create a `Vocab` object from a raw text file.
+def vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token='<unk>', num_cpus=4):
+    r"""Build a `Vocab` object from a text file.
 
-    The `file_object` can contain any raw text. This function applies a generic JITed tokenizer in
-    parallel to the text. Note that the vocab will be created in the order that the tokens first appear
-    in the file (and not by the frequency of tokens).
+    The `file_path` can contain any raw text. This function applies a generic JITed tokenizer in
+    parallel to each line of the text and uses the resulting tokens to construct a vocabulary.
 
     Args:
-        file_object (FileObject): a file object to read data from.
+        file_path (str): path to text file
         jited_tokenizer (ScriptModule): a tokenizer that has been JITed using `torch.jit.script`
         min_freq: The minimum frequency needed to include a token in the vocabulary.
             Values less than 1 will be set to 1. Default: 1.
-        unk_token: The default unknown token to use. Default: '<unk>'.
+        unk_token: The unknown token to use. Default: '<unk>'.
         num_cpus (int): the number of cpus to use when loading the vectors from file. Default: 4.
 
     Returns:
         Vocab: a `Vocab` object.
 
     Examples:
-        >>> from torchtext.experimental.vocab import vocab_from_raw_text_file
+        >>> from torchtext.experimental.vocab import vocab_from_text_file
         >>> from torchtext.experimental.transforms import basic_english_normalize
-        >>> f = open('vocab.txt', 'r')
-        >>>     tokenizer = basic_english_normalize()
         >>> tokenizer = basic_english_normalize()
         >>> jit_tokenizer = torch.jit.script(tokenizer.to_ivalue())
-        >>> v = vocab_from_raw_text_file(f, jit_tokenizer)
+        >>> v = vocab_from_text_file(my_dataset.txt, jit_tokenizer)
     """
-    vocab_obj = _load_vocab_from_raw_text_file(file_object.name, unk_token, min_freq, num_cpus, jited_tokenizer)
+    vocab_obj = _build_vocab_from_raw_text_file(file_object.name, unk_token, min_freq, num_cpus, jited_tokenizer)
     return Vocab(vocab_obj)
 
 

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -7,17 +7,18 @@ import torch.nn as nn
 from torchtext._torchtext import (
     Vocab as VocabPybind,
     _load_vocab_from_file,
-    _load_vocab_from_raw_text_file
+    _build_vocab_from_text_file
 )
 
 logger = logging.getLogger(__name__)
 
 
-def vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token='<unk>', num_cpus=4):
+def build_vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token='<unk>', num_cpus=4):
     r"""Build a `Vocab` object from a text file.
 
-    The `file_path` can contain any raw text. This function applies a generic JITed tokenizer in
-    parallel to each line of the text and uses the resulting tokens to construct a vocabulary.
+    The `file_path` can point to a text file containing any raw text. This function applies a
+    generic JITed tokenizer in parallel to each line of the text and uses the resulting tokens
+    to construct a vocabulary.
 
     Args:
         file_path (str): path to text file
@@ -25,7 +26,7 @@ def vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token='<unk
         min_freq: The minimum frequency needed to include a token in the vocabulary.
             Values less than 1 will be set to 1. Default: 1.
         unk_token: The unknown token to use. Default: '<unk>'.
-        num_cpus (int): the number of cpus to use when loading the vectors from file. Default: 4.
+        num_cpus (int): the number of cpus to use to build the vocabulary. Default: 4.
 
     Returns:
         Vocab: a `Vocab` object.
@@ -37,25 +38,25 @@ def vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token='<unk
         >>> jit_tokenizer = torch.jit.script(tokenizer.to_ivalue())
         >>> v = vocab_from_text_file(my_dataset.txt, jit_tokenizer)
     """
-    vocab_obj = _build_vocab_from_raw_text_file(file_object.name, unk_token, min_freq, num_cpus, jited_tokenizer)
+    vocab_obj = _build_vocab_from_text_file(file_path, unk_token, min_freq, num_cpus, jited_tokenizer)
     return Vocab(vocab_obj)
 
 
-def vocab_from_file(file_object, min_freq=1, unk_token='<unk>', num_cpus=4):
+def load_vocab_from_text_file(file_path, min_freq=1, unk_token='<unk>', num_cpus=4):
     r"""Create a `Vocab` object from a text file.
-    The `file_object` should contain tokens separated by new lines. Note that the vocab
-    will be created in the order that the tokens first appear in the file (and not by the frequency of tokens).
+    The `file_path` should point to a text file where each line represents a token. The vocab
+    will be created in the order that the tokens first appear in the file.
     Format for txt file:
         token1
         token2
         ...
         token_n
     Args:
-        file_object (FileObject): a file like object to read data from.
+        file_path (str): path to text file
         min_freq: The minimum frequency needed to include a token in the vocabulary.
             Values less than 1 will be set to 1. Default: 1.
-        unk_token: The default unknown token to use. Default: '<unk>'.
-        num_cpus (int): the number of cpus to use when loading the vectors from file. Default: 4.
+        unk_token: The unknown token to use. Default: '<unk>'.
+        num_cpus (int): the number of cpus to load the vocabulary. Default: 4.
 
     Returns:
         Vocab: a `Vocab` object.
@@ -64,7 +65,7 @@ def vocab_from_file(file_object, min_freq=1, unk_token='<unk>', num_cpus=4):
         >>> f = open('vocab.txt', 'r')
         >>> v = vocab_from_file(f)
     """
-    vocab_obj = _load_vocab_from_file(file_object.name, unk_token, min_freq, num_cpus)
+    vocab_obj = _load_vocab_from_file(file_path, unk_token, min_freq, num_cpus)
     return Vocab(vocab_obj)
 
 


### PR DESCRIPTION
a) The documentation doesn't clearly state that one factory function is meant to be used to construct a Vocabulary from a dataset (e.g. AG_NEWS) and another is meant to be used to load a vocabulary from a text file that contains a list of tokens (as you might construct when filtering and sorting text files on the command line).
b) factory function vocab_from_file_object doesn't exist.