### PR TITLE
DOCS: remove 'git pull'

### DIFF
--- a/.circleci/build_docs/commit_docs.sh
+++ b/.circleci/build_docs/commit_docs.sh
@@ -17,7 +17,6 @@ echo "committing docs from ${src} to ${target}"
 
 pushd $src
 git checkout gh-pages
-git pull
 mkdir -p ./"${target}"
 rm -rf ./"${target}"/*
 cp -r "${src}/docs/build/html/"* ./"$target"


### PR DESCRIPTION
continuation of gh-1105

Remove git pull, which was meant to solve a possible race condition (if between the time the CI run clones the repo, builds the project, builds the docs, and check out the gh-pages branch someone else has pushed a change to the branch), but does not work.

Please trigger a nightly build after merging this to test it out.