### PR TITLE
Update doc strings to clarify file-object

### DIFF
--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -40,10 +40,10 @@ def generate_sp_model(filename, vocab_size=20000,
 
 
 def load_sp_model(spm):
-    r"""Load a  sentencepiece model for file.
+    r"""Load a sentencepiece model for file.
 
     Arguments:
-        spm: the file path or a file object saving the sentencepiece model.
+        spm: a file path or a file opened in a binary text mode (io.BufferedReader) saving the sentencepiece model.
 
     Outputs:
         output: a SentencePiece model.

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -27,7 +27,7 @@ def vocab_from_raw_text_file(file_object, jited_tokenizer, min_freq=1, unk_token
     in the file (and not by the frequency of tokens).
 
     Args:
-        file_object (FileObject): a file object to read data from.
+        file_object (io.TextIOWrapper): a file opened in a text mode to read data from.
         jited_tokenizer (ScriptModule): a tokenizer that has been JITed using `torch.jit.script`
         min_freq: The minimum frequency needed to include a token in the vocabulary.
             Values less than 1 will be set to 1. Default: 1.
@@ -60,7 +60,7 @@ def vocab_from_file(file_object, min_freq=1, unk_token='<unk>', num_cpus=4):
         ...
         token_n
     Args:
-        file_object (FileObject): a file like object to read data from.
+        file_object (io.TextIOWrapper): a file opened in a text mode to read data from.
         min_freq: The minimum frequency needed to include a token in the vocabulary.
             Values less than 1 will be set to 1. Default: 1.
         unk_token: The default unknown token to use. Default: '<unk>'.


### PR DESCRIPTION
Update doc strings and clarify that the file object supported by the functions are the file opened in a text mode. A followup task is to add the support of `HTTPResponse`, which has `read` and `write`. Relevant issues https://github.com/pytorch/text/issues/1003 and https://github.com/pytorch/text/issues/1004