### PR TITLE
packaging: Specify cpuonly for conda meta.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
           command: |
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y -c file://$HOME/workspace/conda-bld torchtext
       - run:
           name: smoke test
@@ -299,7 +299,7 @@ jobs:
             conda env remove -n python${PYTHON_VERSION} || true
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-"${UPLOAD_CHANNEL}" pytorch
+            conda install -v -y -c pytorch-"${UPLOAD_CHANNEL}" pytorch cpuonly
             conda install -v -y -c ~/workspace/conda-bld torchtext
       - run:
           name: smoke test

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -237,7 +237,7 @@ jobs:
           command: |
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y -c file://$HOME/workspace/conda-bld torchtext
       - run:
           name: smoke test
@@ -299,7 +299,7 @@ jobs:
             conda env remove -n python${PYTHON_VERSION} || true
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-"${UPLOAD_CHANNEL}" pytorch
+            conda install -v -y -c pytorch-"${UPLOAD_CHANNEL}" pytorch cpuonly
             conda install -v -y -c ~/workspace/conda-bld torchtext
       - run:
           name: smoke test

--- a/packaging/torchtext/meta.yaml
+++ b/packaging/torchtext/meta.yaml
@@ -38,6 +38,7 @@ test:
 
   requires:
     - pytest
+    - cpuonly
 
 about:
   home: https://github.com/pytorch/text


### PR DESCRIPTION
Package installation for pytorch binaries was failing out due to
https://github.com/conda/conda-package-handling/issues/71

Default to cpuonly since that won't fail out.

Similar to https://github.com/pytorch/audio/pull/1105

This should resolve issues within the nightly pipeline for conda builds

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>