### PR TITLE
Fixed Sentiment Analysis Dataset docs

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -74,13 +74,13 @@ SST
 ~~~
 
 .. autoclass:: SST
-  :members: splits, iters
+  :members: __init__, splits, iters
 
 IMDb
 ~~~~
 
 .. autoclass:: IMDB
-  :members: splits, iters
+  :members: __init__, splits, iters
 
 
 Text Classification


### PR DESCRIPTION
Currently, the `__init__`  documentation does not show up in the documentation for the [Sentiment Analysis datasets](https://pytorch.org/text/stable/datasets.html#sentiment-analysis).  This PR fixes this issue.