### PR TITLE
reset valid dataset to the middle of data_select

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -50,7 +50,7 @@ class TestDataset(TorchtextTestCase):
         cachefile = os.path.join(self.project_root, ".data", "wikitext-2-v1.zip")
         conditional_remove(cachefile)
 
-        train_dataset, test_dataset, valid_dataset = WikiText2()
+        train_dataset, valid_dataset, test_dataset = WikiText2()
         self._helper_test_func(len(train_dataset), 2049990, train_dataset[20:25],
                                [5024, 89, 21, 3, 1838])
         self._helper_test_func(len(test_dataset), 241859, test_dataset[30:35],
@@ -92,7 +92,7 @@ class TestDataset(TorchtextTestCase):
     def test_penntreebank(self):
         from torchtext.experimental.datasets import PennTreebank
         # smoke test to ensure penn treebank works properly
-        train_dataset, test_dataset, valid_dataset = PennTreebank()
+        train_dataset, valid_dataset, test_dataset = PennTreebank()
         self._helper_test_func(len(train_dataset), 924412, train_dataset[20:25],
                                [9919, 9920, 9921, 9922, 9188])
         self._helper_test_func(len(test_dataset), 82114, test_dataset[30:35],

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -91,7 +91,7 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
                  for item in data_select)
 
 
-def WikiText2(tokenizer=None, root='.data', vocab=None, data_select=('train', 'test', 'valid')):
+def WikiText2(tokenizer=None, root='.data', vocab=None, data_select=('train', 'valid', 'test')):
     """ Defines WikiText2 datasets.
 
     Create language modeling dataset: WikiText2
@@ -105,8 +105,7 @@ def WikiText2(tokenizer=None, root='.data', vocab=None, data_select=('train', 't
         root: Directory where the datasets are saved. Default: ".data"
         vocab: Vocabulary used for dataset. If None, it will generate a new
             vocabulary based on the train data set.
-        data_select: a string or tupel for the returned datasets
-            (Default: ('train', 'test','valid'))
+        data_select: a string or tupel for the returned datasets. Default: ('train', 'valid','test')
             By default, all the three datasets (train, test, valid) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
@@ -117,7 +116,7 @@ def WikiText2(tokenizer=None, root='.data', vocab=None, data_select=('train', 't
         >>> from torchtext.experimental.datasets import WikiText2
         >>> from torchtext.data.utils import get_tokenizer
         >>> tokenizer = get_tokenizer("spacy")
-        >>> train_dataset, test_dataset, valid_dataset = WikiText2(tokenizer=tokenizer)
+        >>> train_dataset, valid_dataset, test_dataset = WikiText2(tokenizer=tokenizer)
         >>> vocab = train_dataset.get_vocab()
         >>> valid_dataset, = WikiText2(tokenizer=tokenizer, vocab=vocab,
                                        data_select='valid')
@@ -126,7 +125,7 @@ def WikiText2(tokenizer=None, root='.data', vocab=None, data_select=('train', 't
     return _setup_datasets("WikiText2", tokenizer, root, vocab, data_select, True, None, None)
 
 
-def WikiText103(tokenizer=None, root='.data', vocab=None, data_select=('train', 'test', 'valid'), single_line=True):
+def WikiText103(tokenizer=None, root='.data', vocab=None, data_select=('train', 'valid', 'test'), single_line=True):
     """ Defines WikiText103 datasets.
 
     Create language modeling dataset: WikiText103
@@ -140,8 +139,7 @@ def WikiText103(tokenizer=None, root='.data', vocab=None, data_select=('train', 
         root: Directory where the datasets are saved. Default: ".data"
         vocab: Vocabulary used for dataset. If None, it will generate a new
             vocabulary based on the train data set.
-        data_select: a string or tupel for the returned datasets
-            (Default: ('train', 'test','valid'))
+        data_select: a string or tupel for the returned datasets. Default: ('train', 'valid', 'test')
             By default, all the three datasets (train, test, valid) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
@@ -156,7 +154,7 @@ def WikiText103(tokenizer=None, root='.data', vocab=None, data_select=('train', 
         >>> from torchtext.experimental.datasets import WikiText103
         >>> from torchtext.data.utils import get_tokenizer
         >>> tokenizer = get_tokenizer("spacy")
-        >>> train_dataset, test_dataset, valid_dataset = WikiText103(tokenizer=tokenizer)
+        >>> train_dataset, valid_dataset, test_dataset = WikiText103(tokenizer=tokenizer)
         >>> vocab = train_dataset.get_vocab()
         >>> valid_dataset, = WikiText103(tokenizer=tokenizer, vocab=vocab,
                                          data_select='valid')
@@ -166,7 +164,7 @@ def WikiText103(tokenizer=None, root='.data', vocab=None, data_select=('train', 
     return _setup_datasets("WikiText103", tokenizer, root, vocab, data_select, single_line, None, None)
 
 
-def PennTreebank(tokenizer=None, root='.data', vocab=None, data_select=('train', 'test', 'valid')):
+def PennTreebank(tokenizer=None, root='.data', vocab=None, data_select=('train', 'valid', 'test')):
     """ Defines PennTreebank datasets.
 
     Create language modeling dataset: PennTreebank
@@ -180,8 +178,7 @@ def PennTreebank(tokenizer=None, root='.data', vocab=None, data_select=('train',
         root: Directory where the datasets are saved. Default: ".data"
         vocab: Vocabulary used for dataset. If None, it will generate a new
             vocabulary based on the train data set.
-        data_select: a string or tupel for the returned datasets
-            (Default: ('train', 'test','valid'))
+        data_select: a string or tupel for the returned datasets. Default: ('train', 'valid', 'test')
             By default, all the three datasets (train, test, valid) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
@@ -192,7 +189,7 @@ def PennTreebank(tokenizer=None, root='.data', vocab=None, data_select=('train',
         >>> from torchtext.experimental.datasets import PennTreebank
         >>> from torchtext.data.utils import get_tokenizer
         >>> tokenizer = get_tokenizer("spacy")
-        >>> train_dataset, test_dataset, valid_dataset = PennTreebank(tokenizer=tokenizer)
+        >>> train_dataset, valid_dataset, test_dataset = PennTreebank(tokenizer=tokenizer)
         >>> vocab = train_dataset.get_vocab()
         >>> valid_dataset, = PennTreebank(tokenizer=tokenizer, vocab=vocab,
                                           data_select='valid')

--- a/torchtext/experimental/datasets/raw/language_modeling.py
+++ b/torchtext/experimental/datasets/raw/language_modeling.py
@@ -56,7 +56,7 @@ def _setup_datasets(dataset_name, root, data_select, year, language):
     return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name], data[item]) for item in data_select)
 
 
-def WikiText2(root='.data', data_select=('train', 'test', 'valid')):
+def WikiText2(root='.data', data_select=('train', 'valid', 'test')):
     """ Defines WikiText2 datasets.
 
     Create language modeling dataset: WikiText2
@@ -64,8 +64,7 @@ def WikiText2(root='.data', data_select=('train', 'test', 'valid')):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: a string or tupel for the returned datasets
-            (Default: ('train', 'test','valid'))
+        data_select: a string or tupel for the returned datasets. Default: ('train', 'valid, 'test')
             By default, all the three datasets (train, test, valid) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
@@ -74,7 +73,7 @@ def WikiText2(root='.data', data_select=('train', 'test', 'valid')):
 
     Examples:
         >>> from torchtext.experimental.raw.datasets import WikiText2
-        >>> train_dataset, test_dataset, valid_dataset = WikiText2()
+        >>> train_dataset, valid_dataset, test_dataset = WikiText2()
         >>> valid_dataset, = WikiText2(data_select='valid')
 
     """
@@ -82,7 +81,7 @@ def WikiText2(root='.data', data_select=('train', 'test', 'valid')):
     return _setup_datasets("WikiText2", root, data_select, None, None)
 
 
-def WikiText103(root='.data', data_select=('train', 'test', 'valid')):
+def WikiText103(root='.data', data_select=('train', 'valid', 'test')):
     """ Defines WikiText103 datasets.
 
     Create language modeling dataset: WikiText103
@@ -90,7 +89,7 @@ def WikiText103(root='.data', data_select=('train', 'test', 'valid')):
 
     Arguments:
         root: Directory where the datasets are saved. Default: ".data"
-        data_select: the returned datasets (Default: ('train', 'test','valid'))
+        data_select: the returned datasets. Default: ('train', 'valid','test')
             By default, all the three datasets (train, test, valid) are generated. Users
             could also choose any one or two of them, for example ('train', 'test').
             If 'train' is not in the tuple, an vocab object should be provided which will
@@ -98,14 +97,14 @@ def WikiText103(root='.data', data_select=('train', 'test', 'valid')):
 
     Examples:
         >>> from torchtext.experimental.datasets.raw import WikiText103
-        >>> train_dataset, test_dataset, valid_dataset = WikiText103()
+        >>> train_dataset, valid_dataset, test_dataset = WikiText103()
         >>> valid_dataset, = WikiText103(data_select='valid')
     """
 
     return _setup_datasets("WikiText103", root, data_select, None, None)
 
 
-def PennTreebank(root='.data', data_select=('train', 'test', 'valid')):
+def PennTreebank(root='.data', data_select=('train', 'valid', 'test')):
     """ Defines PennTreebank datasets.
 
     Create language modeling dataset: PennTreebank
@@ -115,7 +114,7 @@ def PennTreebank(root='.data', data_select=('train', 'test', 'valid')):
         root: Directory where the datasets are saved. Default: ".data"
         data_select: a string or tuple for the returned datasets
             (Default: ('train', 'test','valid'))
-            By default, all the three datasets (train, test, valid) are generated. Users
+            By default, all the three datasets ('train', 'valid', 'test') are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
             just a string 'train'. If 'train' is not in the tuple or string, a vocab
             object should be provided which will be used to process valid and/or test
@@ -123,7 +122,7 @@ def PennTreebank(root='.data', data_select=('train', 'test', 'valid')):
 
     Examples:
         >>> from torchtext.experimental.datasets.raw import PennTreebank
-        >>> train_dataset, test_dataset, valid_dataset = PennTreebank()
+        >>> train_dataset, valid_dataset, test_dataset = PennTreebank()
         >>> valid_dataset, = PennTreebank(data_select='valid')
 
     """


### PR DESCRIPTION
To keep consistent over the datasets, we update the data_select argument in the language modeling datasets and reset the valid entry to the middle.