### PR TITLE
Add the option to run a reference MLM workflow with fairseq pretrained XLM-R model

### DIFF
--- a/examples/BERT/README.md
+++ b/examples/BERT/README.md
@@ -149,4 +149,8 @@ This example also shows a cross-lingual MLM task with XLM-R. The workflow requir
 
 To run the workflow with 3000 lines from each of the 100 languages (CC-100 dataset)
 
-    python cross_lingual_mlm_task.py --num_lines 3000 
+    python cross_lingual_mlm_task.py --num_lines 3000
+
+To Run the reference XLM-R model from fairseq, download and unzip the pretrained model from [link](https://dl.fbaipublicfiles.com/fairseq/models/xlmr.large.tar.gz).
+
+    python cross_lingual_mlm_task.py --eval_ref ./xlmr.large 

--- a/examples/BERT/model.py
+++ b/examples/BERT/model.py
@@ -225,3 +225,13 @@ class QuestionAnswerTask(nn.Module):
         start_pos = start_pos.squeeze(-1)
         end_pos = end_pos.squeeze(-1)
         return start_pos, end_pos
+
+
+class BatchFirstModel(nn.Module):
+    "Model accepts batch-first input while the batch dim is at position 1 for the input and output"
+    def __init__(self, nn_model):
+        super(BatchFirstModel, self).__init__()
+        self.nn_model = nn_model
+
+    def forward(self, x):
+        return self.nn_model(x.transpose(0, 1)).transpose(0, 1)

--- a/examples/BERT/model.py
+++ b/examples/BERT/model.py
@@ -234,4 +234,7 @@ class BatchFirstModel(nn.Module):
         self.nn_model = nn_model
 
     def forward(self, x):
-        return self.nn_model(x.transpose(0, 1)).transpose(0, 1)
+#        return self.nn_model(x)[0]
+        outputs = self.nn_model(x.transpose(0, 1))
+        # print("outputs - ", outputs, outputs[0].size())
+        return outputs[0].transpose(0, 1)

--- a/examples/BERT/model.py
+++ b/examples/BERT/model.py
@@ -225,16 +225,3 @@ class QuestionAnswerTask(nn.Module):
         start_pos = start_pos.squeeze(-1)
         end_pos = end_pos.squeeze(-1)
         return start_pos, end_pos
-
-
-class BatchFirstModel(nn.Module):
-    "Model accepts batch-first input while the batch dim is at position 1 for the input and output"
-    def __init__(self, nn_model):
-        super(BatchFirstModel, self).__init__()
-        self.nn_model = nn_model
-
-    def forward(self, x):
-#        return self.nn_model(x)[0]
-        outputs = self.nn_model(x.transpose(0, 1))
-        # print("outputs - ", outputs, outputs[0].size())
-        return outputs[0].transpose(0, 1)


### PR DESCRIPTION
Fairseq published two reference pretrained XLM-R models and we evaluated those two models in the cross-lingual MLM workflow with WikiText2 valid dataset. The perplexity (PPL) is available in the table below: 


Model | Description | #params | vocab size | Download | Perplexity (ppl)
-- | -- | -- | -- | -- | --
xlmr.base | XLM-R using the BERT-base architecture | 250M | 250k | [xlm.base.tar.gz](https://dl.fbaipublicfiles.com/fairseq/models/xlmr.base.tar.gz) | 6.85
xlmr.large | XLM-R using the BERT-large architecture | 560M | 250k | [xlm.large.tar.gz](https://dl.fbaipublicfiles.com/fairseq/models/xlmr.large.tar.gz) | 5.36
