### PR TITLE
build docs and push to gh-pages on nightly

### DIFF
--- a/.circleci/build_docs/commit_docs.sh
+++ b/.circleci/build_docs/commit_docs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -ex
+
+
+if [ "$2" == "" ]; then
+    echo call as "$0" "<src>" "<target branch>"
+    echo where src is the root of the built documentation git checkout and
+    echo branch should be "master" or "1.7" or so
+    exit 1
+fi
+
+src=$1
+target=$2
+
+echo "committing docs from ${src} to ${target}"
+
+pushd $src
+git checkout gh-pages
+git pull
+mkdir -p ./"${target}"
+rm -rf ./"${target}"/*
+cp -r "${src}/docs/build/html/"* ./"$target"
+if [ "${target}" == "master" ]; then
+    mkdir -p ./_static
+    rm -rf ./_static/*
+    cp -r "${src}/docs/build/html/_static/"* ./_static
+    git add --all ./_static || true
+fi
+git add --all ./"${target}" || true
+git config user.email "soumith+bot@pytorch.org"
+git config user.name "pytorchbot"
+# If there aren't changes, don't make a commit; push is no-op
+git commit -m "auto-generating sphinx docs" || true
+git remote add https https://github.com/pytorch/audio.git
+git push -u https gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,63 @@ jobs:
       - run:
           name: Run style check
           command: .circleci/unittest/linux/scripts/run_style_checks.sh
+  build_docs:
+    <<: *binary_common
+    docker:
+      - image: continuumio/miniconda3
+    resource_class: medium
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - designate_upload_channel
+      - checkout
+      - run:
+          name: install binaries
+          command: |
+            set -x
+            conda install make
+            pip install $(ls ~/workspace/torchtext*.whl) --pre -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/cpu/torch_${UPLOAD_CHANNEL}.html"
+      - run:
+          name: Build docs
+          command: |
+            set -x
+            pushd docs
+            pip install -r requirements.txt
+            make html
+            popd
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - "*"
+
+  upload_docs:
+    <<: *binary_common
+    docker:
+      - image: continuumio/miniconda3
+    resource_class: medium
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - run:
+          name: Generate netrc
+          command: |
+            # set credentials for https pushing
+            # requires the org-member context
+            cat > ~/.netrc \<<DONE
+              machine github.com
+              login pytorchbot
+              password ${GITHUB_PYTORCHBOT_TOKEN}
+            DONE
+      - run:
+          name: Upload docs
+          command: |
+            # Don't use "checkout" step since it uses ssh, which cannot git push
+            # https://circleci.com/docs/2.0/configuration-reference/#checkout
+            set -ex
+            tag=${CIRCLE_TAG:1:5}
+            target=${tag:-master}
+            ~/workspace/.circleci/build_docs/commit_docs.sh ~/workspace $target
+
 
 workflows:
   build:
@@ -526,6 +583,22 @@ workflows:
       - binary_windows_conda:
           name: binary_windows_conda_py3.8
           python_version: '3.8'
+      - build_docs:
+          name: build_docs
+          python_version: '3.8'
+          requires:
+          - binary_linux_wheel_py3.8
+      - upload_docs:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: upload_docs
+          python_version: '3.8'
+          requires:
+          - build_docs
   unittest:
     jobs:
       - unittest_linux:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -467,6 +467,63 @@ jobs:
       - run:
           name: Run style check
           command: .circleci/unittest/linux/scripts/run_style_checks.sh
+  build_docs:
+    <<: *binary_common
+    docker:
+      - image: continuumio/miniconda3
+    resource_class: medium
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - designate_upload_channel
+      - checkout
+      - run:
+          name: install binaries
+          command: |
+            set -x
+            conda install make
+            pip install $(ls ~/workspace/torchtext*.whl) --pre -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/cpu/torch_${UPLOAD_CHANNEL}.html"
+      - run:
+          name: Build docs
+          command: |
+            set -x
+            pushd docs
+            pip install -r requirements.txt
+            make html
+            popd
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - "*"
+
+  upload_docs:
+    <<: *binary_common
+    docker:
+      - image: continuumio/miniconda3
+    resource_class: medium
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - run:
+          name: Generate netrc
+          command: |
+            # set credentials for https pushing
+            # requires the org-member context
+            cat > ~/.netrc \<<DONE
+              machine github.com
+              login pytorchbot
+              password ${GITHUB_PYTORCHBOT_TOKEN}
+            DONE
+      - run:
+          name: Upload docs
+          command: |
+            # Don't use "checkout" step since it uses ssh, which cannot git push
+            # https://circleci.com/docs/2.0/configuration-reference/#checkout
+            set -ex
+            tag=${CIRCLE_TAG:1:5}
+            target=${tag:-master}
+            ~/workspace/.circleci/build_docs/commit_docs.sh ~/workspace $target
+
 
 workflows:
   build:


### PR DESCRIPTION
Copy pytorch/audio#1100 and friends to here, which 
- builds docs on every PR
- pushes the built docs on nightly (to `gh-pages/master`) and when the repo is tagged (to `gh-pages/tag`)