### PR TITLE
Use union regex for basic_english

### DIFF
--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -41,7 +41,8 @@ _replacements = [' \'  ',
                  ' ',
                  ' ']
 
-_patterns_dict = list((re.compile(p), r) for p, r in zip(_patterns, _replacements))
+_patterns_dict = {p: r for p, r in zip(_patterns, _replacements)}
+_compiled_pattern = re.compile(r"(%s)" % '|'.join(map(re.escape, _patterns)))
 
 
 def _basic_english_normalize(line):
@@ -67,8 +68,7 @@ def _basic_english_normalize(line):
     """
 
     line = line.lower()
-    for pattern_re, replaced_str in _patterns_dict:
-        line = pattern_re.sub(replaced_str, line)
+    line = _compiled_pattern.sub(lambda mo: _patterns_dict[mo.string[mo.start():mo.end()]], line)
     return line.split()
 
 


### PR DESCRIPTION
Create a single union regular expression that uses a lambda to query a dictionary of patterns for the correct replacement. This causes a significant speedup, however is different from the current behavior where the substitutions are applied consecutively instead of in parallel all at once. We might want to hide this behavior behind a flag, but it is useful and can yield significantly faster code.