### PR TITLE
Add logging for experimental datasets

### DIFF
--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -5,7 +5,7 @@ from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import language_modeling as raw
 from torchtext.experimental.datasets.raw.common import check_default_set
 
-_logger = logging.getLogger(__name__)
+logger_ = logging.getLogger(__name__)
 
 
 def build_vocab(data, transforms):
@@ -79,9 +79,9 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
             raw_train, = raw.DATASETS[dataset_name](root=root, data_select=('train',), year=year, language=language)
         else:
             raw_train, = raw.DATASETS[dataset_name](root=root, data_select=('train',))
-        _logger.info('Building Vocab based on train data')
+        logger_.info('Building Vocab based on train data')
         vocab = build_vocab(raw_train, tokenizer)
-    _logger.info('Vocab has %d entries', len(vocab))
+    logger_.info('Vocab has %d entries', len(vocab))
 
     def text_transform(line):
         return torch.tensor([vocab[token] for token in tokenizer(line)], dtype=torch.long)
@@ -91,7 +91,7 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
     else:
         raw_datasets = raw.DATASETS[dataset_name](root=root, data_select=data_select)
     raw_data = {name: list(map(text_transform, raw_dataset)) for name, raw_dataset in zip(data_select, raw_datasets)}
-    _logger.info('Building datasets for {}'.format(data_select))
+    logger_.info('Building datasets for {}'.format(data_select))
     return tuple(LanguageModelingDataset(raw_data[item], vocab, text_transform, single_line)
                  for item in data_select)
 

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -5,6 +5,8 @@ from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import language_modeling as raw
 from torchtext.experimental.datasets.raw.common import check_default_set
 
+_logger = logging.getLogger(__name__)
+
 
 def build_vocab(data, transforms):
     def apply_transforms(data):
@@ -77,9 +79,9 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
             raw_train, = raw.DATASETS[dataset_name](root=root, data_select=('train',), year=year, language=language)
         else:
             raw_train, = raw.DATASETS[dataset_name](root=root, data_select=('train',))
-        logging.info('Building Vocab based on train data')
+        _logger.info('Building Vocab based on train data')
         vocab = build_vocab(raw_train, tokenizer)
-    logging.info('Vocab has {} entries'.format(len(vocab)))
+    _logger.info('Vocab has {} entries'.format(len(vocab)))
 
     def text_transform(line):
         return torch.tensor([vocab[token] for token in tokenizer(line)], dtype=torch.long)
@@ -89,7 +91,7 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
     else:
         raw_datasets = raw.DATASETS[dataset_name](root=root, data_select=data_select)
     raw_data = {name: list(map(text_transform, raw_dataset)) for name, raw_dataset in zip(data_select, raw_datasets)}
-    logging.info('Building datasets for {}'.format(data_select))
+    _logger.info('Building datasets for {}'.format(data_select))
     return tuple(LanguageModelingDataset(raw_data[item], vocab, text_transform, single_line)
                  for item in data_select)
 

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -81,7 +81,7 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
             raw_train, = raw.DATASETS[dataset_name](root=root, data_select=('train',))
         _logger.info('Building Vocab based on train data')
         vocab = build_vocab(raw_train, tokenizer)
-    _logger.info('Vocab has {} entries'.format(len(vocab)))
+    _logger.info('Vocab has %d entries', len(vocab))
 
     def text_transform(line):
         return torch.tensor([vocab[token] for token in tokenizer(line)], dtype=torch.long)

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -1,4 +1,5 @@
 import torch
+import logging
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import language_modeling as raw
@@ -76,7 +77,9 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
             raw_train, = raw.DATASETS[dataset_name](root=root, data_select=('train',), year=year, language=language)
         else:
             raw_train, = raw.DATASETS[dataset_name](root=root, data_select=('train',))
+        logging.info('Building Vocab based on train data')
         vocab = build_vocab(raw_train, tokenizer)
+    logging.info('Vocab has {} entries'.format(len(vocab)))
 
     def text_transform(line):
         return torch.tensor([vocab[token] for token in tokenizer(line)], dtype=torch.long)
@@ -86,7 +89,7 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, data_select, single_li
     else:
         raw_datasets = raw.DATASETS[dataset_name](root=root, data_select=data_select)
     raw_data = {name: list(map(text_transform, raw_dataset)) for name, raw_dataset in zip(data_select, raw_datasets)}
-
+    logging.info('Building datasets for {}'.format(data_select))
     return tuple(LanguageModelingDataset(raw_data[item], vocab, text_transform, single_line)
                  for item in data_select)
 

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -81,7 +81,7 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, data_select):
                 yield text_transform(_context) + text_transform(_question) + tok_ans
         _logger.info('Building Vocab based on train data')
         vocab = build_vocab_from_iterator(apply_transform(raw_data['train']), len(raw_data['train']))
-    _logger.info('Vocab has {} entries'.format(len(vocab)))
+    _logger.info('Vocab has %d entries', len(vocab))
     text_transform = sequential_transforms(text_transform, vocab_func(vocab), totensor(dtype=torch.long))
     transforms = {'context': text_transform, 'question': text_transform,
                   'answers': text_transform, 'ans_pos': totensor(dtype=torch.long)}

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -10,7 +10,7 @@ from torchtext.experimental.functional import (
     sequential_transforms,
 )
 
-_logger = logging.getLogger(__name__)
+logger_ = logging.getLogger(__name__)
 
 
 class QuestionAnswerDataset(torch.utils.data.Dataset):
@@ -79,13 +79,13 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, data_select):
                 for item in _answers:
                     tok_ans += text_transform(item)
                 yield text_transform(_context) + text_transform(_question) + tok_ans
-        _logger.info('Building Vocab based on train data')
+        logger_.info('Building Vocab based on train data')
         vocab = build_vocab_from_iterator(apply_transform(raw_data['train']), len(raw_data['train']))
-    _logger.info('Vocab has %d entries', len(vocab))
+    logger_.info('Vocab has %d entries', len(vocab))
     text_transform = sequential_transforms(text_transform, vocab_func(vocab), totensor(dtype=torch.long))
     transforms = {'context': text_transform, 'question': text_transform,
                   'answers': text_transform, 'ans_pos': totensor(dtype=torch.long)}
-    _logger.info('Building datasets for {}'.format(data_select))
+    logger_.info('Building datasets for {}'.format(data_select))
     return tuple(QuestionAnswerDataset(raw_data[item], vocab, transforms) for item in data_select)
 
 

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -10,6 +10,8 @@ from torchtext.experimental.functional import (
     sequential_transforms,
 )
 
+_logger = logging.getLogger(__name__)
+
 
 class QuestionAnswerDataset(torch.utils.data.Dataset):
     """Defines an abstract question answer datasets.
@@ -77,13 +79,13 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, data_select):
                 for item in _answers:
                     tok_ans += text_transform(item)
                 yield text_transform(_context) + text_transform(_question) + tok_ans
-        logging.info('Building Vocab based on train data')
+        _logger.info('Building Vocab based on train data')
         vocab = build_vocab_from_iterator(apply_transform(raw_data['train']), len(raw_data['train']))
-    logging.info('Vocab has {} entries'.format(len(vocab)))
+    _logger.info('Vocab has {} entries'.format(len(vocab)))
     text_transform = sequential_transforms(text_transform, vocab_func(vocab), totensor(dtype=torch.long))
     transforms = {'context': text_transform, 'question': text_transform,
                   'answers': text_transform, 'ans_pos': totensor(dtype=torch.long)}
-    logging.info('Building datasets for {}'.format(data_select))
+    _logger.info('Building datasets for {}'.format(data_select))
     return tuple(QuestionAnswerDataset(raw_data[item], vocab, transforms) for item in data_select)
 
 

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -1,4 +1,5 @@
 import torch
+import logging
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import question_answer as raw
@@ -76,10 +77,13 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, data_select):
                 for item in _answers:
                     tok_ans += text_transform(item)
                 yield text_transform(_context) + text_transform(_question) + tok_ans
+        logging.info('Building Vocab based on train data')
         vocab = build_vocab_from_iterator(apply_transform(raw_data['train']), len(raw_data['train']))
+    logging.info('Vocab has {} entries'.format(len(vocab)))
     text_transform = sequential_transforms(text_transform, vocab_func(vocab), totensor(dtype=torch.long))
     transforms = {'context': text_transform, 'question': text_transform,
                   'answers': text_transform, 'ans_pos': totensor(dtype=torch.long)}
+    logging.info('Building datasets for {}'.format(data_select))
     return tuple(QuestionAnswerDataset(raw_data[item], vocab, transforms) for item in data_select)
 
 

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -9,7 +9,7 @@ from torchtext.experimental.functional import (
     sequential_transforms,
 )
 
-_logger = logging.getLogger(__name__)
+logger_ = logging.getLogger(__name__)
 
 
 def build_vocab(data):
@@ -36,7 +36,7 @@ def _setup_datasets(dataset_name, root, vocabs, data_select):
     if vocabs is None:
         if "train" not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        _logger.info('Building Vocab based on train data')
+        logger_.info('Building Vocab based on train data')
         vocabs = build_vocab(raw_data["train"])
     else:
         if not isinstance(vocabs, list):
@@ -58,7 +58,7 @@ def _setup_datasets(dataset_name, root, vocabs, data_select):
                               totensor(dtype=torch.long))
         for idx in range(len(vocabs))
     ]
-    _logger.info('Building datasets for {}'.format(data_select))
+    logger_.info('Building datasets for {}'.format(data_select))
     return tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in data_select)
 
 

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -1,4 +1,5 @@
 import torch
+import logging
 from torchtext.experimental.datasets.raw.common import check_default_set
 from torchtext.experimental.datasets import raw
 from torchtext.vocab import build_vocab_from_iterator

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -9,6 +9,8 @@ from torchtext.experimental.functional import (
     sequential_transforms,
 )
 
+_logger = logging.getLogger(__name__)
+
 
 def build_vocab(data):
     total_columns = len(data[0])
@@ -34,7 +36,7 @@ def _setup_datasets(dataset_name, root, vocabs, data_select):
     if vocabs is None:
         if "train" not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        logging.info('Building Vocab based on train data')
+        _logger.info('Building Vocab based on train data')
         vocabs = build_vocab(raw_data["train"])
     else:
         if not isinstance(vocabs, list):
@@ -56,7 +58,7 @@ def _setup_datasets(dataset_name, root, vocabs, data_select):
                               totensor(dtype=torch.long))
         for idx in range(len(vocabs))
     ]
-    logging.info('Building datasets for {}'.format(data_select))
+    _logger.info('Building datasets for {}'.format(data_select))
     return tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in data_select)
 
 

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -33,6 +33,7 @@ def _setup_datasets(dataset_name, root, vocabs, data_select):
     if vocabs is None:
         if "train" not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
+        logging.info('Building Vocab based on train data')
         vocabs = build_vocab(raw_data["train"])
     else:
         if not isinstance(vocabs, list):
@@ -54,6 +55,7 @@ def _setup_datasets(dataset_name, root, vocabs, data_select):
                               totensor(dtype=torch.long))
         for idx in range(len(vocabs))
     ]
+    logging.info('Building datasets for {}'.format(data_select))
     return tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in data_select)
 
 

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -84,7 +84,7 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, data_select):
             raise TypeError("Must pass a vocab if train is not selected.")
         _logger.info('Building Vocab based on train data')
         vocab = build_vocab(raw_data["train"], text_transform)
-    _logger.info('Vocab has {} entries'.format(len(vocab)))
+    _logger.info('Vocab has %d entries', len(vocab))
     text_transform = sequential_transforms(
         text_transform, vocab_func(vocab), totensor(dtype=torch.long)
     )

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -1,4 +1,5 @@
 import torch
+import logging
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import text_classification as raw
@@ -79,7 +80,9 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, data_select):
     if vocab is None:
         if "train" not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
+        logging.info('Building Vocab based on train data')
         vocab = build_vocab(raw_data["train"], text_transform)
+    logging.info('Vocab has {} entries'.format(len(vocab)))
     text_transform = sequential_transforms(
         text_transform, vocab_func(vocab), totensor(dtype=torch.long)
     )
@@ -87,6 +90,7 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, data_select):
         label_transform = sequential_transforms(lambda x: 1 if x == 'pos' else 0, totensor(dtype=torch.long))
     else:
         label_transform = sequential_transforms(totensor(dtype=torch.long))
+    logging.info('Building datasets for {}'.format(data_select))
     return tuple(
         TextClassificationDataset(
             raw_data[item], vocab, (label_transform, text_transform)

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -11,6 +11,8 @@ from torchtext.experimental.functional import (
     sequential_transforms,
 )
 
+_logger = logging.getLogger(__name__)
+
 
 def build_vocab(data, transforms):
     def apply_transforms(data):
@@ -80,9 +82,9 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, data_select):
     if vocab is None:
         if "train" not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        logging.info('Building Vocab based on train data')
+        _logger.info('Building Vocab based on train data')
         vocab = build_vocab(raw_data["train"], text_transform)
-    logging.info('Vocab has {} entries'.format(len(vocab)))
+    _logger.info('Vocab has {} entries'.format(len(vocab)))
     text_transform = sequential_transforms(
         text_transform, vocab_func(vocab), totensor(dtype=torch.long)
     )
@@ -90,7 +92,7 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, data_select):
         label_transform = sequential_transforms(lambda x: 1 if x == 'pos' else 0, totensor(dtype=torch.long))
     else:
         label_transform = sequential_transforms(totensor(dtype=torch.long))
-    logging.info('Building datasets for {}'.format(data_select))
+    _logger.info('Building datasets for {}'.format(data_select))
     return tuple(
         TextClassificationDataset(
             raw_data[item], vocab, (label_transform, text_transform)

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -11,7 +11,7 @@ from torchtext.experimental.functional import (
     sequential_transforms,
 )
 
-_logger = logging.getLogger(__name__)
+logger_ = logging.getLogger(__name__)
 
 
 def build_vocab(data, transforms):
@@ -82,9 +82,9 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, data_select):
     if vocab is None:
         if "train" not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        _logger.info('Building Vocab based on train data')
+        logger_.info('Building Vocab based on train data')
         vocab = build_vocab(raw_data["train"], text_transform)
-    _logger.info('Vocab has %d entries', len(vocab))
+    logger_.info('Vocab has %d entries', len(vocab))
     text_transform = sequential_transforms(
         text_transform, vocab_func(vocab), totensor(dtype=torch.long)
     )
@@ -92,7 +92,7 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, data_select):
         label_transform = sequential_transforms(lambda x: 1 if x == 'pos' else 0, totensor(dtype=torch.long))
     else:
         label_transform = sequential_transforms(totensor(dtype=torch.long))
-    _logger.info('Building datasets for {}'.format(data_select))
+    logger_.info('Building datasets for {}'.format(data_select))
     return tuple(
         TextClassificationDataset(
             raw_data[item], vocab, (label_transform, text_transform)

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -6,6 +6,8 @@ from torchtext.vocab import Vocab, build_vocab_from_iterator
 from torchtext.data.utils import get_tokenizer
 from ..functional import vocab_func, totensor, sequential_transforms
 
+_logger = logging.getLogger(__name__)
+
 
 def build_vocab(data, transforms, index):
     def apply_transforms(data):
@@ -43,28 +45,28 @@ def _setup_datasets(dataset_name,
     if src_vocab is None:
         if 'train' not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        logging.info('Building src Vocab based on train data')
+        _logger.info('Building src Vocab based on train data')
         src_vocab = build_vocab(raw_data["train"],
                                 src_text_vocab_transform,
                                 index=0)
     else:
         if not isinstance(src_vocab, Vocab):
             raise TypeError("Passed src vocabulary is not of type Vocab")
-    logging.info('src Vocab has {} entries'.format(len(src_vocab)))
+    _logger.info('src Vocab has {} entries'.format(len(src_vocab)))
 
     if tgt_vocab is None:
         if 'train' not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        logging.info('Building tgt Vocab based on train data')
+        _logger.info('Building tgt Vocab based on train data')
         tgt_vocab = build_vocab(raw_data["train"],
                                 tgt_text_vocab_transform,
                                 index=1)
     else:
         if not isinstance(tgt_vocab, Vocab):
             raise TypeError("Passed tgt vocabulary is not of type Vocab")
-    logging.info('tgt Vocab has {} entries'.format(len(tgt_vocab)))
+    _logger.info('tgt Vocab has {} entries'.format(len(tgt_vocab)))
 
-    logging.info('Building datasets for {}'.format(data_select))
+    _logger.info('Building datasets for {}'.format(data_select))
     datasets = []
     for key in data_select:
         src_text_transform = sequential_transforms(src_text_vocab_transform,

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -6,7 +6,7 @@ from torchtext.vocab import Vocab, build_vocab_from_iterator
 from torchtext.data.utils import get_tokenizer
 from ..functional import vocab_func, totensor, sequential_transforms
 
-_logger = logging.getLogger(__name__)
+logger_ = logging.getLogger(__name__)
 
 
 def build_vocab(data, transforms, index):
@@ -45,28 +45,28 @@ def _setup_datasets(dataset_name,
     if src_vocab is None:
         if 'train' not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        _logger.info('Building src Vocab based on train data')
+        logger_.info('Building src Vocab based on train data')
         src_vocab = build_vocab(raw_data["train"],
                                 src_text_vocab_transform,
                                 index=0)
     else:
         if not isinstance(src_vocab, Vocab):
             raise TypeError("Passed src vocabulary is not of type Vocab")
-    _logger.info('src Vocab has %d entries', len(src_vocab))
+    logger_.info('src Vocab has %d entries', len(src_vocab))
 
     if tgt_vocab is None:
         if 'train' not in data_select:
             raise TypeError("Must pass a vocab if train is not selected.")
-        _logger.info('Building tgt Vocab based on train data')
+        logger_.info('Building tgt Vocab based on train data')
         tgt_vocab = build_vocab(raw_data["train"],
                                 tgt_text_vocab_transform,
                                 index=1)
     else:
         if not isinstance(tgt_vocab, Vocab):
             raise TypeError("Passed tgt vocabulary is not of type Vocab")
-    _logger.info('tgt Vocab has %d entries', len(tgt_vocab))
+    logger_.info('tgt Vocab has %d entries', len(tgt_vocab))
 
-    _logger.info('Building datasets for {}'.format(data_select))
+    logger_.info('Building datasets for {}'.format(data_select))
     datasets = []
     for key in data_select:
         src_text_transform = sequential_transforms(src_text_vocab_transform,

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -52,7 +52,7 @@ def _setup_datasets(dataset_name,
     else:
         if not isinstance(src_vocab, Vocab):
             raise TypeError("Passed src vocabulary is not of type Vocab")
-    _logger.info('src Vocab has {} entries'.format(len(src_vocab)))
+    _logger.info('src Vocab has %d entries', len(src_vocab))
 
     if tgt_vocab is None:
         if 'train' not in data_select:
@@ -64,7 +64,7 @@ def _setup_datasets(dataset_name,
     else:
         if not isinstance(tgt_vocab, Vocab):
             raise TypeError("Passed tgt vocabulary is not of type Vocab")
-    _logger.info('tgt Vocab has {} entries'.format(len(tgt_vocab)))
+    _logger.info('tgt Vocab has %d entries', len(tgt_vocab))
 
     _logger.info('Building datasets for {}'.format(data_select))
     datasets = []


### PR DESCRIPTION
Add logging for the experimental datasets:

- text classification
- language modeling
- question answer
- sequence tagging
- translation

The logging information include:

- building vocabulary
- vocabulary length
- building datasets