### PR TITLE
Simplify TorchScript registration with TORCH_LIBRARY_FRAGMENT macro

### DIFF
--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -71,119 +71,100 @@ PYBIND11_MODULE(_torchtext, m) {
   m.def("_build_vocab_from_text_file", _build_vocab_from_text_file);
 }
 
-// Registers our custom classes with torch.
-static auto regex =
-    torch::class_<Regex>("torchtext", "Regex")
-        .def(torch::init<std::string>())
-        .def("Sub", &Regex::Sub)
-        .def_pickle(
-            // __getstate__
-            [](const c10::intrusive_ptr<Regex> &self) -> std::string {
-              return self->re_str_;
-            },
-            // __setstate__
-            [](std::string state) -> c10::intrusive_ptr<Regex> {
-              return c10::make_intrusive<Regex>(std::move(state));
-            });
+TORCH_LIBRARY_FRAGMENT(torchtext, m) {
+  m.class_<Regex>("Regex")
+    .def(torch::init<std::string>())
+    .def("Sub", &Regex::Sub)
+    .def_pickle(
+        // __getstate__
+        [](const c10::intrusive_ptr<Regex> &self) -> std::string {
+          return self->re_str_;
+        },
+        // __setstate__
+        [](std::string state) -> c10::intrusive_ptr<Regex> {
+          return c10::make_intrusive<Regex>(std::move(state));
+        });
 
-static auto regex_tokenizer =
-    torch::class_<RegexTokenizer>("torchtext", "RegexTokenizer")
-        .def(torch::init<std::vector<std::string>, std::vector<std::string>,
-                         bool>())
-        .def("forward", &RegexTokenizer::forward)
-        .def_pickle(
-            // __setstate__
-            [](const c10::intrusive_ptr<RegexTokenizer> &self)
-                -> std::tuple<std::vector<std::string>,
-                              std::vector<std::string>, bool> {
-              return std::make_tuple(self->patterns_, self->replacements_,
-                                     self->to_lower_);
-            },
-            // __getstate__
-            [](std::tuple<std::vector<std::string>, std::vector<std::string>,
-                          bool>
-                   states) -> c10::intrusive_ptr<RegexTokenizer> {
-              auto patterns = std::get<0>(states);
-              auto replacements = std::get<1>(states);
-              auto to_lower = std::get<2>(states);
+  using RegexTokenizerState = std::tuple<std::vector<std::string>, std::vector<std::string>, bool>;
+  m.class_<RegexTokenizer>("RegexTokenizer")
+    .def(torch::init<std::vector<std::string>, std::vector<std::string>, bool>())
+    .def("forward", &RegexTokenizer::forward)
+    .def_pickle(
+        // __getstate__
+        [](const c10::intrusive_ptr<RegexTokenizer> &self) -> RegexTokenizerState {
+          return std::make_tuple(
+                 self->patterns_,
+                 self->replacements_,
+                 self->to_lower_);
+        },
+        // __setstate__
+        [](RegexTokenizerState state) -> c10::intrusive_ptr<RegexTokenizer> {
+          return c10::make_intrusive<RegexTokenizer>(
+                 std::move(std::get<0>(state)),
+                 std::move(std::get<1>(state)),
+                 std::get<2>(state));
+        });
+  m.class_<SentencePiece>("SentencePiece")
+    .def(torch::init<std::string>())
+    .def("Encode", &SentencePiece::Encode)
+    .def("EncodeAsIds", &SentencePiece::EncodeAsIds)
+    .def("DecodeIds", &SentencePiece::DecodeIds)
+    .def("EncodeAsPieces", &SentencePiece::EncodeAsPieces)
+    .def("DecodePieces", &SentencePiece::DecodePieces)
+    .def("GetPieceSize", &SentencePiece::GetPieceSize)
+    .def("unk_id", &SentencePiece::unk_id)
+    .def("PieceToId", &SentencePiece::PieceToId)
+    .def("IdToPiece", &SentencePiece::IdToPiece)
+    .def_pickle(
+        // __getstate__
+        [](const c10::intrusive_ptr<SentencePiece> &self) -> std::string {
+          return self->content_;
+        },
+        // __setstate__
+        [](std::string state) -> c10::intrusive_ptr<SentencePiece> {
+          return c10::make_intrusive<SentencePiece>(std::move(state));
+        });
 
-              return c10::make_intrusive<RegexTokenizer>(
-                  std::move(patterns), std::move(replacements), to_lower);
-            });
+  m.class_<Vectors>("Vectors")
+    .def(torch::init<std::vector<std::string>, std::vector<std::int64_t>, torch::Tensor, torch::Tensor>())
+    .def("__getitem__", &Vectors::__getitem__)
+    .def("lookup_vectors", &Vectors::lookup_vectors)
+    .def("__setitem__", &Vectors::__setitem__)
+    .def("__len__", &Vectors::__len__)
+    .def_pickle(
+        // __getstate__
+        [](const c10::intrusive_ptr<Vectors> &self) -> VectorsStates {
+          return _set_vectors_states(self);
+        },
+        // __setstate__
+        [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
+          return _get_vectors_from_states(states);
+        });
 
-static auto sentencepiece =
-    torch::class_<SentencePiece>("torchtext", "SentencePiece")
-        .def(torch::init<std::string>())
-        .def("Encode", &SentencePiece::Encode)
-        .def("EncodeAsIds", &SentencePiece::EncodeAsIds)
-        .def("DecodeIds", &SentencePiece::DecodeIds)
-        .def("EncodeAsPieces", &SentencePiece::EncodeAsPieces)
-        .def("DecodePieces", &SentencePiece::DecodePieces)
-        .def("GetPieceSize", &SentencePiece::GetPieceSize)
-        .def("unk_id", &SentencePiece::unk_id)
-        .def("PieceToId", &SentencePiece::PieceToId)
-        .def("IdToPiece", &SentencePiece::IdToPiece)
-        .def_pickle(
-            // __setstate__
-            [](const c10::intrusive_ptr<SentencePiece> &self) -> std::string {
-              return self->content_;
-            },
-            // __getstate__
-            [](std::string state) -> c10::intrusive_ptr<SentencePiece> {
-              return c10::make_intrusive<SentencePiece>(std::move(state));
-            });
+  m.class_<Vocab>("Vocab")
+    .def(torch::init<StringList, std::string>())
+    .def("__getitem__", &Vocab::__getitem__)
+    .def("__len__", &Vocab::__len__)
+    .def("insert_token", &Vocab::insert_token)
+    .def("append_token", &Vocab::append_token)
+    .def("lookup_token", &Vocab::lookup_token)
+    .def("lookup_tokens", &Vocab::lookup_tokens)
+    .def("lookup_indices", &Vocab::lookup_indices)
+    .def("get_stoi", &Vocab::get_stoi)
+    .def("get_itos", &Vocab::get_itos)
+    .def_pickle(
+        // __getstate__
+        [](const c10::intrusive_ptr<Vocab> &self) -> VocabStates {
+          return _set_vocab_states(self);
+        },
+        // __setstate__
+        [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
+          return _get_vocab_from_states(states);
+        });
 
-static auto vocab =
-    torch::class_<Vocab>("torchtext", "Vocab")
-        .def(torch::init<StringList, std::string>())
-        .def("__getitem__", &Vocab::__getitem__)
-        .def("__len__", &Vocab::__len__)
-        .def("insert_token", &Vocab::insert_token)
-        .def("append_token", &Vocab::append_token)
-        .def("lookup_token", &Vocab::lookup_token)
-        .def("lookup_tokens", &Vocab::lookup_tokens)
-        .def("lookup_indices", &Vocab::lookup_indices)
-        .def("get_stoi", &Vocab::get_stoi)
-        .def("get_itos", &Vocab::get_itos)
-        .def_pickle(
-            // __setstate__
-            [](const c10::intrusive_ptr<Vocab> &self) -> VocabStates {
-              return _set_vocab_states(self);
-            },
-            // __getstate__
-            [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
-              return _get_vocab_from_states(states);
-            });
+  m.def("torchtext::generate_sp_model", &generate_sp_model);
+  m.def("torchtext::load_sp_model", &load_sp_model);
+  m.def("torchtext::load_sp_model_string", &load_sp_model_string);
+}
 
-static auto vectors =
-    torch::class_<Vectors>("torchtext", "Vectors")
-        .def(torch::init<std::vector<std::string>, std::vector<std::int64_t>,
-                         torch::Tensor, torch::Tensor>())
-        .def("__getitem__", &Vectors::__getitem__)
-        .def("lookup_vectors", &Vectors::lookup_vectors)
-        .def("__setitem__", &Vectors::__setitem__)
-        .def("__len__", &Vectors::__len__)
-        .def_pickle(
-            // __setstate__
-            [](const c10::intrusive_ptr<Vectors> &self) -> VectorsStates {
-              return _set_vectors_states(self);
-            },
-            // __getstate__
-            [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
-              return _get_vectors_from_states(states);
-            });
-
-// Registers our custom op with torch.
-static auto registry =
-    torch::RegisterOperators()
-        .op("torchtext::generate_sp_model", &generate_sp_model)
-        .op(torch::RegisterOperators::options()
-                .schema("torchtext::load_sp_model(str path) -> "
-                        "__torch__.torch.classes.torchtext.SentencePiece model")
-                .catchAllKernel<decltype(load_sp_model), &load_sp_model>())
-        .op(torch::RegisterOperators::options()
-                .schema("torchtext::load_sp_model_string(str content) -> "
-                        "__torch__.torch.classes.torchtext.SentencePiece model")
-                .catchAllKernel<decltype(load_sp_model_string),
-                                &load_sp_model_string>());
 } // namespace torchtext


### PR DESCRIPTION
This PR adopts `TORCH_LIBRARY_FRAGMENT` to make the TorchScript registration simpler and similar to the PyBind11.

Also the order of registration is changed a bit to match the one in PyBind11. 