### PR TITLE
Make Regex, RegexTokenizer, Vocab, Vectors, SentencePiece pickle-able

### DIFF
--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -107,13 +107,17 @@ class TestFunctional(TorchtextTestCase):
         self.assertEqual(eager_tokens, ref_results)
         self.assertEqual(experimental_eager_tokens, ref_results)
 
-        # test load and save
-        save_path = os.path.join(self.test_dir, 'basic_english_normalize.pt')
+        # test pybind load and save
+        save_path = os.path.join(self.test_dir, 'basic_english_normalize_pybind.pt')
+        torch.save(basic_eng_norm, save_path)
+        loaded_basic_eng_norm = torch.load(save_path)
+        self.assertEqual(loaded_basic_eng_norm(test_sample), ref_results)
+
+        # test torchscript load and save
+        save_path = os.path.join(self.test_dir, 'basic_english_normalize_torchscrip.pt')
         torch.save(basic_eng_norm.to_ivalue(), save_path)
         loaded_basic_eng_norm = torch.load(save_path)
-
-        loaded_eager_tokens = loaded_basic_eng_norm(test_sample)
-        self.assertEqual(loaded_eager_tokens, ref_results)
+        self.assertEqual(loaded_basic_eng_norm(test_sample), ref_results)
 
     # TODO(Nayef211): remove decorator once	https://github.com/pytorch/pytorch/issues/38207 is closed
     @unittest.skipIf(platform.system() == "Windows", "Test is known to fail on Windows.")
@@ -147,11 +151,17 @@ class TestFunctional(TorchtextTestCase):
         self.assertEqual(eager_tokens, ref_results)
         self.assertEqual(jit_tokens, ref_results)
 
-        # test load and save
-        save_path = os.path.join(self.test_dir, 'regex.pt')
+        # test pybind load and save
+        save_path = os.path.join(self.test_dir, 'regex_pybind.pt')
+        torch.save(r_tokenizer, save_path)
+        loaded_r_tokenizer = torch.load(save_path)
+        loaded_eager_tokens = loaded_r_tokenizer(test_sample)
+        self.assertEqual(loaded_eager_tokens, ref_results)
+
+        # test torchscript load and save
+        save_path = os.path.join(self.test_dir, 'regex_torchscript.pt')
         torch.save(r_tokenizer.to_ivalue(), save_path)
         loaded_r_tokenizer = torch.load(save_path)
-
         loaded_eager_tokens = loaded_r_tokenizer(test_sample)
         self.assertEqual(loaded_eager_tokens, ref_results)
 

--- a/test/experimental/test_transforms.py
+++ b/test/experimental/test_transforms.py
@@ -57,7 +57,6 @@ class TestTransforms(TorchtextTestCase):
 
     def test_sentencepiece_load_and_save(self):
         model_path = get_asset_path('spm_example.model')
-        spm = sentencepiece_tokenizer((model_path))
         input = 'SentencePiece is an unsupervised text tokenizer and detokenizer'
         expected = [
             '▁Sent', 'ence', 'P', 'ie', 'ce', '▁is',
@@ -66,14 +65,16 @@ class TestTransforms(TorchtextTestCase):
             '▁de', 'to', 'ken', 'izer',
         ]
 
-        # test pybind load and save
-        save_path = os.path.join(self.test_dir, 'spm_pybind.pt')
-        torch.save(spm, save_path)
-        loaded_spm = torch.load(save_path)
-        self.assertEqual(expected, loaded_spm(input))
+        with self.subTest('pybind'):
+            save_path = os.path.join(self.test_dir, 'spm_pybind.pt')
+            spm = sentencepiece_tokenizer((model_path))
+            torch.save(spm, save_path)
+            loaded_spm = torch.load(save_path)
+            self.assertEqual(expected, loaded_spm(input))
 
-        # test torchscript load and save
-        save_path = os.path.join(self.test_dir, 'spm_torchscript.pt')
-        torch.save(spm.to_ivalue(), save_path)
-        loaded_spm = torch.load(save_path)
-        self.assertEqual(expected, loaded_spm(input))
+        with self.subTest('torchscript'):
+            save_path = os.path.join(self.test_dir, 'spm_torchscript.pt')
+            spm = sentencepiece_tokenizer((model_path)).to_ivalue()
+            torch.save(spm, save_path)
+            loaded_spm = torch.load(save_path)
+            self.assertEqual(expected, loaded_spm(input))

--- a/test/experimental/test_transforms.py
+++ b/test/experimental/test_transforms.py
@@ -54,3 +54,26 @@ class TestTransforms(TorchtextTestCase):
                                                         [-0.32423, -0.098845, -0.0073467]])
             self.assertEqual(vector_transform(['the', 'world'])[:, 0:3], expected_fasttext_simple_en)
             self.assertEqual(jit_vector_transform(['the', 'world'])[:, 0:3], expected_fasttext_simple_en)
+
+    def test_sentencepiece_load_and_save(self):
+        model_path = get_asset_path('spm_example.model')
+        spm = sentencepiece_tokenizer((model_path))
+        input = 'SentencePiece is an unsupervised text tokenizer and detokenizer'
+        expected = [
+            '▁Sent', 'ence', 'P', 'ie', 'ce', '▁is',
+            '▁an', '▁un', 'super', 'vis', 'ed', '▁text',
+            '▁to', 'ken', 'izer', '▁and',
+            '▁de', 'to', 'ken', 'izer',
+        ]
+
+        # test pybind load and save
+        save_path = os.path.join(self.test_dir, 'spm_pybind.pt')
+        torch.save(spm, save_path)
+        loaded_spm = torch.load(save_path)
+        self.assertEqual(expected, loaded_spm(input))
+
+        # test torchscript load and save
+        save_path = os.path.join(self.test_dir, 'spm_torchscript.pt')
+        torch.save(spm.to_ivalue(), save_path)
+        loaded_spm = torch.load(save_path)
+        self.assertEqual(expected, loaded_spm(input))

--- a/test/experimental/test_vectors.py
+++ b/test/experimental/test_vectors.py
@@ -111,6 +111,23 @@ class TestVectors(TorchtextTestCase):
         self.assertEqual(vectors_obj['b'], tensorB)
         self.assertEqual(vectors_obj['not_in_it'], unk_tensor)
 
+    def test_vectors_update(self):
+        tensorA = torch.tensor([1, 0], dtype=torch.float)
+        tensorB = torch.tensor([0, 1], dtype=torch.float)
+        tensorC = torch.tensor([1, 1], dtype=torch.float)
+
+        expected_unk_tensor = torch.tensor([0, 0], dtype=torch.float)
+
+        tokens = ['a', 'b']
+        vecs = torch.stack((tensorA, tensorB), 0)
+        vectors_obj = build_vectors(tokens, vecs)
+
+        vectors_obj['b'] = tensorC
+
+        self.assertEqual(vectors_obj['a'], tensorA)
+        self.assertEqual(vectors_obj['b'], tensorC)
+        self.assertEqual(vectors_obj['not_in_it'], expected_unk_tensor)
+
     def test_vectors_load_and_save(self):
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1], dtype=torch.float)
@@ -120,26 +137,23 @@ class TestVectors(TorchtextTestCase):
         vecs = torch.stack((tensorA, tensorB), 0)
         vectors_obj = build_vectors(tokens, vecs)
 
-        tensorC = torch.tensor([1, 1], dtype=torch.float)
-        vectors_obj['b'] = tensorC
+        with self.subTest('pybind'):
+            vector_path = os.path.join(self.test_dir, 'vectors_pybind.pt')
+            torch.save(vectors_obj, vector_path)
+            loaded_vectors_obj = torch.load(vector_path)
 
-        # test pybind load and save
-        vector_path = os.path.join(self.test_dir, 'vectors_pybind.pt')
-        torch.save(vectors_obj, vector_path)
-        loaded_vectors_obj = torch.load(vector_path)
+            self.assertEqual(loaded_vectors_obj['a'], tensorA)
+            self.assertEqual(loaded_vectors_obj['b'], tensorB)
+            self.assertEqual(loaded_vectors_obj['not_in_it'], expected_unk_tensor)
 
-        self.assertEqual(loaded_vectors_obj['a'], tensorA)
-        self.assertEqual(loaded_vectors_obj['b'], tensorC)
-        self.assertEqual(loaded_vectors_obj['not_in_it'], expected_unk_tensor)
+        with self.subTest('torchscript'):
+            vector_path = os.path.join(self.test_dir, 'vectors_torchscript.pt')
+            torch.save(vectors_obj.to_ivalue(), vector_path)
+            loaded_vectors_obj = torch.load(vector_path)
 
-        # test torchscript load and save
-        vector_path = os.path.join(self.test_dir, 'vectors_torchscript.pt')
-        torch.save(vectors_obj.to_ivalue(), vector_path)
-        loaded_vectors_obj = torch.load(vector_path)
-
-        self.assertEqual(loaded_vectors_obj['a'], tensorA)
-        self.assertEqual(loaded_vectors_obj['b'], tensorC)
-        self.assertEqual(loaded_vectors_obj['not_in_it'], expected_unk_tensor)
+            self.assertEqual(loaded_vectors_obj['a'], tensorA)
+            self.assertEqual(loaded_vectors_obj['b'], tensorB)
+            self.assertEqual(loaded_vectors_obj['not_in_it'], expected_unk_tensor)
 
     # we separate out these errors because Windows runs into seg faults when propagating
     # exceptions from C++ using pybind11

--- a/test/experimental/test_vectors.py
+++ b/test/experimental/test_vectors.py
@@ -123,7 +123,17 @@ class TestVectors(TorchtextTestCase):
         tensorC = torch.tensor([1, 1], dtype=torch.float)
         vectors_obj['b'] = tensorC
 
-        vector_path = os.path.join(self.test_dir, 'vectors.pt')
+        # test pybind load and save
+        vector_path = os.path.join(self.test_dir, 'vectors_pybind.pt')
+        torch.save(vectors_obj, vector_path)
+        loaded_vectors_obj = torch.load(vector_path)
+
+        self.assertEqual(loaded_vectors_obj['a'], tensorA)
+        self.assertEqual(loaded_vectors_obj['b'], tensorC)
+        self.assertEqual(loaded_vectors_obj['not_in_it'], expected_unk_tensor)
+
+        # test torchscript load and save
+        vector_path = os.path.join(self.test_dir, 'vectors_torchscript.pt')
         torch.save(vectors_obj.to_ivalue(), vector_path)
         loaded_vectors_obj = torch.load(vector_path)
 

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -199,19 +199,19 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-        # test pybind load and save
-        vocab_path = os.path.join(self.test_dir, 'vocab_pybind.pt')
-        torch.save(v, vocab_path)
-        loaded_v = torch.load(vocab_path)
-        self.assertEqual(v.get_itos(), expected_itos)
-        self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
+        with self.subTest('pybind'):
+            vocab_path = os.path.join(self.test_dir, 'vocab_pybind.pt')
+            torch.save(v, vocab_path)
+            loaded_v = torch.load(vocab_path)
+            self.assertEqual(v.get_itos(), expected_itos)
+            self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
 
-        # test torchscript load and save
-        vocab_path = os.path.join(self.test_dir, 'vocab_torchscript.pt')
-        torch.save(v.to_ivalue(), vocab_path)
-        loaded_v = torch.load(vocab_path)
-        self.assertEqual(v.get_itos(), expected_itos)
-        self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
+        with self.subTest('torchscript'):
+            vocab_path = os.path.join(self.test_dir, 'vocab_torchscript.pt')
+            torch.save(v.to_ivalue(), vocab_path)
+            loaded_v = torch.load(vocab_path)
+            self.assertEqual(v.get_itos(), expected_itos)
+            self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
 
     def test_build_vocab_iterator(self):
         iterator = [['hello', 'hello', 'hello', 'freq_low', 'hello', 'world', 'world', 'world', 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T',

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -199,10 +199,17 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-        vocab_path = os.path.join(self.test_dir, 'vocab.pt')
+        # test pybind load and save
+        vocab_path = os.path.join(self.test_dir, 'vocab_pybind.pt')
+        torch.save(v, vocab_path)
+        loaded_v = torch.load(vocab_path)
+        self.assertEqual(v.get_itos(), expected_itos)
+        self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
+
+        # test torchscript load and save
+        vocab_path = os.path.join(self.test_dir, 'vocab_torchscript.pt')
         torch.save(v.to_ivalue(), vocab_path)
         loaded_v = torch.load(vocab_path)
-
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
 

--- a/torchtext/csrc/regex.cpp
+++ b/torchtext/csrc/regex.cpp
@@ -15,7 +15,7 @@ std::string _serialize_regex(const c10::intrusive_ptr<Regex> &self) {
   return self->re_str_;
 }
 
-c10::intrusive_ptr<Regex> _deserialize_regex(std::string state) {
+c10::intrusive_ptr<Regex> _deserialize_regex(std::string &&state) {
   return c10::make_intrusive<Regex>(std::move(state));
 }
 

--- a/torchtext/csrc/regex.cpp
+++ b/torchtext/csrc/regex.cpp
@@ -11,4 +11,12 @@ std::string Regex::Sub(std::string str, const std::string &repl) const {
   return str;
 }
 
+std::string _serialize_regex(const c10::intrusive_ptr<Regex> &self) {
+  return self->re_str_;
+}
+
+c10::intrusive_ptr<Regex> _deserialize_regex(std::string state) {
+  return c10::make_intrusive<Regex>(std::move(state));
+}
+
 } // namespace torchtext

--- a/torchtext/csrc/regex.h
+++ b/torchtext/csrc/regex.h
@@ -13,4 +13,8 @@ public:
   Regex(const std::string &re_str);
   std::string Sub(std::string str, const std::string &repl) const;
 };
+
+std::string _serialize_regex(const c10::intrusive_ptr<Regex> &self);
+c10::intrusive_ptr<Regex> _deserialize_regex(std::string state);
+
 } // namespace torchtext

--- a/torchtext/csrc/regex.h
+++ b/torchtext/csrc/regex.h
@@ -15,6 +15,6 @@ public:
 };
 
 std::string _serialize_regex(const c10::intrusive_ptr<Regex> &self);
-c10::intrusive_ptr<Regex> _deserialize_regex(std::string state);
+c10::intrusive_ptr<Regex> _deserialize_regex(std::string &&state);
 
 } // namespace torchtext

--- a/torchtext/csrc/regex_tokenizer.cpp
+++ b/torchtext/csrc/regex_tokenizer.cpp
@@ -48,7 +48,7 @@ RegexTokenizerStates _serialize_regex_tokenizer(const c10::intrusive_ptr<RegexTo
   return std::make_tuple(self->patterns_, self->replacements_, self->to_lower_);
 }
 
-c10::intrusive_ptr<RegexTokenizer> _deserialize_regex_tokenizer(RegexTokenizerStates states) {
+c10::intrusive_ptr<RegexTokenizer> _deserialize_regex_tokenizer(RegexTokenizerStates &&states) {
   return c10::make_intrusive<RegexTokenizer>(
       std::move(std::get<0>(states)),
       std::move(std::get<1>(states)),

--- a/torchtext/csrc/regex_tokenizer.cpp
+++ b/torchtext/csrc/regex_tokenizer.cpp
@@ -44,4 +44,15 @@ void RegexTokenizer::split_(std::string &str, std::vector<std::string> &tokens,
   }
 }
 
+RegexTokenizerStates _serialize_regex_tokenizer(const c10::intrusive_ptr<RegexTokenizer> &self) {
+  return std::make_tuple(self->patterns_, self->replacements_, self->to_lower_);
+}
+
+c10::intrusive_ptr<RegexTokenizer> _deserialize_regex_tokenizer(RegexTokenizerStates states) {
+  return c10::make_intrusive<RegexTokenizer>(
+      std::move(std::get<0>(states)),
+      std::move(std::get<1>(states)),
+      std::get<2>(states));
+}
+
 } // namespace torchtext

--- a/torchtext/csrc/regex_tokenizer.h
+++ b/torchtext/csrc/regex_tokenizer.h
@@ -24,6 +24,6 @@ public:
 };
 
 RegexTokenizerStates _serialize_regex_tokenizer(const c10::intrusive_ptr<RegexTokenizer> &self);
-c10::intrusive_ptr<RegexTokenizer> _deserialize_regex_tokenizer(RegexTokenizerStates states);
+c10::intrusive_ptr<RegexTokenizer> _deserialize_regex_tokenizer(RegexTokenizerStates &&states);
 
 } // namespace torchtext

--- a/torchtext/csrc/regex_tokenizer.h
+++ b/torchtext/csrc/regex_tokenizer.h
@@ -3,6 +3,9 @@
 
 namespace torchtext {
 
+typedef std::tuple<std::vector<std::string>, std::vector<std::string>, bool>
+    RegexTokenizerStates;
+
 struct RegexTokenizer : torch::CustomClassHolder {
 private:
   std::vector<RE2 *> compiled_patterns_;
@@ -19,5 +22,8 @@ public:
                           const bool to_lower);
   std::vector<std::string> forward(std::string str) const;
 };
+
+RegexTokenizerStates _serialize_regex_tokenizer(const c10::intrusive_ptr<RegexTokenizer> &self);
+c10::intrusive_ptr<RegexTokenizer> _deserialize_regex_tokenizer(RegexTokenizerStates states);
 
 } // namespace torchtext

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -27,18 +27,36 @@ Vocab build_vocab_from_text_file(const std::string &file_path,
 // Registers our custom classes with pybind11.
 PYBIND11_MODULE(_torchtext, m) {
   // Classes
-  py::class_<Regex>(m, "Regex")
+  py::class_<Regex, c10::intrusive_ptr<Regex>>(m, "Regex")
       .def(py::init<std::string>())
-      .def("Sub", &Regex::Sub);
+      .def("Sub", &Regex::Sub)
+      .def(py::pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<Regex> &self) -> std::string {
+            return _serialize_regex(self);
+          },
+          // __setstate__
+          [](std::string state) -> c10::intrusive_ptr<Regex> {
+            return _deserialize_regex(state);
+          }));
 
-  py::class_<RegexTokenizer>(m, "RegexTokenizer")
+  py::class_<RegexTokenizer, c10::intrusive_ptr<RegexTokenizer>>(m, "RegexTokenizer")
       .def_readonly("patterns_", &RegexTokenizer::patterns_)
       .def_readonly("replacements_", &RegexTokenizer::replacements_)
       .def_readonly("to_lower_", &RegexTokenizer::to_lower_)
       .def(py::init<std::vector<std::string>, std::vector<std::string>, bool>())
-      .def("forward", &RegexTokenizer::forward);
+      .def("forward", &RegexTokenizer::forward)
+      .def(py::pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<RegexTokenizer> &self) -> RegexTokenizerStates {
+            return _serialize_regex_tokenizer(self);
+          },
+          // __setstate__
+          [](RegexTokenizerStates states) -> c10::intrusive_ptr<RegexTokenizer> {
+            return _deserialize_regex_tokenizer(states);
+          }));
 
-  py::class_<SentencePiece>(m, "SentencePiece")
+  py::class_<SentencePiece, c10::intrusive_ptr<SentencePiece>>(m, "SentencePiece")
       .def(py::init<std::string>())
       .def("_return_content",
            [](const SentencePiece &self) { return py::bytes(self.content_); })
@@ -50,9 +68,18 @@ PYBIND11_MODULE(_torchtext, m) {
       .def("GetPieceSize", &SentencePiece::GetPieceSize)
       .def("unk_id", &SentencePiece::unk_id)
       .def("PieceToId", &SentencePiece::PieceToId)
-      .def("IdToPiece", &SentencePiece::IdToPiece);
+      .def("IdToPiece", &SentencePiece::IdToPiece)
+      .def(py::pickle(
+           // __getstate__
+           [](const c10::intrusive_ptr<SentencePiece> &self) -> py::bytes{
+             return py::bytes(_serialize_sentence_piece(self));
+           },
+           // __setstate__
+           [](py::bytes state) -> c10::intrusive_ptr<SentencePiece> {
+             return _deserialize_sentence_piece(std::string(state));
+           }));
 
-  py::class_<Vectors>(m, "Vectors")
+  py::class_<Vectors, c10::intrusive_ptr<Vectors>>(m, "Vectors")
       .def(py::init<std::vector<std::string>, std::vector<int64_t>,
                     torch::Tensor, torch::Tensor>())
       .def_readonly("vectors_", &Vectors::vectors_)
@@ -61,9 +88,18 @@ PYBIND11_MODULE(_torchtext, m) {
       .def("__getitem__", &Vectors::__getitem__)
       .def("lookup_vectors", &Vectors::lookup_vectors)
       .def("__setitem__", &Vectors::__setitem__)
-      .def("__len__", &Vectors::__len__);
+      .def("__len__", &Vectors::__len__)
+      .def(py::pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<Vectors> &self) -> VectorsStates {
+            return _serialize_vectors(self);
+          },
+          // __setstate__
+          [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
+            return _deserialize_vectors(states);
+          }));
 
-  py::class_<Vocab>(m, "Vocab")
+  py::class_<Vocab, c10::intrusive_ptr<Vocab>>(m, "Vocab")
       .def(py::init<std::vector<std::string>, std::string>())
       .def_readonly("itos_", &Vocab::itos_)
       .def_readonly("unk_token_", &Vocab::unk_token_)
@@ -75,7 +111,16 @@ PYBIND11_MODULE(_torchtext, m) {
       .def("lookup_tokens", &Vocab::lookup_tokens)
       .def("lookup_indices", &Vocab::lookup_indices)
       .def("get_stoi", &Vocab::get_stoi)
-      .def("get_itos", &Vocab::get_itos);
+      .def("get_itos", &Vocab::get_itos)
+      .def(py::pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<Vocab> &self) -> VocabStates {
+            return _serialize_vocab(self);
+          },
+          // __setstate__
+          [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
+              return _deserialize_vocab(states);
+          }));
 
   // Functions
   m.def("_load_token_and_vectors_from_file",
@@ -91,32 +136,26 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
     .def_pickle(
         // __getstate__
         [](const c10::intrusive_ptr<Regex> &self) -> std::string {
-          return self->re_str_;
+          return _serialize_regex(self);
         },
         // __setstate__
         [](std::string state) -> c10::intrusive_ptr<Regex> {
-          return c10::make_intrusive<Regex>(std::move(state));
+          return _deserialize_regex(state);
         });
 
-  using RegexTokenizerState = std::tuple<std::vector<std::string>, std::vector<std::string>, bool>;
   m.class_<RegexTokenizer>("RegexTokenizer")
     .def(torch::init<std::vector<std::string>, std::vector<std::string>, bool>())
     .def("forward", &RegexTokenizer::forward)
     .def_pickle(
         // __getstate__
-        [](const c10::intrusive_ptr<RegexTokenizer> &self) -> RegexTokenizerState {
-          return std::make_tuple(
-                 self->patterns_,
-                 self->replacements_,
-                 self->to_lower_);
+        [](const c10::intrusive_ptr<RegexTokenizer> &self) -> RegexTokenizerStates {
+          return _serialize_regex_tokenizer(self);
         },
         // __setstate__
-        [](RegexTokenizerState state) -> c10::intrusive_ptr<RegexTokenizer> {
-          return c10::make_intrusive<RegexTokenizer>(
-                 std::move(std::get<0>(state)),
-                 std::move(std::get<1>(state)),
-                 std::get<2>(state));
+        [](RegexTokenizerStates states) -> c10::intrusive_ptr<RegexTokenizer> {
+          return _deserialize_regex_tokenizer(states);
         });
+
   m.class_<SentencePiece>("SentencePiece")
     .def(torch::init<std::string>())
     .def("Encode", &SentencePiece::Encode)
@@ -147,11 +186,11 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
     .def_pickle(
         // __getstate__
         [](const c10::intrusive_ptr<Vectors> &self) -> VectorsStates {
-          return _set_vectors_states(self);
+          return _serialize_vectors(self);
         },
         // __setstate__
         [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
-          return _get_vectors_from_states(states);
+          return _deserialize_vectors(states);
         });
 
   m.class_<Vocab>("Vocab")
@@ -168,11 +207,11 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
     .def_pickle(
         // __getstate__
         [](const c10::intrusive_ptr<Vocab> &self) -> VocabStates {
-          return _set_vocab_states(self);
+          return _serialize_vocab(self);
         },
         // __setstate__
         [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
-          return _get_vocab_from_states(states);
+          return _deserialize_vocab(states);
         });
 
   m.def("torchtext::generate_sp_model", &generate_sp_model);

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -176,7 +176,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
         [](const c10::intrusive_ptr<SentencePiece> &self) -> torch::Tensor {
           auto *data = static_cast<void*>(const_cast<char*>(self->content_.data()));
           auto numel = static_cast<int64_t>(self->content_.size());
-          return torch::from_blob(data, {numel}, {torch::kUInt8});
+          return torch::from_blob(data, {numel}, {torch::kUInt8}).clone();
         },
         // __setstate__
         [](torch::Tensor state) -> c10::intrusive_ptr<SentencePiece> {

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -175,7 +175,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
         // __getstate__
         [](const c10::intrusive_ptr<SentencePiece> &self) -> torch::Tensor {
           auto *data = static_cast<void*>(const_cast<char*>(self->content_.data()));
-          auto numel = self->content_.size();
+          auto numel = static_cast<int64_t>(self->content_.size());
           return torch::from_blob(data, {numel}, {torch::kUInt8});
         },
         // __setstate__

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -37,7 +37,7 @@ PYBIND11_MODULE(_torchtext, m) {
           },
           // __setstate__
           [](std::string state) -> c10::intrusive_ptr<Regex> {
-            return _deserialize_regex(state);
+            return _deserialize_regex(std::move(state));
           }));
 
   py::class_<RegexTokenizer, c10::intrusive_ptr<RegexTokenizer>>(m, "RegexTokenizer")
@@ -53,7 +53,7 @@ PYBIND11_MODULE(_torchtext, m) {
           },
           // __setstate__
           [](RegexTokenizerStates states) -> c10::intrusive_ptr<RegexTokenizer> {
-            return _deserialize_regex_tokenizer(states);
+            return _deserialize_regex_tokenizer(std::move(states));
           }));
 
   py::class_<SentencePiece, c10::intrusive_ptr<SentencePiece>>(m, "SentencePiece")
@@ -119,7 +119,7 @@ PYBIND11_MODULE(_torchtext, m) {
           },
           // __setstate__
           [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
-              return _deserialize_vocab(states);
+            return _deserialize_vocab(states);
           }));
 
   // Functions
@@ -140,7 +140,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
         },
         // __setstate__
         [](std::string state) -> c10::intrusive_ptr<Regex> {
-          return _deserialize_regex(state);
+          return _deserialize_regex(std::move(state));
         });
 
   m.class_<RegexTokenizer>("RegexTokenizer")
@@ -153,7 +153,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
         },
         // __setstate__
         [](RegexTokenizerStates states) -> c10::intrusive_ptr<RegexTokenizer> {
-          return _deserialize_regex_tokenizer(states);
+          return _deserialize_regex_tokenizer(std::move(states));
         });
 
   m.class_<SentencePiece>("SentencePiece")

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -275,7 +275,7 @@ std::tuple<Vectors, std::vector<std::string>> _load_token_and_vectors_from_file(
   return result;
 }
 
-VectorsStates _set_vectors_states(const c10::intrusive_ptr<Vectors> &self) {
+VectorsStates _serialize_vectors(const c10::intrusive_ptr<Vectors> &self) {
   std::vector<std::string> tokens;
   std::vector<int64_t> indices;
   tokens.reserve(self->stoi_.size());
@@ -299,7 +299,7 @@ VectorsStates _set_vectors_states(const c10::intrusive_ptr<Vectors> &self) {
   return states;
 }
 
-c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states) {
+c10::intrusive_ptr<Vectors> _deserialize_vectors(VectorsStates states) {
   auto state_size = std::tuple_size<decltype(states)>::value;
   if (state_size != 4) {
     throw std::runtime_error(

--- a/torchtext/csrc/vectors.h
+++ b/torchtext/csrc/vectors.h
@@ -32,8 +32,8 @@ public:
   int64_t __len__();
 };
 
-c10::intrusive_ptr<Vectors> _get_vectors_from_states(VectorsStates states);
-VectorsStates _set_vectors_states(const c10::intrusive_ptr<Vectors> &self);
+VectorsStates _serialize_vectors(const c10::intrusive_ptr<Vectors> &self);
+c10::intrusive_ptr<Vectors> _deserialize_vectors(VectorsStates states);
 
 std::tuple<Vectors, std::vector<std::string>> _load_token_and_vectors_from_file(
     const std::string &file_path, const std::string delimiter_str,

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -379,7 +379,7 @@ Vocab _build_vocab_from_text_file(const std::string &file_path,
   return Vocab(std::move(tokens), std::move(stoi), unk_token, unk_index);
 }
 
-VocabStates _set_vocab_states(const c10::intrusive_ptr<Vocab> &self) {
+VocabStates _serialize_vocab(const c10::intrusive_ptr<Vocab> &self) {
   std::vector<int64_t> integers;
   StringList strings = self->itos_;
   strings.push_back(self->unk_token_);
@@ -390,7 +390,7 @@ VocabStates _set_vocab_states(const c10::intrusive_ptr<Vocab> &self) {
   return states;
 }
 
-c10::intrusive_ptr<Vocab> _get_vocab_from_states(VocabStates states) {
+c10::intrusive_ptr<Vocab> _deserialize_vocab(VocabStates states) {
   auto state_size = std::tuple_size<decltype(states)>::value;
   if (state_size != 4) {
 #ifdef _MSC_VER

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -35,8 +35,9 @@ public:
   std::vector<std::string> get_itos() const;
 };
 
-c10::intrusive_ptr<Vocab> _get_vocab_from_states(VocabStates states);
-VocabStates _set_vocab_states(const c10::intrusive_ptr<Vocab> &self);
+VocabStates _serialize_vocab(const c10::intrusive_ptr<Vocab> &self);
+c10::intrusive_ptr<Vocab> _deserialize_vocab(VocabStates states);
+
 Vocab _load_vocab_from_file(const std::string &file_path,
                             const std::string &unk_token,
                             const int64_t min_freq, const int64_t num_cpus);


### PR DESCRIPTION
This PR makes Regex, RegexTokenizer, Vocab, Vectors and SentencePiece
pickle-able on both PyBind11 and TorchScript.

closes #1085 

## Approach

1. define `_serialize_XXX` and `_deserialize_XXX` next to these classes
    This is the replacement of `_get_states_XXX` and `_set_states_XXX`.
    I saw the names of the original functions were flipped, and used wrongly in
    `__getstate__` and `__setstate__` so I changed the function names to something
    more descriptive and less confusing.

2. Use `c10::intrusive_ptr` as holder for custom class when using pybind11.
    This allows to use the same serialization/deserialization function for both
    PyBind11 and TorchScript.
    See https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html#smart-pointers
    for the detail of holder.

3. For pickling TorchScript-bound `SentencePiece`, use byte Tensor as bytes container
    The serialized form of `SentencePiece` is byte string and returning `std::string` to 
    Python realm causes decoding error as Python tries to decode it as UTF-8.
    PyBind11 can work around this with `pybind11::bytes` type, but TorchScript does not
    support byte string, this approach uses bytes Tensor as a container/intermediate format
    to pass byte string to Python.

## Problem

* ~[TorchScript does not support `bytes`](https://pytorch.org/docs/stable/jit_language_reference.html#unsupported-typing-constructs), thus SentencePiece bound via TorchScript is not pickle-able.~

## Added I/O round trip tests

| class | PyBind11 | TorchScript |
|:-----:|:---------:|:------------:|
| `Regex` | | |
| `RegexTokenizer` | ✅ | ✅ |
| `BasicEnglishNormalize` | ✅ | ✅ |
| `Vocab` | ✅ | ✅ |
| `Vectors` | ✅ | ✅ |
| `SentencePiece` | ✅ | ✅ |
