### PR TITLE
Avoid unnecessary memory allocations in translation datasets and fix critical bugs.

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -129,8 +129,8 @@ class TestDataset(TorchtextTestCase):
         # smoke test to ensure multi30k works properly
         train_dataset, valid_dataset, test_dataset = Multi30k()
         self.assertEqual(len(train_dataset), 29000)
-        self.assertEqual(len(valid_dataset), 1000)
-        self.assertEqual(len(test_dataset), 1014)
+        self.assertEqual(len(valid_dataset), 1014)
+        self.assertEqual(len(test_dataset), 1000)
 
         de_vocab, en_vocab = train_dataset.get_vocab()
         de_tokens_ids = [
@@ -146,13 +146,13 @@ class TestDataset(TorchtextTestCase):
         self.assertEqual(en_tokens_ids,
                          [17, 23, 1167, 806, 15, 55, 82, 334, 1337])
 
-        datafile = os.path.join(self.project_root, ".data", "train*")
+        datafile = os.path.join(self.project_root, ".data", "Multi30k", "train*")
         conditional_remove(datafile)
-        datafile = os.path.join(self.project_root, ".data", "val*")
+        datafile = os.path.join(self.project_root, ".data", "Multi30k", "val*")
         conditional_remove(datafile)
-        datafile = os.path.join(self.project_root, ".data", "test*")
+        datafile = os.path.join(self.project_root, ".data", "Multi30k", "test*")
         conditional_remove(datafile)
-        datafile = os.path.join(self.project_root, ".data",
+        datafile = os.path.join(self.project_root, ".data", "Multi30k",
                                 "multi30k_task*.tar.gz")
         conditional_remove(datafile)
 

--- a/torchtext/experimental/datasets/raw/language_modeling.py
+++ b/torchtext/experimental/datasets/raw/language_modeling.py
@@ -2,6 +2,7 @@ import torch
 import logging
 import io
 from torchtext.utils import download_from_url, extract_archive
+from torchtext.experimental.datasets.raw.utils import process_data_select
 
 URLS = {
     'WikiText2':
@@ -48,10 +49,7 @@ class RawTextIterableDataset(torch.utils.data.IterableDataset):
 
 
 def _setup_datasets(dataset_name, root='.data', data_select=('train', 'test', 'valid'), **kwargs):
-    if isinstance(data_select, str):
-        data_select = [data_select]
-    if not set(data_select).issubset(set(('train', 'test', 'valid'))):
-        raise TypeError('data_select is not supported!')
+    data_select = process_data_select(data_select)
 
     if dataset_name == 'PennTreebank':
         extracted_files = []

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -131,7 +131,8 @@ def _setup_datasets(dataset_name,
     # We stand to download a lot of files for some of
     # these datasets. Creating a subfolder makes that more
     # manageable.
-    download_root = os.path.join(root, dataset_name)
+    download_root = root
+    # download_root = os.path.join(root, dataset_name)
     os.makedirs(download_root, exist_ok=True)
     extracted_files = []
     if isinstance(URLS[dataset_name], list):

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 from torchtext.utils import (download_from_url, extract_archive,
                              unicode_csv_reader)
+from torchtext.experimental.datasets.raw.utils import process_data_select
 
 URLS = {
     'Multi30k': [
@@ -121,10 +122,11 @@ def _setup_datasets(dataset_name,
                     valid_filenames,
                     test_filenames,
                     root='.data',
-                    data_select=('train', 'test', 'valid')):
+                    data_select=('train', 'valid', 'test')):
     if not isinstance(train_filenames, tuple) and not isinstance(valid_filenames, tuple) \
             and not isinstance(test_filenames, tuple):
         raise ValueError("All filenames must be tuples")
+    data_select = process_data_select(data_select)
 
     filenames = {'train': train_filenames, 'valid': valid_filenames, 'test': test_filenames}
 
@@ -160,6 +162,8 @@ def _setup_datasets(dataset_name,
             file_archives.append(fname)
 
     datasets = []
+    print('data_select')
+    print(data_select)
     for key in data_select:
         src, tgt = filenames[key]
         data_filenames = _construct_filepaths(file_archives, src, tgt)

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -131,8 +131,7 @@ def _setup_datasets(dataset_name,
     # We stand to download a lot of files for some of
     # these datasets. Creating a subfolder makes that more
     # manageable.
-    download_root = root
-    # download_root = os.path.join(root, dataset_name)
+    download_root = os.path.join(root, dataset_name)
     os.makedirs(download_root, exist_ok=True)
     extracted_files = []
     if isinstance(URLS[dataset_name], list):

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -120,7 +120,8 @@ def _setup_datasets(dataset_name,
                     train_filenames,
                     valid_filenames,
                     test_filenames,
-                    root='.data'):
+                    root='.data',
+                    data_select=('train', 'test', 'valid')):
     if not isinstance(train_filenames, tuple) and not isinstance(valid_filenames, tuple) \
             and not isinstance(test_filenames, tuple):
         raise ValueError("All filenames must be tuples")
@@ -167,7 +168,7 @@ def _setup_datasets(dataset_name,
                 "Files are not found for data type {}".format(key))
 
     datasets = []
-    for key in data_filenames.keys():
+    for key in data_select:
         src_data_iter = _read_text_iterator(data_filenames[key][0])
         tgt_data_iter = _read_text_iterator(data_filenames[key][1])
 
@@ -180,6 +181,7 @@ def _setup_datasets(dataset_name,
 class RawTranslationIterableDataset(torch.utils.data.IterableDataset):
     """Defines an abstraction for raw text iterable datasets.
     """
+
     def __init__(self, src_iterator, tgt_iterator):
         """Initiate text-classification dataset.
         """
@@ -213,7 +215,8 @@ class RawTranslationIterableDataset(torch.utils.data.IterableDataset):
 def Multi30k(train_filenames=("train.de", "train.en"),
              valid_filenames=("val.de", "val.en"),
              test_filenames=("test_2016_flickr.de", "test_2016_flickr.en"),
-             root='.data'):
+             root='.data',
+             data_select=('train', 'test', 'valid')):
     """ Define translation datasets: Multi30k
         Separately returns train/valid/test datasets as a tuple
         The available dataset include:
@@ -275,6 +278,13 @@ def Multi30k(train_filenames=("train.de", "train.en"),
         test_filenames: the source and target filenames for test.
             Default: ('test2016.de', 'test2016.en')
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tuple for the returned datasets
+            (Default: ('train', 'test','valid'))
+            By default, all the three datasets (train, test, valid) are generated. Users
+            could also choose any one or two of them, for example ('train', 'test') or
+            just a string 'train'. If 'train' is not in the tuple or string, a vocab
+            object should be provided which will be used to process valid and/or test
+            data.
 
     Examples:
         >>> from torchtext.datasets import Multi30k
@@ -284,7 +294,8 @@ def Multi30k(train_filenames=("train.de", "train.en"),
                            train_filenames=train_filenames,
                            valid_filenames=valid_filenames,
                            test_filenames=test_filenames,
-                           root=root)
+                           root=root,
+                           data_select=data_select)
 
 
 def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
@@ -292,7 +303,8 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
                            'IWSLT16.TED.tst2013.de-en.en'),
           test_filenames=('IWSLT16.TED.tst2014.de-en.de',
                           'IWSLT16.TED.tst2014.de-en.en'),
-          root='.data'):
+          root='.data',
+          data_select=('train', 'test', 'valid')):
     """ Define translation datasets: IWSLT
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -440,6 +452,13 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
         test_filenames: the source and target filenames for test.
             Default: ('IWSLT16.TED.tst2014.de-en.de', 'IWSLT16.TED.tst2014.de-en.en')
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tuple for the returned datasets
+            (Default: ('train', 'test','valid'))
+            By default, all the three datasets (train, test, valid) are generated. Users
+            could also choose any one or two of them, for example ('train', 'test') or
+            just a string 'train'. If 'train' is not in the tuple or string, a vocab
+            object should be provided which will be used to process valid and/or test
+            data.
 
     Examples:
         >>> from torchtext.datasets.raw import IWSLT
@@ -456,6 +475,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
         valid_filenames=valid_filenames,
         test_filenames=test_filenames,
         root=root,
+        data_select=data_select
     )
 
 
@@ -465,7 +485,8 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
                            'newstest2013.tok.bpe.32000.en'),
           test_filenames=('newstest2014.tok.bpe.32000.de',
                           'newstest2014.tok.bpe.32000.en'),
-          root='.data'):
+          root='.data',
+          data_select=('train', 'test', 'valid')):
     """ Define translation datasets: WMT14
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -528,6 +549,13 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
         test_filenames: the source and target filenames for test.
             Default: ('newstest2014.tok.bpe.32000.de', 'newstest2014.tok.bpe.32000.en')
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tuple for the returned datasets
+            (Default: ('train', 'test','valid'))
+            By default, all the three datasets (train, test, valid) are generated. Users
+            could also choose any one or two of them, for example ('train', 'test') or
+            just a string 'train'. If 'train' is not in the tuple or string, a vocab
+            object should be provided which will be used to process valid and/or test
+            data.
 
     Examples:
         >>> from torchtext.datasets import WMT14
@@ -538,7 +566,8 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
                            train_filenames=train_filenames,
                            valid_filenames=valid_filenames,
                            test_filenames=test_filenames,
-                           root=root)
+                           root=root,
+                           data_select=data_select)
 
 
 DATASETS = {'Multi30k': Multi30k, 'IWSLT': IWSLT, 'WMT14': WMT14}

--- a/torchtext/experimental/datasets/raw/utils.py
+++ b/torchtext/experimental/datasets/raw/utils.py
@@ -1,0 +1,8 @@
+def process_data_select(data_select):
+    if isinstance(data_select, str):
+        data_select = (data_select,)
+    if not isinstance(data_select, tuple):
+        raise TypeError('Expected tuple for data_select, got {} instead.'.format(type(data_select)))
+    if not set(data_select).issubset(set(('train', 'test', 'valid'))):
+        raise TypeError('Given data_select {} is not supported!'.format(data_select))
+    return data_select

--- a/torchtext/experimental/datasets/raw/utils.py
+++ b/torchtext/experimental/datasets/raw/utils.py
@@ -2,7 +2,7 @@ def process_data_select(data_select):
     if isinstance(data_select, str):
         data_select = (data_select,)
     if not isinstance(data_select, tuple):
-        raise TypeError('Expected tuple for data_select, got {} instead.'.format(type(data_select)))
+        raise TypeError('Expected tuple or string for data_select, got {} instead.'.format(type(data_select)))
     if not set(data_select).issubset(set(('train', 'test', 'valid'))):
         raise TypeError('Given data_select {} is not supported!'.format(data_select))
     return data_select

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -38,9 +38,9 @@ def _setup_datasets(dataset_name,
 
     def build_raw_iter(raw_iter=None):
         raw_iter_ = raw.translation.DATASETS[dataset_name](train_filenames=train_filenames,
-                                               valid_filenames=valid_filenames,
-                                               test_filenames=test_filenames,
-                                               root=root, data_select=data_select)
+                                                           valid_filenames=valid_filenames,
+                                                           test_filenames=test_filenames,
+                                                           root=root, data_select=data_select)
         if raw_iter is None:
             raw_iter = {}
         for i, name in enumerate(data_select):
@@ -53,8 +53,8 @@ def _setup_datasets(dataset_name,
     vocab_ = len(vocab) * [None]
     for i in range(len(vocab)):
         vocab_[i] = build_vocab(raw_iter.pop("train"),
-                               tokenizer[i],
-                               index=i)
+                                tokenizer[i],
+                                index=i)
         raw_iter = build_raw_iter()
     vocab = tuple(vocab_)
     logging.info('src Vocab has {} entries'.format(len(vocab[0])))

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -18,7 +18,7 @@ def _setup_datasets(dataset_name,
                     train_filenames,
                     valid_filenames,
                     test_filenames,
-                    data_select=('train', 'test', 'valid'),
+                    data_select=('train', 'valid', 'test'),
                     root='.data',
                     vocab=(None, None),
                     tokenizer=(None, None)):
@@ -38,7 +38,7 @@ def _setup_datasets(dataset_name,
     def build_raw_iter(raw_iter):
         for i, name in enumerate(data_select):
             if name not in raw_iter:
-                raw_iter[name] = raw.translation.DATASETS[dataset_name](
+                raw_iter[name], = raw.translation.DATASETS[dataset_name](
                     train_filenames=train_filenames,
                     valid_filenames=valid_filenames,
                     test_filenames=test_filenames,
@@ -71,8 +71,7 @@ def _setup_datasets(dataset_name,
 
     logging.info('Building datasets for {}'.format(data_select))
     transforms = tuple(build_transform(v, t) for v, t in zip(vocab, tokenizer))
-    return tuple(TranslationDataset(data, vocab, transforms)
-                 for data in raw_data.values())
+    return tuple(TranslationDataset(raw_data[name], vocab, transforms) for name in data_select)
 
 
 class TranslationDataset(torch.utils.data.Dataset):

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -21,8 +21,7 @@ def _setup_datasets(dataset_name,
                     data_select=('train', 'test', 'valid'),
                     root='.data',
                     vocab=(None, None),
-                    tokenizer=(None, None),
-                    removed_tokens=['<unk>']):
+                    tokenizer=(None, None)):
     if 'train' not in data_select and None in vocab:
         raise TypeError("If train is not selected must pass Vocab for both source and target.")
     if vocab[0] is not None and not isinstance(vocab[0], Vocab):
@@ -36,26 +35,24 @@ def _setup_datasets(dataset_name,
         get_tokenizer("spacy", language='de_core_news_sm') if tokenizer[0] is None else tokenizer[0],
         get_tokenizer("spacy", language='en_core_web_sm') if tokenizer[1] is None else tokenizer[1])
 
-    def build_raw_iter(raw_iter=None):
-        raw_iter_ = raw.translation.DATASETS[dataset_name](train_filenames=train_filenames,
-                                                           valid_filenames=valid_filenames,
-                                                           test_filenames=test_filenames,
-                                                           root=root, data_select=data_select)
-        if raw_iter is None:
-            raw_iter = {}
+    def build_raw_iter(raw_iter):
         for i, name in enumerate(data_select):
             if name not in raw_iter:
-                raw_iter[name] = raw_iter_[i]
+                raw_iter[name] = raw.translation.DATASETS[dataset_name](
+                    train_filenames=train_filenames,
+                    valid_filenames=valid_filenames,
+                    test_filenames=test_filenames,
+                    root=root, data_select=name)
         return raw_iter
-    raw_iter = build_raw_iter()
 
+    raw_iter = build_raw_iter({})
     # pop train iterator to force repopulation
     vocab_ = len(vocab) * [None]
     for i in range(len(vocab)):
         vocab_[i] = build_vocab(raw_iter.pop("train"),
                                 tokenizer[i],
                                 index=i)
-        raw_iter = build_raw_iter()
+        raw_iter = build_raw_iter(raw_iter)
     vocab = tuple(vocab_)
     logging.info('src Vocab has {} entries'.format(len(vocab[0])))
     logging.info('tgt Vocab has {} entries'.format(len(vocab[1])))
@@ -130,8 +127,7 @@ def Multi30k(train_filenames=("train.de", "train.en"),
              tokenizer=(None, None),
              root='.data',
              vocab=(None, None),
-             data_select=('train', 'valid', 'test'),
-             removed_tokens=['<unk>']):
+             data_select=('train', 'valid', 'test')):
     """ Define translation datasets: Multi30k
         Separately returns train/valid/test datasets as a tuple
 
@@ -158,7 +154,6 @@ def Multi30k(train_filenames=("train.de", "train.en"),
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
-        removed_tokens: removed tokens from output dataset (Default: '<unk>')
         The available dataset include:
             test_2016_flickr.cs
             test_2016_flickr.de
@@ -226,8 +221,7 @@ def Multi30k(train_filenames=("train.de", "train.en"),
                            tokenizer=tokenizer,
                            root=root,
                            data_select=data_select,
-                           vocab=vocab,
-                           removed_tokens=removed_tokens)
+                           vocab=vocab)
 
 
 def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
@@ -238,8 +232,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
           tokenizer=(None, None),
           root='.data',
           vocab=(None, None),
-          data_select=('train', 'valid', 'test'),
-          removed_tokens=['<unk>']):
+          data_select=('train', 'valid', 'test')):
     """ Define translation datasets: IWSLT
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -267,7 +260,6 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
-        removed_tokens: removed tokens from output dataset (Default: '<unk>')
         The available datasets include:
             IWSLT16.TED.dev2010.ar-en.ar
             IWSLT16.TED.dev2010.ar-en.en
@@ -423,8 +415,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
                            tokenizer=tokenizer,
                            root=root,
                            data_select=data_select,
-                           vocab=vocab,
-                           removed_tokens=removed_tokens)
+                           vocab=vocab)
 
 
 def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
@@ -436,8 +427,7 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
           tokenizer=(None, None),
           root='.data',
           vocab=(None, None),
-          data_select=('train', 'valid', 'test'),
-          removed_tokens=['<unk>']):
+          data_select=('train', 'valid', 'test')):
     """ Define translation datasets: WMT14
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -515,7 +505,6 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
-        removed_tokens: removed tokens from output dataset (Default: '<unk>')
 
     Examples:
         >>> from torchtext.datasets import WMT14
@@ -535,8 +524,7 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
                            data_select=data_select,
                            tokenizer=tokenizer,
                            root=root,
-                           vocab=vocab,
-                           removed_tokens=removed_tokens)
+                           vocab=vocab)
 
 
 DATASETS = {'Multi30k': Multi30k, 'IWSLT': IWSLT, 'WMT14': WMT14}


### PR DESCRIPTION
By default the constructor allocates data for all datasets, even if only a subset was constructed. 

The error handling could be written a bit more concisely and give a user feedback to fix the issue more easily.

The data_select keyword was also not forwarded and the raw version doesn't accept data_select.

The DATASETS dictionary also referenced the raw version instead of the processed.

The removed_tokens flag has no effect and was removed.

The current implementation sets "train", "test", "valid" as the default data_select, even though the test assumes train, valid, test.

This PR also creates a per-dataset subfolder for the long list of Multi30k, etc. files to make it easier for the user to keep structure in the .data folder. Maybe there are some downsides to this?