### PR TITLE
Strip "+cpu" suffix in pip runtime dependency.

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -38,7 +38,7 @@ setup_cuda() {
   # Wheel builds need suffixes (but not if they're on OS X, which never has suffix)
   if [[ "$BUILD_TYPE" == "wheel" ]] && [[ "$(uname)" != Darwin ]]; then
     # The default CUDA has no suffix
-    if [[ "$CU_VERSION" != "cu100" ]]; then
+    if [[ "$CU_VERSION" != "cu100" ]] && [[ "$CU_VERSION" != "cpu" ]]; then
       export PYTORCH_VERSION_SUFFIX="+$CU_VERSION"
     fi
     # Match the suffix scheme of pytorch, unless this package does not have


### PR DESCRIPTION
Currently, torchtext wheels depend on torch versions that have "+cpu" suffix, for example:
    
    $ pkginfo -f requires_dist torchtext-0.9.0.dev20210109-cp38-cp38-linux_x86_64.whl
       torch (==1.8.0.dev20210109+cpu)

In fact, we don't publish torch packages with "+cpu" suffix on PyPI. This PR is to remove this suffix as dependency.