### PR TITLE
Consistently support data_select for raw Datasets and update documentation.

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -4,7 +4,7 @@ import os
 import glob
 import shutil
 import torchtext.data as data
-from torchtext.datasets import AG_NEWS
+from torchtext.experimental.datasets import AG_NEWS
 import torch
 from ..common.torchtext_test_case import TorchtextTestCase
 

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -2,6 +2,7 @@ import torch
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import language_modeling as raw
+from torchtext.experimental.datasets.raw.common import check_default_set
 
 
 def build_vocab(data, transforms):
@@ -65,10 +66,7 @@ def _setup_datasets(dataset_name, tokenizer=None, root='.data', vocab=None,
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
 
-    if isinstance(data_select, str):
-        data_select = [data_select]
-    if not set(data_select).issubset(set(('train', 'valid', 'test'))):
-        raise TypeError('Given data selection {} is not supported!'.format(data_select))
+    data_select = check_default_set(data_select, target_select=('train', 'test', 'valid'))
 
     if not single_line and dataset_name != 'WikiText103':
         raise TypeError('single_line must be True except for WikiText103')

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -66,7 +66,7 @@ def _setup_datasets(dataset_name, tokenizer=None, root='.data', vocab=None,
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
 
-    data_select = check_default_set(data_select, target_select=('train', 'test', 'valid'))
+    data_select = check_default_set(data_select, ('train', 'test', 'valid'))
 
     if not single_line and dataset_name != 'WikiText103':
         raise TypeError('single_line must be True except for WikiText103')

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -108,8 +108,7 @@ def SQuAD1(*args, **kwargs):
             could also choose any one of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
-            data. Note: we follow the convention of Stanford Question Answering datasets
-            and split the data with the names of 'train' and 'dev'.
+            data.
 
     Examples:
         >>> from torchtext.experimental.datasets import SQuAD1
@@ -143,8 +142,7 @@ def SQuAD2(*args, **kwargs):
             could also choose any one of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
-            data. Note: we follow the convention of Stanford Question Answering datasets
-            and split the data with the names of 'train' and 'dev'.
+            data.
 
     Examples:
         >>> from torchtext.experimental.datasets import SQuAD2

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -66,7 +66,7 @@ def _setup_datasets(dataset_name,
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
     text_transform = sequential_transforms(tokenizer)
-    data_select = check_default_set(data_select, target_select=('train', 'dev'))
+    data_select = check_default_set(data_select, ('train', 'dev'))
     train, dev = raw.DATASETS[dataset_name](root=root)
     raw_data = {'train': [item for item in train],
                 'dev': [item for item in dev]}

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -110,7 +110,8 @@ def SQuAD1(*args, **kwargs):
             could also choose any one of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
-            data.
+            data. Note: we follow the convention of Stanford Question Answering datasets
+            and split the data with the names of 'train' and 'dev'.
 
     Examples:
         >>> from torchtext.experimental.datasets import SQuAD1
@@ -144,7 +145,8 @@ def SQuAD2(*args, **kwargs):
             could also choose any one of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
-            data.
+            data. Note: we follow the convention of Stanford Question Answering datasets
+            and split the data with the names of 'train' and 'dev'.
 
     Examples:
         >>> from torchtext.experimental.datasets import SQuAD2

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -2,6 +2,7 @@ import torch
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import question_answer as raw
+from torchtext.experimental.datasets.raw.common import check_default_set
 from torchtext.experimental.functional import (
     totensor,
     vocab_func,
@@ -65,10 +66,7 @@ def _setup_datasets(dataset_name,
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
     text_transform = sequential_transforms(tokenizer)
-    if isinstance(data_select, str):
-        data_select = [data_select]
-    if not set(data_select).issubset(set(('train', 'dev'))):
-        raise TypeError('Given data selection {} is not supported!'.format(data_select))
+    data_select = check_default_set(data_select, target_select=('train', 'dev'))
     train, dev = raw.DATASETS[dataset_name](root=root)
     raw_data = {'train': [item for item in train],
                 'dev': [item for item in dev]}

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def check_default_set(data_select, target_select=('train', 'test', 'valid')):
+def check_default_set(data_select, target_select):
     if isinstance(data_select, str):
         data_select = (data_select)
     if not set(data_select).issubset(set(target_select)):

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -5,7 +5,7 @@ def check_default_set(data_select, target_select):
     if isinstance(data_select, str):
         data_select = (data_select)
     if not set(data_select).issubset(set(target_select)):
-        raise TypeError('A subset of data selection {} is supported! but get {}'.format(target_select, data_select))
+        raise TypeError('A subset of data selection {} is supported but {} is passed in'.format(target_select, data_select))
     return data_select
 
 

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -5,7 +5,7 @@ def check_default_set(data_select, target_select):
     if isinstance(data_select, str):
         data_select = (data_select)
     if not set(data_select).issubset(set(target_select)):
-        raise TypeError('Given data selection {} is not supported!'.format(data_select))
+        raise TypeError('A subset of data selection {} is supported!'.format(target_select))
     return data_select
 
 

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -1,6 +1,14 @@
 import torch
 
 
+def check_default_set(data_select, target_select=('train', 'test', 'valid')):
+    if isinstance(data_select, str):
+        data_select = (data_select)
+    if not set(data_select).issubset(set(target_select)):
+        raise TypeError('Given data selection {} is not supported!'.format(data_select))
+    return data_select
+
+
 class RawTextIterableDataset(torch.utils.data.IterableDataset):
     """Defines an abstraction for raw text iterable datasets.
     """

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -3,7 +3,7 @@ import torch
 
 def check_default_set(data_select, target_select):
     if isinstance(data_select, str):
-        data_select = (data_select)
+        data_select = tuple([data_select])
     if not set(data_select).issubset(set(target_select)):
         raise TypeError('A subset of data selection {} is supported but {} is passed in'.format(target_select, data_select))
     return data_select

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -5,7 +5,7 @@ def check_default_set(data_select, target_select):
     if isinstance(data_select, str):
         data_select = (data_select)
     if not set(data_select).issubset(set(target_select)):
-        raise TypeError('A subset of data selection {} is supported!'.format(target_select))
+        raise TypeError('A subset of data selection {} is supported! but get {}'.format(target_select, data_select))
     return data_select
 
 

--- a/torchtext/experimental/datasets/raw/language_modeling.py
+++ b/torchtext/experimental/datasets/raw/language_modeling.py
@@ -2,6 +2,7 @@ import logging
 import io
 from torchtext.utils import download_from_url, extract_archive
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
+from torchtext.experimental.datasets.raw.common import check_default_set
 
 URLS = {
     'WikiText2':
@@ -17,6 +18,7 @@ URLS = {
 
 
 def _setup_datasets(dataset_name, root='.data', data_select=('train', 'test', 'valid'), **kwargs):
+    data_select = check_default_set(data_select, ('train', 'test', 'valid'))
     if isinstance(data_select, str):
         data_select = [data_select]
     if not set(data_select).issubset(set(('train', 'test', 'valid'))):

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -37,7 +37,7 @@ def _setup_datasets(dataset_name, root='.data', data_select=('train', 'dev')):
     select_to_index = {'train': 0, 'dev': 1}
     extracted_files = [download_from_url(URLS[dataset_name][select_to_index[key]],
                                          root=root) for key in select_to_index.keys()]
-    return tuple(RawTextIterableDataset(_create_data_from_json(extracted_files[select_to_index[item]])) for item in data_select)
+    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], _create_data_from_json(extracted_files[select_to_index[item]])) for item in data_select)
 
 
 def SQuAD1(*args, **kwargs):

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -6,10 +6,10 @@ from torchtext.experimental.datasets.raw.common import check_default_set
 URLS = {
     'SQuAD1':
         {'train': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json',
-         'test': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json'},
+         'dev': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json'},
     'SQuAD2':
         {'train': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v2.0.json',
-         'test': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json'}
+         'dev': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json'}
 }
 
 

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -57,10 +57,10 @@ class RawQuestionAnswerDataset(torch.utils.data.IterableDataset):
                 break
 
 
-def _setup_datasets(dataset_name, root='.data', data_select=('train', 'test')):
+def _setup_datasets(dataset_name, root='.data', data_select=('train', 'dev')):
     if isinstance(data_select, str):
         data_select = [data_select]
-    if not set(data_select).issubset(set(('train', 'test'))):
+    if not set(data_select).issubset(set(('train', 'dev'))):
         raise TypeError('data_select is not supported!')
     extracted_files = []
     select_to_index = {'train': 0, 'dev': 1}

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -57,15 +57,16 @@ class RawQuestionAnswerDataset(torch.utils.data.IterableDataset):
                 break
 
 
-def _setup_datasets(dataset_name, root='.data'):
+def _setup_datasets(dataset_name, root='.data', data_select=('train', 'test')):
+    if isinstance(data_select, str):
+        data_select = [data_select]
+    if not set(data_select).issubset(set(('train', 'test'))):
+        raise TypeError('data_select is not supported!')
     extracted_files = []
     select_to_index = {'train': 0, 'dev': 1}
     extracted_files = [download_from_url(URLS[dataset_name][select_to_index[key]],
                                          root=root) for key in select_to_index.keys()]
-    train_iter = _create_data_from_json(extracted_files[0])
-    dev_iter = _create_data_from_json(extracted_files[1])
-    return (RawQuestionAnswerDataset(train_iter),
-            RawQuestionAnswerDataset(dev_iter))
+    return tuple(RawQuestionAnswerDataset(_create_data_from_json(extracted_files[select_to_index[item]])) for item in data_select)
 
 
 def SQuAD1(*args, **kwargs):
@@ -75,6 +76,12 @@ def SQuAD1(*args, **kwargs):
                   'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?',
                   ['Saint Bernadette Soubirous'],
                   [515])
+
+    Arguments:
+        root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tuple for the returned datasets (Default: ('train', 'dev'))
+            By default, both datasets (train, dev) are generated. Users could also choose any one or two of them,
+            for example ('train', 'dev') or just a string 'train'.
 
     Examples:
         >>> train_dataset, dev_dataset = torchtext.experimental.datasets.raw.SQuAD1()
@@ -92,6 +99,12 @@ def SQuAD2(*args, **kwargs):
                   'When did Beyonce start becoming popular?',
                   ['in the late 1990s'],
                   [269])
+
+    Arguments:
+        root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tuple for the returned datasets (Default: ('train', 'dev'))
+            By default, both datasets (train, dev) are generated. Users could also choose any one or two of them,
+            for example ('train', 'dev') or just a string 'train'.
 
     Examples:
         >>> train_dataset, dev_dataset = torchtext.experimental.datasets.raw.SQuAD2()

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -35,7 +35,8 @@ def _setup_datasets(dataset_name, root='.data', data_select=('train', 'dev')):
     select_to_index = {'train': 0, 'dev': 1}
     extracted_files = [download_from_url(URLS[dataset_name][select_to_index[key]],
                                          root=root) for key in select_to_index.keys()]
-    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], _create_data_from_json(extracted_files[select_to_index[item]])) for item in data_select)
+    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name],
+                 _create_data_from_json(extracted_files[select_to_index[item]])) for item in data_select)
 
 
 def SQuAD1(*args, **kwargs):

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -1,6 +1,7 @@
 from torchtext.utils import download_from_url
 import json
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
+from torchtext.experimental.datasets.raw.common import check_default_set
 
 URLS = {
     'SQuAD1':
@@ -29,10 +30,7 @@ def _create_data_from_json(data_path):
 
 
 def _setup_datasets(dataset_name, root='.data', data_select=('train', 'dev')):
-    if isinstance(data_select, str):
-        data_select = [data_select]
-    if not set(data_select).issubset(set(('train', 'dev'))):
-        raise TypeError('data_select is not supported!')
+    data_select = check_default_set(data_select, ('train', 'dev'))
     extracted_files = []
     select_to_index = {'train': 0, 'dev': 1}
     extracted_files = [download_from_url(URLS[dataset_name][select_to_index[key]],

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -5,11 +5,11 @@ from torchtext.experimental.datasets.raw.common import check_default_set
 
 URLS = {
     'SQuAD1':
-        ['https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json',
-         'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json'],
+        {'train': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json',
+         'test': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json'},
     'SQuAD2':
-        ['https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v2.0.json',
-         'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json']
+        {'train': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v2.0.json',
+         'test': 'https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json'}
 }
 
 
@@ -31,12 +31,10 @@ def _create_data_from_json(data_path):
 
 def _setup_datasets(dataset_name, root='.data', data_select=('train', 'dev')):
     data_select = check_default_set(data_select, ('train', 'dev'))
-    extracted_files = []
-    select_to_index = {'train': 0, 'dev': 1}
-    extracted_files = [download_from_url(URLS[dataset_name][select_to_index[key]],
-                                         root=root) for key in select_to_index.keys()]
+    extracted_files = {key: download_from_url(URLS[dataset_name][key],
+                                              root=root) for key in data_select}
     return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name],
-                 _create_data_from_json(extracted_files[select_to_index[item]])) for item in data_select)
+                 _create_data_from_json(extracted_files[item])) for item in data_select)
 
 
 def SQuAD1(*args, **kwargs):

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -69,20 +69,34 @@ def _setup_datasets(dataset_name, root='.data'):
 
 
 def SQuAD1(*args, **kwargs):
-    """ Defines SQuAD1 datasets.
+    """ A dataset iterator yields the data of Stanford Question Answering dataset - SQuAD1.0.
+    The iterator yields a tuple of (raw context, raw question, a list of raw answer, a list of answer positions in the raw context).
+    For example, ('Architecturally, the school has a Catholic character. Atop the ...',
+                  'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?',
+                  ['Saint Bernadette Soubirous'],
+                  [515])
 
     Examples:
-        >>> train, dev = torchtext.experimental.datasets.raw.SQuAD1()
+        >>> train_dataset, dev_dataset = torchtext.experimental.datasets.raw.SQuAD1()
+        >>> for idx, (context, question, answer, ans_pos) in enumerate(train_dataset):
+        >>>     print(idx, (context, question, answer, ans_pos))
     """
 
     return _setup_datasets(*(("SQuAD1",) + args), **kwargs)
 
 
 def SQuAD2(*args, **kwargs):
-    """ Defines SQuAD2 datasets.
+    """ A dataset iterator yields the data of Stanford Question Answering dataset - SQuAD2.0.
+    The iterator yields a tuple of (raw context, raw question, a list of raw answer, a list of answer positions in the raw context).
+    For example, ('Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981) is an ...',
+                  'When did Beyonce start becoming popular?',
+                  ['in the late 1990s'],
+                  [269])
 
     Examples:
-        >>> train, dev = torchtext.experimental.datasets.raw.SQuAD2()
+        >>> train_dataset, dev_dataset = torchtext.experimental.datasets.raw.SQuAD2()
+        >>> for idx, (context, question, answer, ans_pos) in enumerate(train_dataset):
+        >>>     print(idx, (context, question, answer, ans_pos))
     """
 
     return _setup_datasets(*(("SQuAD2",) + args), **kwargs)

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -59,7 +59,9 @@ def _setup_datasets(dataset_name, separator, root=".data", data_select=('train',
         "valid": _construct_filepath(extracted_files, "dev.txt"),
         "test": _construct_filepath(extracted_files, "test.txt")
     }
-    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], _create_data_from_iob(data_filenames[item], separator)) if data_filenames[item] is not None else None for item in data_select)
+    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name],
+                 _create_data_from_iob(data_filenames[item], separator))
+                 if data_filenames[item] is not None else None for item in data_select)
 
 
 def UDPOS(root=".data", data_select=('train', 'valid', 'test')):

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -97,7 +97,7 @@ def CoNLL2000Chunking(root=".data", data_select=('train', 'test')):
         >>> from torchtext.experimental.datasets.raw import CoNLL2000Chunking
         >>> train_dataset, test_dataset = CoNLL2000Chunking()
     """
-    return _setup_datasets("CoNLL2000Chunking", " ", root=".data", data_select=('train', 'test'))
+    return _setup_datasets("CoNLL2000Chunking", " ", root=root, data_select=data_select)
 
 
 DATASETS = {

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -62,7 +62,7 @@ def _setup_datasets(dataset_name, separator, root=".data", data_select=('train',
     return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], _create_data_from_iob(data_filenames[item], separator)) if data_filenames[item] is not None else None for item in data_select)
 
 
-def UDPOS(*args, **kwargs):
+def UDPOS(root=".data", data_select=('train', 'valid', 'test')):
     """ Universal Dependencies English Web Treebank
 
     Separately returns the training and test dataset
@@ -77,7 +77,7 @@ def UDPOS(*args, **kwargs):
         >>> from torchtext.experimental.datasets.raw import UDPOS
         >>> train_dataset, valid_dataset, test_dataset = UDPOS()
     """
-    return _setup_datasets(*(("UDPOS", "\t") + args), **kwargs)
+    return _setup_datasets("UDPOS", "\t", root=root, data_select=data_select)
 
 
 def CoNLL2000Chunking(root=".data", data_select=('train', 'test')):

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -61,7 +61,7 @@ def _setup_datasets(dataset_name, separator, root=".data", data_select=('train',
         "valid": _construct_filepath(extracted_files, "dev.txt"),
         "test": _construct_filepath(extracted_files, "test.txt")
     }
-    return tuple(RawTextIterableDataset(_create_data_from_iob(data_filenames[item], separator)) if data_filenames[item] is not None else None for item in data_select)
+    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], _create_data_from_iob(data_filenames[item], separator)) if data_filenames[item] is not None else None for item in data_select)
 
 
 def UDPOS(*args, **kwargs):

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -1,5 +1,6 @@
 from torchtext.utils import download_from_url, extract_archive
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
+from torchtext.experimental.datasets.raw.common import check_default_set
 
 URLS = {
     "UDPOS":
@@ -39,10 +40,7 @@ def _construct_filepath(paths, file_suffix):
 
 
 def _setup_datasets(dataset_name, separator, root=".data", data_select=('train', 'valid', 'test')):
-    if isinstance(data_select, str):
-        data_select = [data_select]
-    if not set(data_select).issubset(set(('train', 'valid', 'test'))):
-        raise TypeError('data_select is not supported!')
+    data_select = check_default_set(data_select, target_select=('train', 'valid', 'test'))
     extracted_files = []
     if isinstance(URLS[dataset_name], list):
         for f in URLS[dataset_name]:

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -114,7 +114,7 @@ def UDPOS(*args, **kwargs):
     return _setup_datasets(*(("UDPOS", "\t") + args), **kwargs)
 
 
-def CoNLL2000Chunking(*args, **kwargs):
+def CoNLL2000Chunking(root=".data", data_select=('train', 'test')):
     """ CoNLL 2000 Chunking Dataset
 
     Separately returns the training and test dataset
@@ -127,12 +127,9 @@ def CoNLL2000Chunking(*args, **kwargs):
 
     Examples:
         >>> from torchtext.experimental.datasets.raw import CoNLL2000Chunking
-        >>> train_dataset, valid_dataset, test_dataset = CoNLL2000Chunking()
+        >>> train_dataset, test_dataset = CoNLL2000Chunking()
     """
-    if 'data_select' in kwargs:
-        return _setup_datasets(*(("CoNLL2000Chunking", " ") + args), **kwargs)
-    else:
-        return _setup_datasets(*(("CoNLL2000Chunking", " ") + args), **dict(kwargs, data_select=('train', 'test')))
+    return _setup_datasets("CoNLL2000Chunking", " ", root=".data", data_select=('train', 'test'))
 
 
 DATASETS = {"UDPOS": UDPOS, "CoNLL2000Chunking": CoNLL2000Chunking}

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -76,7 +76,7 @@ def _setup_datasets(dataset_name, root='.data', data_select=('train', 'test')):
             cvs_path['train'] = fname
         if fname.endswith('test.csv'):
             cvs_path['test'] = fname
-    return tuple(RawTextIterableDataset(_create_data_from_csv(cvs_path[item])) for item in dataset)
+    return tuple(RawTextIterableDataset(_create_data_from_csv(cvs_path[item])) for item in data_select)
 
 
 def AG_NEWS(*args, **kwargs):
@@ -279,7 +279,7 @@ def IMDB(root='.data', data_select=('train', 'test')):
         raise TypeError('data_select is not supported!')
     dataset_tar = download_from_url(URLS['IMDB'], root=root)
     extracted_files = extract_archive(dataset_tar)
-    return tuple(RawTextIterableDataset(generate_imdb_data(item, extracted_files)) for item in dataset)
+    return tuple(RawTextIterableDataset(generate_imdb_data(item, extracted_files)) for item in data_select)
 
 
 DATASETS = {

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -247,14 +247,7 @@ def IMDB(root='.data', data_select=('train', 'test')):
         raise TypeError('data_select is not supported!')
     dataset_tar = download_from_url(URLS['IMDB'], root=root)
     extracted_files = extract_archive(dataset_tar)
-<<<<<<< HEAD
     return tuple(RawTextIterableDataset(generate_imdb_data(item, extracted_files)) for item in data_select)
-=======
-    train_iter = generate_imdb_data('train', extracted_files)
-    test_iter = generate_imdb_data('test', extracted_files)
-    return (RawTextIterableDataset("IMDB", NUM_LINES["IMDB"], train_iter),
-            RawTextIterableDataset("IMDB", NUM_LINES["IMDB"], test_iter))
->>>>>>> master
 
 
 DATASETS = {

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -252,7 +252,7 @@ def generate_imdb_data(key, extracted_files):
             continue
         elif key in fname and ('pos' in fname or 'neg' in fname):
             with io.open(fname, encoding="utf8") as f:
-                label = 'pos' if 'pos' in fname else 'neg'
+                label = 1 if 'pos' in fname else 0
                 yield label, f.read()
 
 

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -63,20 +63,20 @@ class RawTextIterableDataset(torch.utils.data.IterableDataset):
         return self._iterator
 
 
-def _setup_datasets(dataset_name, root='.data'):
+def _setup_datasets(dataset_name, root='.data', data_select=('train', 'test')):
+    if isinstance(data_select, str):
+        data_select = [data_select]
+    if not set(data_select).issubset(set(('train', 'test'))):
+        raise TypeError('data_select is not supported!')
     dataset_tar = download_from_url(URLS[dataset_name], root=root)
     extracted_files = extract_archive(dataset_tar)
-
+    cvs_path = {}
     for fname in extracted_files:
         if fname.endswith('train.csv'):
-            train_csv_path = fname
+            cvs_path['train'] = fname
         if fname.endswith('test.csv'):
-            test_csv_path = fname
-
-    train_iter = _create_data_from_csv(train_csv_path)
-    test_iter = _create_data_from_csv(test_csv_path)
-    return (RawTextIterableDataset(train_iter),
-            RawTextIterableDataset(test_iter))
+            cvs_path['test'] = fname
+    return tuple(RawTextIterableDataset(_create_data_from_csv(cvs_path[item])) for item in dataset)
 
 
 def AG_NEWS(*args, **kwargs):
@@ -88,7 +88,10 @@ def AG_NEWS(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.AG_NEWS()
     """
@@ -105,6 +108,10 @@ def SogouNews(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.SogouNews()
@@ -122,6 +129,10 @@ def DBpedia(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.DBpedia()
@@ -139,6 +150,10 @@ def YelpReviewPolarity(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.YelpReviewPolarity()
@@ -156,6 +171,10 @@ def YelpReviewFull(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.YelpReviewFull()
@@ -173,6 +192,10 @@ def YahooAnswers(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.YahooAnswers()
@@ -190,6 +213,10 @@ def AmazonReviewPolarity(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.AmazonReviewPolarity()
@@ -207,6 +234,10 @@ def AmazonReviewFull(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.AmazonReviewFull()
@@ -225,26 +256,30 @@ def generate_imdb_data(key, extracted_files):
                 yield label, f.read()
 
 
-def IMDB(root='.data'):
-    """ Defines IMDB datasets.
+def IMDB(root='.data', data_select=('train', 'test')):
+    """ Defines raw IMDB datasets.
 
     Create supervised learning dataset: IMDB
 
-    Separately returns the training and test dataset
+    Separately returns the raw training and test dataset
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
+        data_select: a string or tupel for the returned datasets
+            (Default: ('train', 'test'))
+            By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
+            for example ('train', 'test') or just a string 'train'.
 
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.IMDB()
     """
-
+    if isinstance(data_select, str):
+        data_select = [data_select]
+    if not set(data_select).issubset(set(('train', 'test'))):
+        raise TypeError('data_select is not supported!')
     dataset_tar = download_from_url(URLS['IMDB'], root=root)
     extracted_files = extract_archive(dataset_tar)
-    train_iter = generate_imdb_data('train', extracted_files)
-    test_iter = generate_imdb_data('test', extracted_files)
-    return (RawTextIterableDataset(train_iter),
-            RawTextIterableDataset(test_iter))
+    return tuple(RawTextIterableDataset(generate_imdb_data(item, extracted_files)) for item in dataset)
 
 
 DATASETS = {

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -88,7 +88,7 @@ def AG_NEWS(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -108,7 +108,7 @@ def SogouNews(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -129,7 +129,7 @@ def DBpedia(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -150,7 +150,7 @@ def YelpReviewPolarity(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -171,7 +171,7 @@ def YelpReviewFull(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -192,7 +192,7 @@ def YahooAnswers(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -213,7 +213,7 @@ def AmazonReviewPolarity(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -234,7 +234,7 @@ def AmazonReviewFull(*args, **kwargs):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.
@@ -265,7 +265,7 @@ def IMDB(root='.data', data_select=('train', 'test')):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
+        data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test'))
             By default, both datasets (train, test) are generated. Users could also choose any one or two of them,
             for example ('train', 'test') or just a string 'train'.

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -44,7 +44,7 @@ def _setup_datasets(dataset_name, root='.data', data_select=('train', 'test')):
             cvs_path['train'] = fname
         if fname.endswith('test.csv'):
             cvs_path['test'] = fname
-    return tuple(RawTextIterableDataset(_create_data_from_csv(cvs_path[item])) for item in data_select)
+    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], _create_data_from_csv(cvs_path[item])) for item in data_select)
 
 
 def AG_NEWS(*args, **kwargs):

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -247,7 +247,7 @@ def IMDB(root='.data', data_select=('train', 'test')):
         raise TypeError('data_select is not supported!')
     dataset_tar = download_from_url(URLS['IMDB'], root=root)
     extracted_files = extract_archive(dataset_tar)
-    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], generate_imdb_data(item, extracted_files)) for item in data_select)
+    return tuple(RawTextIterableDataset("IMDB", NUM_LINES["IMDB"], generate_imdb_data(item, extracted_files)) for item in data_select)
 
 
 DATASETS = {

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -221,7 +221,7 @@ def generate_imdb_data(key, extracted_files):
             continue
         elif key in fname and ('pos' in fname or 'neg' in fname):
             with io.open(fname, encoding="utf8") as f:
-                label = 1 if 'pos' in fname else 0
+                label = 'pos' if 'pos' in fname else 'neg'
                 yield label, f.read()
 
 

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -247,7 +247,7 @@ def IMDB(root='.data', data_select=('train', 'test')):
         raise TypeError('data_select is not supported!')
     dataset_tar = download_from_url(URLS['IMDB'], root=root)
     extracted_files = extract_archive(dataset_tar)
-    return tuple(RawTextIterableDataset(generate_imdb_data(item, extracted_files)) for item in data_select)
+    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], generate_imdb_data(item, extracted_files)) for item in data_select)
 
 
 DATASETS = {

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -3,10 +3,10 @@ import io
 import codecs
 import xml.etree.ElementTree as ET
 from collections import defaultdict
-
 from torchtext.utils import (download_from_url, extract_archive,
                              unicode_csv_reader)
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
+from torchtext.experimental.datasets.raw.common import check_default_set
 
 URLS = {
     'Multi30k': [
@@ -120,11 +120,12 @@ def _setup_datasets(dataset_name,
                     train_filenames,
                     valid_filenames,
                     test_filenames,
+                    data_select=('train', 'test', 'valid'),
                     root='.data'):
+    data_select = check_default_set(data_select, ('train', 'test', 'valid'))
     if not isinstance(train_filenames, tuple) and not isinstance(valid_filenames, tuple) \
             and not isinstance(test_filenames, tuple):
         raise ValueError("All filenames must be tuples")
-
     src_train, tgt_train = train_filenames
     src_eval, tgt_eval = valid_filenames
     src_test, tgt_test = test_filenames
@@ -167,7 +168,7 @@ def _setup_datasets(dataset_name,
                 "Files are not found for data type {}".format(key))
 
     datasets = []
-    for key in data_filenames.keys():
+    for key in data_select:
         src_data_iter = _read_text_iterator(data_filenames[key][0])
         tgt_data_iter = _read_text_iterator(data_filenames[key][1])
 

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -120,9 +120,9 @@ def _setup_datasets(dataset_name,
                     train_filenames,
                     valid_filenames,
                     test_filenames,
-                    data_select=('train', 'test', 'valid'),
+                    data_select=('train', 'valid', 'test'),
                     root='.data'):
-    data_select = check_default_set(data_select, ('train', 'test', 'valid'))
+    data_select = check_default_set(data_select, ('train', 'valid', 'test'))
     if not isinstance(train_filenames, tuple) and not isinstance(valid_filenames, tuple) \
             and not isinstance(test_filenames, tuple):
         raise ValueError("All filenames must be tuples")

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -1,5 +1,5 @@
 import torch
-
+from torchtext.experimental.datasets.raw.common import check_default_set
 from torchtext.experimental.datasets import raw
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.functional import (
@@ -27,11 +27,7 @@ def _setup_datasets(dataset_name,
                     root=".data",
                     vocabs=None,
                     data_select=("train", "valid", "test")):
-    if isinstance(data_select, str):
-        data_select = [data_select]
-    if not set(data_select).issubset(set(("train", "valid", "test"))):
-        raise TypeError("Given data selection {} is not supported!".format(data_select))
-
+    data_select = check_default_set(data_select, target_select=('train', 'valid', 'test'))
     if dataset_name == 'UDPOS':
         train, val, test = raw.DATASETS[dataset_name](root=root)
     elif dataset_name == 'CoNLL2000Chunking':

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -109,7 +109,7 @@ class SequenceTaggingDataset(torch.utils.data.Dataset):
         return self.vocabs
 
 
-def UDPOS(*args, **kwargs):
+def UDPOS(root=".data", vocabs=None, data_select=("train", "valid", "test")):
     """ Universal Dependencies English Web Treebank
 
     Separately returns the training, validation, and test dataset
@@ -131,10 +131,10 @@ def UDPOS(*args, **kwargs):
         >>> from torchtext.datasets.raw import UDPOS
         >>> train_dataset, valid_dataset, test_dataset = UDPOS()
     """
-    return _setup_datasets(*(("UDPOS", ) + args), **kwargs)
+    return _setup_datasets("UDPOS", root, vocabs, data_select)
 
 
-def CoNLL2000Chunking(*args, **kwargs):
+def CoNLL2000Chunking(root=".data", vocabs=None, data_select=("train", "test")):
     """ CoNLL 2000 Chunking Dataset
 
     Separately returns the training and test dataset
@@ -156,10 +156,7 @@ def CoNLL2000Chunking(*args, **kwargs):
         >>> from torchtext.datasets.raw import CoNLL2000Chunking
         >>> train_dataset, test_dataset = CoNLL2000Chunking()
     """
-    if 'data_select' in kwargs:
-        return _setup_datasets(*(("CoNLL2000Chunking", " ") + args), **kwargs)
-    else:
-        return _setup_datasets(*(("CoNLL2000Chunking", " ") + args), **dict(kwargs, data_select=('train', 'test')))
+    return _setup_datasets("CoNLL2000Chunking", root, vocabs, data_select)
 
 
 DATASETS = {"UDPOS": UDPOS, "CoNLL2000Chunking": CoNLL2000Chunking}

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -31,7 +31,7 @@ def _setup_datasets(dataset_name,
     raw_iter_tuple = raw.DATASETS[dataset_name](root=root, data_select=data_select)
     raw_data = {}
     for name, raw_iter in zip(data_select, raw_iter_tuple):
-        raw_data[name] = list(train)
+        raw_data[name] = list(raw_iter)
 
     if vocabs is None:
         if "train" not in data_select:

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -28,16 +28,10 @@ def _setup_datasets(dataset_name,
                     vocabs=None,
                     data_select=("train", "valid", "test")):
     data_select = check_default_set(data_select, ('train', 'valid', 'test'))
-    if dataset_name == 'UDPOS':
-        train, val, test = raw.DATASETS[dataset_name](root=root)
-    elif dataset_name == 'CoNLL2000Chunking':
-        train, test = raw.DATASETS[dataset_name](root=root)
-        val = None
-    raw_data = {
-        "train": [line for line in train] if train and 'train' in data_select else None,
-        "valid": [line for line in val] if val and 'valid' in data_select else None,
-        "test": [line for line in test] if test and 'test' in data_select else None
-    }
+    raw_iter_tuple = raw.DATASETS[dataset_name](root=root, data_select=data_select)
+    raw_data = {}
+    for name, raw_iter in zip(data_select, raw_iter_tuple):
+        raw_data[name] = list(train)
 
     if vocabs is None:
         if "train" not in data_select:
@@ -63,7 +57,7 @@ def _setup_datasets(dataset_name,
                               totensor(dtype=torch.long))
         for idx in range(len(vocabs))
     ]
-    return tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in data_select if raw_data[item] is not None)
+    return tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in data_select)
 
 
 class SequenceTaggingDataset(torch.utils.data.Dataset):

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -27,7 +27,7 @@ def _setup_datasets(dataset_name,
                     root=".data",
                     vocabs=None,
                     data_select=("train", "valid", "test")):
-    data_select = check_default_set(data_select, target_select=('train', 'valid', 'test'))
+    data_select = check_default_set(data_select, ('train', 'valid', 'test'))
     if dataset_name == 'UDPOS':
         train, val, test = raw.DATASETS[dataset_name](root=root)
     elif dataset_name == 'CoNLL2000Chunking':

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -95,7 +95,10 @@ def _setup_datasets(
     text_transform = sequential_transforms(
         text_transform, vocab_func(vocab), totensor(dtype=torch.long)
     )
-    label_transform = sequential_transforms(totensor(dtype=torch.long))
+    if dataset_name == 'IMDB':
+        label_transform = sequential_transforms(lambda x: 1 if x == 'pos' else 0, totensor(dtype=torch.long))
+    else:
+        label_transform = sequential_transforms(totensor(dtype=torch.long))
     return tuple(
         TextClassificationDataset(
             raw_data[item], vocab, (label_transform, text_transform)

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -2,6 +2,7 @@ import torch
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import text_classification as raw
+from torchtext.experimental.datasets.raw.common import check_default_set
 from torchtext.experimental.functional import (
     vocab_func,
     totensor,
@@ -76,11 +77,7 @@ def _setup_datasets(
     if tokenizer is None:
         tokenizer = get_tokenizer("basic_english")
     text_transform = sequential_transforms(tokenizer, ngrams_func(ngrams))
-
-    if isinstance(data_select, str):
-        data_select = [data_select]
-    if not set(data_select).issubset(set(("train", "test"))):
-        raise TypeError("Given data selection {} is not supported!".format(data_select))
+    data_select = check_default_set(data_select, target_select=('train', 'test'))
     train, test = raw.DATASETS[dataset_name](root=root)
     # Cache raw text iterable dataset
     raw_data = {

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -95,10 +95,7 @@ def _setup_datasets(
     text_transform = sequential_transforms(
         text_transform, vocab_func(vocab), totensor(dtype=torch.long)
     )
-    if dataset_name == 'IMDB':
-        label_transform = sequential_transforms(lambda x: 1 if x == 'pos' else 0, totensor(dtype=torch.long))
-    else:
-        label_transform = sequential_transforms(totensor(dtype=torch.long))
+    label_transform = sequential_transforms(totensor(dtype=torch.long))
     return tuple(
         TextClassificationDataset(
             raw_data[item], vocab, (label_transform, text_transform)

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -77,7 +77,7 @@ def _setup_datasets(
     if tokenizer is None:
         tokenizer = get_tokenizer("basic_english")
     text_transform = sequential_transforms(tokenizer, ngrams_func(ngrams))
-    data_select = check_default_set(data_select, target_select=('train', 'test'))
+    data_select = check_default_set(data_select, ('train', 'test'))
     train, test = raw.DATASETS[dataset_name](root=root)
     # Cache raw text iterable dataset
     raw_data = {

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -172,7 +172,6 @@ def Multi30k(train_filenames=("train.de", "train.en"),
             object should be provided which will be used to process valid and/or test
             data.
         removed_tokens: removed tokens from output dataset (Default: '<unk>')
-
         The available dataset include:
             test_2016_flickr.cs
             test_2016_flickr.de
@@ -282,7 +281,6 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
             object should be provided which will be used to process valid and/or test
             data.
         removed_tokens: removed tokens from output dataset (Default: '<unk>')
-
         The available datasets include:
             IWSLT16.TED.dev2010.ar-en.ar
             IWSLT16.TED.dev2010.ar-en.en

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -21,8 +21,7 @@ def _setup_datasets(dataset_name,
                     data_select=('train', 'test', 'valid'),
                     root='.data',
                     vocab=(None, None),
-                    tokenizer=None,
-                    removed_tokens=['<unk>']):
+                    tokenizer=None):
     src_vocab, tgt_vocab = vocab
     if tokenizer is None:
         src_tokenizer = get_tokenizer("spacy", language='de_core_news_sm')
@@ -143,8 +142,7 @@ def Multi30k(train_filenames=("train.de", "train.en"),
              tokenizer=None,
              root='.data',
              vocab=(None, None),
-             data_select=('train', 'valid', 'test'),
-             removed_tokens=['<unk>']):
+             data_select=('train', 'valid', 'test')):
     """ Define translation datasets: Multi30k
         Separately returns train/valid/test datasets as a tuple
 
@@ -171,7 +169,7 @@ def Multi30k(train_filenames=("train.de", "train.en"),
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
-        removed_tokens: removed tokens from output dataset (Default: '<unk>')
+
         The available dataset include:
             test_2016_flickr.cs
             test_2016_flickr.de
@@ -239,8 +237,7 @@ def Multi30k(train_filenames=("train.de", "train.en"),
                            data_select=data_select,
                            tokenizer=tokenizer,
                            root=root,
-                           vocab=vocab,
-                           removed_tokens=removed_tokens)
+                           vocab=vocab)
 
 
 def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
@@ -251,8 +248,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
           tokenizer=None,
           root='.data',
           vocab=(None, None),
-          data_select=('train', 'valid', 'test'),
-          removed_tokens=['<unk>']):
+          data_select=('train', 'valid', 'test')):
     """ Define translation datasets: IWSLT
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -280,7 +276,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
-        removed_tokens: removed tokens from output dataset (Default: '<unk>')
+
         The available datasets include:
             IWSLT16.TED.dev2010.ar-en.ar
             IWSLT16.TED.dev2010.ar-en.en
@@ -436,8 +432,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
                            data_select=data_select,
                            tokenizer=tokenizer,
                            root=root,
-                           vocab=vocab,
-                           removed_tokens=removed_tokens)
+                           vocab=vocab)
 
 
 def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
@@ -449,8 +444,7 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
           tokenizer=None,
           root='.data',
           vocab=(None, None),
-          data_select=('train', 'valid', 'test'),
-          removed_tokens=['<unk>']):
+          data_select=('train', 'valid', 'test')):
     """ Define translation datasets: WMT14
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -528,7 +522,6 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
-        removed_tokens: removed tokens from output dataset (Default: '<unk>')
 
     Examples:
         >>> from torchtext.datasets import WMT14
@@ -548,8 +541,7 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
                            data_select=data_select,
                            tokenizer=tokenizer,
                            root=root,
-                           vocab=vocab,
-                           removed_tokens=removed_tokens)
+                           vocab=vocab)
 
 
 DATASETS = {'Multi30k': Multi30k, 'IWSLT': IWSLT, 'WMT14': WMT14}

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -1,6 +1,6 @@
 import torch
 import logging
-
+from torchtext.experimental.datasets.raw.common import check_default_set
 from torchtext.experimental.datasets import raw
 from torchtext.vocab import Vocab, build_vocab_from_iterator
 from torchtext.data.utils import get_tokenizer
@@ -22,6 +22,7 @@ def _setup_datasets(dataset_name,
                     root='.data',
                     vocab=(None, None),
                     tokenizer=None):
+    data_select = check_default_set(data_select, ('train', 'test', 'valid'))
     src_vocab, tgt_vocab = vocab
     if tokenizer is None:
         src_tokenizer = get_tokenizer("spacy", language='de_core_news_sm')

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -21,7 +21,8 @@ def _setup_datasets(dataset_name,
                     data_select=('train', 'test', 'valid'),
                     root='.data',
                     vocab=(None, None),
-                    tokenizer=None):
+                    tokenizer=None,
+                    removed_tokens=['<unk>']):
     src_vocab, tgt_vocab = vocab
     if tokenizer is None:
         src_tokenizer = get_tokenizer("spacy", language='de_core_news_sm')
@@ -142,7 +143,8 @@ def Multi30k(train_filenames=("train.de", "train.en"),
              tokenizer=None,
              root='.data',
              vocab=(None, None),
-             data_select=('train', 'valid', 'test')):
+             data_select=('train', 'valid', 'test'),
+             removed_tokens=['<unk>']):
     """ Define translation datasets: Multi30k
         Separately returns train/valid/test datasets as a tuple
 
@@ -169,6 +171,7 @@ def Multi30k(train_filenames=("train.de", "train.en"),
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
+        removed_tokens: removed tokens from output dataset (Default: '<unk>')
 
         The available dataset include:
             test_2016_flickr.cs
@@ -237,7 +240,8 @@ def Multi30k(train_filenames=("train.de", "train.en"),
                            data_select=data_select,
                            tokenizer=tokenizer,
                            root=root,
-                           vocab=vocab)
+                           vocab=vocab,
+                           removed_tokens=removed_tokens)
 
 
 def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
@@ -248,7 +252,8 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
           tokenizer=None,
           root='.data',
           vocab=(None, None),
-          data_select=('train', 'valid', 'test')):
+          data_select=('train', 'valid', 'test'),
+          removed_tokens=['<unk>']):
     """ Define translation datasets: IWSLT
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -276,6 +281,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
+        removed_tokens: removed tokens from output dataset (Default: '<unk>')
 
         The available datasets include:
             IWSLT16.TED.dev2010.ar-en.ar
@@ -432,7 +438,8 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
                            data_select=data_select,
                            tokenizer=tokenizer,
                            root=root,
-                           vocab=vocab)
+                           vocab=vocab,
+                           removed_tokens=removed_tokens)
 
 
 def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
@@ -444,7 +451,8 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
           tokenizer=None,
           root='.data',
           vocab=(None, None),
-          data_select=('train', 'valid', 'test')):
+          data_select=('train', 'valid', 'test'),
+          removed_tokens=['<unk>']):
     """ Define translation datasets: WMT14
         Separately returns train/valid/test datasets
         The available datasets include:
@@ -522,6 +530,7 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
             data.
+        removed_tokens: removed tokens from output dataset (Default: '<unk>')
 
     Examples:
         >>> from torchtext.datasets import WMT14
@@ -541,7 +550,8 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
                            data_select=data_select,
                            tokenizer=tokenizer,
                            root=root,
-                           vocab=vocab)
+                           vocab=vocab,
+                           removed_tokens=removed_tokens)
 
 
 DATASETS = {'Multi30k': Multi30k, 'IWSLT': IWSLT, 'WMT14': WMT14}


### PR DESCRIPTION
Make some updates on the experimental datasets:
- Add `data_select` argument to the raw text classification datasets
- Update the doc strings of the raw text classification datasets.
- Add data_select to raw question answer datasets
- Add data_select support to sequence tagging datasets