### PR TITLE
Pass BUILD_VERSION env from local shell to conda build.

### DIFF
--- a/packaging/torchtext/meta.yaml
+++ b/packaging/torchtext/meta.yaml
@@ -25,6 +25,8 @@ requirements:
 
 build:
   string: py{{py}}
+  script_env:
+    - BUILD_VERSION
 
 test:
   imports:


### PR DESCRIPTION
Fixes nightly conda version by passing through BUILD_VERSION environment variable.