### PR TITLE
Fixing clang-format version to what PyTorch uses

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -5,7 +5,6 @@ dependencies:
   - codecov
   - pip
   - pip:
-    - clang-format
     - dataclasses
     - nltk
     - requests

--- a/.circleci/unittest/linux/scripts/run_style_checks.sh
+++ b/.circleci/unittest/linux/scripts/run_style_checks.sh
@@ -20,9 +20,9 @@ if [ "${status}" -ne 0 ]; then
 fi
 
 printf "\x1b[34mRunning clang-format: "
-clang-format --version
+./clang-format --version
 printf "\x1b[0m\n"
-git-clang-format origin/master
+git-clang-format --binary ./clang-format origin/master
 git diff --exit-code
 status=$?
 exit_status="$((exit_status+status))"

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -14,6 +14,11 @@ env_dir="${root_dir}/env"
 
 cd "${root_dir}"
 
+case "$(uname -s)" in
+    Darwin*) os=MacOSX;;
+    *) os=Linux
+esac
+
 # 1. Install conda at ./conda
 if [ ! -d "${conda_dir}" ]; then
     printf "* Installing conda\n"
@@ -32,6 +37,11 @@ conda activate "${env_dir}"
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"
 conda env update --file "${this_dir}/environment.yml" --prune
+if [ "${os}" == Linux ] ; then
+    clangformat_path="${root_dir}/clang-format"
+    curl https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-format-linux64 -o "${clangformat_path}"
+    chmod +x "${clangformat_path}"
+fi
 
 # 4. Download
 printf "* Downloading SpaCy English models\n"


### PR DESCRIPTION
In [Vision-2372](https://github.com/pytorch/vision/issues/2372) we fixed the clang-format version. @mthrok [proposed](https://github.com/pytorch/vision/pull/2872#issuecomment-714495595) to do the same in text.