### PR TITLE
const string for c10::string_view

### DIFF
--- a/torchtext/csrc/common.h
+++ b/torchtext/csrc/common.h
@@ -1,4 +1,11 @@
+#pragma once
+#include <string>
+#include <vector>
+
 namespace torchtext {
+typedef std::string const_string;
+typedef std::vector<std::string> StringList;
+typedef std::vector<const_string> ConstStringList;
 
 namespace impl {
 int64_t divup(int64_t x, int64_t y);

--- a/torchtext/csrc/regex.cpp
+++ b/torchtext/csrc/regex.cpp
@@ -2,11 +2,11 @@
 
 namespace torchtext {
 
-Regex::Regex(const std::string &re_str) : re_str_(re_str) {
+Regex::Regex(const const_string &re_str) : re_str_(re_str) {
   compiled_pattern_ = new RE2(re_str_);
 }
 
-std::string Regex::Sub(std::string str, const std::string &repl) const {
+std::string Regex::Sub(std::string str, const const_string &repl) const {
   RE2::GlobalReplace(&str, *compiled_pattern_, repl);
   return str;
 }

--- a/torchtext/csrc/regex.h
+++ b/torchtext/csrc/regex.h
@@ -1,6 +1,8 @@
+#pragma once
 #include <re2/re2.h>
 #include <string>
 #include <torch/script.h>
+#include <common.h>
 
 namespace torchtext {
 struct Regex : torch::CustomClassHolder {
@@ -10,7 +12,7 @@ private:
 public:
   std::string re_str_;
 
-  Regex(const std::string &re_str);
-  std::string Sub(std::string str, const std::string &repl) const;
+  Regex(const const_string &re_str);
+  std::string Sub(std::string str, const const_string &repl) const;
 };
 } // namespace torchtext

--- a/torchtext/csrc/regex_tokenizer.cpp
+++ b/torchtext/csrc/regex_tokenizer.cpp
@@ -3,8 +3,8 @@
 
 namespace torchtext {
 
-RegexTokenizer::RegexTokenizer(const std::vector<std::string> &patterns,
-                               const std::vector<std::string> &replacements,
+RegexTokenizer::RegexTokenizer(ConstStringList patterns,
+                               ConstStringList replacements,
                                const bool to_lower = false)
     : patterns_(std::move(patterns)), replacements_(std::move(replacements)),
       to_lower_(to_lower) {
@@ -32,7 +32,7 @@ std::vector<std::string> RegexTokenizer::forward(std::string str) const {
   return tokens;
 }
 
-void RegexTokenizer::split_(std::string &str, std::vector<std::string> &tokens,
+void RegexTokenizer::split_(std::string &str, StringList &tokens,
                             const char &delimiter) const {
   std::stringstream ss(str);
   std::string token;

--- a/torchtext/csrc/regex_tokenizer.h
+++ b/torchtext/csrc/regex_tokenizer.h
@@ -1,5 +1,7 @@
+#pragma once
 #include <re2/re2.h>
 #include <torch/script.h>
+#include <common.h>
 
 namespace torchtext {
 
@@ -14,8 +16,8 @@ public:
   std::vector<std::string> replacements_;
   bool to_lower_;
 
-  explicit RegexTokenizer(const std::vector<std::string> &patterns,
-                          const std::vector<std::string> &replacements,
+  explicit RegexTokenizer(ConstStringList patterns,
+                          ConstStringList replacements,
                           const bool to_lower);
   std::vector<std::string> forward(std::string str) const;
 };

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -1,3 +1,4 @@
+#include <common.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <regex.h>
@@ -22,7 +23,7 @@ PYBIND11_MODULE(_torchtext, m) {
       .def_readonly("patterns_", &RegexTokenizer::patterns_)
       .def_readonly("replacements_", &RegexTokenizer::replacements_)
       .def_readonly("to_lower_", &RegexTokenizer::to_lower_)
-      .def(py::init<std::vector<std::string>, std::vector<std::string>, bool>())
+      .def(py::init<ConstStringList, ConstStringList, bool>())
       .def("forward", &RegexTokenizer::forward);
 
   py::class_<SentencePiece>(m, "SentencePiece")
@@ -35,7 +36,7 @@ PYBIND11_MODULE(_torchtext, m) {
       .def("IdToPiece", &SentencePiece::IdToPiece);
 
   py::class_<Vectors>(m, "Vectors")
-      .def(py::init<std::vector<std::string>, std::vector<int64_t>,
+      .def(py::init<ConstStringList, std::vector<int64_t>,
                     torch::Tensor, torch::Tensor>())
       .def_readonly("vectors_", &Vectors::vectors_)
       .def_readonly("unk_tensor_", &Vectors::unk_tensor_)
@@ -46,7 +47,7 @@ PYBIND11_MODULE(_torchtext, m) {
       .def("__len__", &Vectors::__len__);
 
   py::class_<Vocab>(m, "Vocab")
-      .def(py::init<std::vector<std::string>, std::string>())
+      .def(py::init<ConstStringList, std::string>())
       .def_readonly("itos_", &Vocab::itos_)
       .def_readonly("unk_token_", &Vocab::unk_token_)
       .def("__getitem__", &Vocab::__getitem__)
@@ -83,7 +84,7 @@ static auto regex =
 
 static auto regex_tokenizer =
     torch::class_<RegexTokenizer>("torchtext", "RegexTokenizer")
-        .def(torch::init<std::vector<std::string>, std::vector<std::string>,
+        .def(torch::init<ConstStringList, ConstStringList,
                          bool>())
         .def("forward", &RegexTokenizer::forward)
         .def_pickle(
@@ -149,7 +150,7 @@ static auto vocab =
 
 static auto vectors =
     torch::class_<Vectors>("torchtext", "Vectors")
-        .def(torch::init<std::vector<std::string>, std::vector<std::int64_t>,
+        .def(torch::init<ConstStringList, std::vector<std::int64_t>,
                          torch::Tensor, torch::Tensor>())
         .def("__getitem__", &Vectors::__getitem__)
         .def("lookup_vectors", &Vectors::lookup_vectors)

--- a/torchtext/csrc/sentencepiece.h
+++ b/torchtext/csrc/sentencepiece.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <sentencepiece_processor.h>
 #include <sentencepiece_trainer.h>
 #include <torch/script.h>

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -19,7 +19,7 @@ Vectors::Vectors(const IndexMap &stoi, const torch::Tensor vectors,
                  const torch::Tensor &unk_tensor)
     : stoi_(stoi), vectors_(vectors), unk_tensor_(unk_tensor) {}
 
-Vectors::Vectors(const std::vector<std::string> &tokens,
+Vectors::Vectors(ConstStringList tokens,
                  const std::vector<std::int64_t> &indices,
                  const torch::Tensor &vectors, const torch::Tensor &unk_tensor)
     : vectors_(std::move(vectors)), unk_tensor_(std::move(unk_tensor)) {
@@ -54,7 +54,7 @@ Vectors::Vectors(const std::vector<std::string> &tokens,
   }
 }
 
-torch::Tensor Vectors::__getitem__(const std::string &token) {
+torch::Tensor Vectors::__getitem__(const_string token) {
   const auto &item = stovec_.find(token);
   if (item != stovec_.end()) {
     return item->second;
@@ -69,7 +69,7 @@ torch::Tensor Vectors::__getitem__(const std::string &token) {
   return unk_tensor_;
 }
 
-torch::Tensor Vectors::lookup_vectors(const std::vector<std::string> &tokens) {
+torch::Tensor Vectors::lookup_vectors(ConstStringList tokens) {
   std::vector<torch::Tensor> vectors;
   for (const std::string &token : tokens) {
     vectors.push_back(__getitem__(token));
@@ -77,8 +77,7 @@ torch::Tensor Vectors::lookup_vectors(const std::vector<std::string> &tokens) {
   return torch::stack(vectors, 0);
 }
 
-void Vectors::__setitem__(const std::string &token,
-                          const torch::Tensor &vector) {
+void Vectors::__setitem__(const_string token, const torch::Tensor &vector) {
   const auto &item_index = stoi_.find(token);
   if (item_index != stoi_.end()) {
     stovec_[token] = vector;

--- a/torchtext/csrc/vectors.h
+++ b/torchtext/csrc/vectors.h
@@ -1,13 +1,14 @@
+#pragma once
 #include <torch/script.h>
+#include <common.h>
 
 namespace torchtext {
 
-typedef std::vector<std::string> StringList;
 typedef ska_ordered::order_preserving_flat_hash_map<std::string, torch::Tensor>
     VectorsMap;
 typedef ska_ordered::order_preserving_flat_hash_map<std::string, int64_t>
     IndexMap;
-typedef std::tuple<std::string, std::vector<int64_t>, std::vector<std::string>,
+typedef std::tuple<std::string, std::vector<int64_t>, StringList,
                    std::vector<torch::Tensor>>
     VectorsStates;
 
@@ -21,21 +22,21 @@ public:
 
   explicit Vectors(const IndexMap &stoi, const torch::Tensor vectors,
                    const torch::Tensor &unk_tensor);
-  explicit Vectors(const std::vector<std::string> &tokens,
+  explicit Vectors(ConstStringList tokens,
                    const std::vector<std::int64_t> &indices,
                    const torch::Tensor &vectors,
                    const torch::Tensor &unk_tensor);
   std::unordered_map<std::string, int64_t> get_stoi();
-  torch::Tensor __getitem__(const std::string &token);
-  torch::Tensor lookup_vectors(const std::vector<std::string> &tokens);
-  void __setitem__(const std::string &token, const torch::Tensor &vector);
+  torch::Tensor __getitem__(const_string token);
+  torch::Tensor lookup_vectors(ConstStringList tokens);
+  void __setitem__(const_string token, const torch::Tensor &vector);
   int64_t __len__();
 };
 
 c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states);
 VectorsStates _set_vectors_states(const c10::intrusive_ptr<Vectors> &self);
 
-std::tuple<Vectors, std::vector<std::string>> _load_token_and_vectors_from_file(
+std::tuple<Vectors, StringList> _load_token_and_vectors_from_file(
     const std::string &file_path, const std::string delimiter_str,
     const int64_t num_cpus, c10::optional<torch::Tensor> opt_unk_tensor);
 

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -1,5 +1,4 @@
 #include <ATen/Parallel.h> // @manual
-#include <common.h>
 #include <stdexcept>
 #include <string>
 #include <torch/csrc/jit/python/pybind_utils.h> // @manual
@@ -8,12 +7,12 @@
 
 namespace torchtext {
 
-Vocab::Vocab(const StringList &tokens, const IndexDict &stoi,
-             const std::string &unk_token, const int64_t unk_index)
+Vocab::Vocab(ConstStringList tokens, const IndexDict &stoi,
+             const_string unk_token, const int64_t unk_index)
     : unk_index_(std::move(unk_index)), stoi_(std::move(stoi)),
       itos_(std::move(tokens)), unk_token_(std::move(unk_token)) {}
 
-Vocab::Vocab(const StringList &tokens, const std::string &unk_token)
+Vocab::Vocab(ConstStringList tokens, const_string unk_token)
     : itos_(std::move(tokens)), unk_token_(std::move(unk_token)) {
   stoi_.reserve(tokens.size());
   for (std::size_t i = 0; i < tokens.size(); i++) {
@@ -33,7 +32,7 @@ Vocab::Vocab(const StringList &tokens, const std::string &unk_token)
 
 int64_t Vocab::__len__() const { return stoi_.size(); }
 
-int64_t Vocab::__getitem__(const std::string &token) const {
+int64_t Vocab::__getitem__(const_string token) const {
   const auto &item = stoi_.find(token);
   if (item != stoi_.end()) {
     return item->second;
@@ -41,7 +40,7 @@ int64_t Vocab::__getitem__(const std::string &token) const {
   return unk_index_;
 }
 
-void Vocab::append_token(const std::string &token) {
+void Vocab::append_token(const_string token) {
   if (stoi_.find(token) == stoi_.end()) {
     // Note: we can't do `stoi_[token] = stoi_.size()` because of a bug
     // on Windows where the size gets updated before the assign occurs.
@@ -53,7 +52,7 @@ void Vocab::append_token(const std::string &token) {
   }
 }
 
-void Vocab::insert_token(const std::string &token, const int64_t &index) {
+void Vocab::insert_token(const_string token, const int64_t &index) {
   if (index < 0 || index > static_cast<int64_t>(stoi_.size())) {
 #ifdef _MSC_VER
     std::cerr << "[RuntimeError] Specified index " << index
@@ -116,7 +115,7 @@ StringList Vocab::lookup_tokens(const std::vector<int64_t> &indices) {
   return tokens;
 }
 
-std::vector<int64_t> Vocab::lookup_indices(const StringList &tokens) {
+std::vector<int64_t> Vocab::lookup_indices(ConstStringList tokens) {
   std::vector<int64_t> indices(tokens.size());
   for (int64_t i = 0; i < static_cast<int64_t>(tokens.size()); i++) {
     indices[i] = __getitem__(tokens[i]);

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -1,12 +1,13 @@
+#pragma once
+#include <common.h>
 #include <pybind11/pybind11.h>
 #include <torch/script.h>
 
 namespace torchtext {
 
-typedef std::vector<std::string> StringList;
 typedef ska_ordered::order_preserving_flat_hash_map<std::string, int64_t>
     IndexDict;
-typedef std::tuple<std::string, std::vector<int64_t>, std::vector<std::string>,
+typedef std::tuple<std::string, std::vector<int64_t>, StringList,
                    std::vector<torch::Tensor>>
     VocabStates;
 
@@ -20,29 +21,26 @@ public:
   StringList itos_;
   std::string unk_token_;
 
-  explicit Vocab(const std::vector<std::string> &tokens,
-                 const std::string &unk_token);
-  explicit Vocab(const StringList &tokens, const IndexDict &stoi,
-
-                 const std::string &unk_token, const int64_t unk_index);
+  explicit Vocab(ConstStringList tokens, const_string unk_token);
+  explicit Vocab(ConstStringList tokens, const IndexDict &stoi,
+                 const_string unk_token, const int64_t unk_index);
   int64_t __len__() const;
-  int64_t __getitem__(const std::string &token) const;
-  void append_token(const std::string &token);
-  void insert_token(const std::string &token, const int64_t &index);
+  int64_t __getitem__(const_string token) const;
+  void append_token(const_string token);
+  void insert_token(const_string token, const int64_t &index);
   std::string lookup_token(const int64_t &index);
   std::vector<std::string> lookup_tokens(const std::vector<int64_t> &indices);
-  std::vector<int64_t> lookup_indices(const std::vector<std::string> &tokens);
+  std::vector<int64_t> lookup_indices(ConstStringList tokens);
   std::unordered_map<std::string, int64_t> get_stoi() const;
   std::vector<std::string> get_itos() const;
 };
 
 c10::intrusive_ptr<Vocab> _get_vocab_from_states(VocabStates states);
 VocabStates _set_vocab_states(const c10::intrusive_ptr<Vocab> &self);
-Vocab _load_vocab_from_file(const std::string &file_path,
-                            const std::string &unk_token,
+Vocab _load_vocab_from_file(const_string file_path, const_string unk_token,
                             const int64_t min_freq, const int64_t num_cpus);
-Vocab _load_vocab_from_raw_text_file(const std::string &file_path,
-                                     const std::string &unk_token,
+Vocab _load_vocab_from_raw_text_file(const_string file_path,
+                                     const_string unk_token,
                                      const int64_t min_freq,
                                      const int64_t num_cpus,
                                      py::object tokenizer);


### PR DESCRIPTION
This PR typedefs strings that are meant to be constant, i.e. read-only. They can then be optionally replaced by std::string_view.

Also adds the ever so important "#pragma once" to the header files.