### PR TITLE
packaging: Always strip +.* for torch dependency

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -163,13 +163,9 @@ setup_pip_pytorch_version() {
     # Install latest prerelease version of torch, per our nightlies, consistent
     # with the requested cuda version
     pip_install --pre torch -f "https://download.pytorch.org/whl/nightly/${WHEEL_DIR}torch_nightly.html"
-    if [[ "$CUDA_VERSION" == "cpu" ]]; then
-      # CUDA and CPU are ABI compatible on the CPU-only parts, so strip
-      # in this case
-      export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-    else
-      export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//')"
-    fi
+    # CUDA and CPU are ABI compatible on the CPU-only parts, so strip
+    # in this case
+    export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
   else
     pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
       -f https://download.pytorch.org/whl/torch_stable.html \


### PR DESCRIPTION
Packages were getting unfairly pinned as needing the `+cpu` version of
pytorch when all versions of pytorch should be ABI compatible when
running cpu-only operations.

This eliminates any suffixed version we may have for torch and makes it
so that torchtext can be installed with any version of torch

Tested with the following script:
```
$ cat <<"EOF" | docker run --rm -i -v $(pwd):/v -w /v python:3.8 bash
#!/usr/bin/env bash

source packaging/pkg_helpers.bash

CU_VERSION=cpu

setup_cuda
setup_pip_pytorch_version
echo "PYTORCH_VERSION=${PYTORCH_VERSION}"
EOF
Looking in links: https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
Collecting torch
  Downloading https://download.pytorch.org/whl/nightly/cpu/torch-1.8.0.dev20210113%2Bcpu-cp38-cp38-linux_x86_64.whl (166.7 MB)
Collecting numpy
  Downloading numpy-1.20.0rc2-cp38-cp38-manylinux2010_x86_64.whl (15.3 MB)
Collecting typing-extensions
  Downloading typing_extensions-3.7.4.3-py3-none-any.whl (22 kB)
Installing collected packages: typing-extensions, numpy, torch
Successfully installed numpy-1.20.0rc2 torch-1.8.0.dev20210113+cpu typing-extensions-3.7.4.3
PYTORCH_VERSION=1.8.0.dev20210113
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>