### PR TITLE
DistCrossLingualMLMTask with two shards

### DIFF
--- a/examples/BERT/README.md
+++ b/examples/BERT/README.md
@@ -151,6 +151,10 @@ To run the workflow with 3000 lines from each of the 100 languages (CC-100 datas
 
     python cross_lingual_mlm_task.py --num_lines 3000
 
+To run the distributed training use '--dist' flag, to specify world size use '--world_size=N', the default world size is 3 for one master and 2 worker nodes.
+
+    python cross_lingual_mlm_task.py --num_lines 3000 --dist
+
 To Run the reference XLM-R model from fairseq, download and unzip the pretrained model from [link](https://dl.fbaipublicfiles.com/fairseq/models/xlmr.large.tar.gz).
 
     python cross_lingual_mlm_task.py --eval_ref ./xlmr.large 

--- a/examples/BERT/dist_model.py
+++ b/examples/BERT/dist_model.py
@@ -1,0 +1,114 @@
+import threading
+
+import torch
+import torch.distributed.rpc as rpc
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.rpc import RRef
+from torch.nn import Linear, LayerNorm
+
+from model import XLMREmbedding, TransformerEncoderLayer, TransformerEncoder
+
+
+def get_cuda_if_available(i):
+    assert i >= 0
+    if torch.cuda.is_available():
+        return f"cuda:{min(i, torch.cuda.device_count() - 1)}"
+    else:
+        return "cpu"
+
+
+class CrossLingualMLMTaskBase(nn.Module):
+    def __init__(self, device):
+        super(CrossLingualMLMTaskBase, self).__init__()
+        self.device = device
+        self._lock = threading.Lock()
+
+    def forward(self, x_rref):
+        x = x_rref.to_here().to(self.device)
+        with self._lock:
+            out = self._forward(x)
+        return out.cpu()
+
+    def parameter_rrefs(self):
+        r"""
+        Create one RRef for each parameter in the given local module, and return a
+        list of RRefs.
+        """
+        return [RRef(p) for p in self.parameters()]
+
+
+class CrossLingualMLMTaskShard1(CrossLingualMLMTaskBase):
+    def __init__(self, device, ntoken, ninp, nhead, nhid, nlayers, dropout=0.5):
+        super(CrossLingualMLMTaskShard1, self).__init__(device)
+        self.xlmr_embed = XLMREmbedding(ntoken, ninp, dropout).to(device)
+        encoder_layers = TransformerEncoderLayer(ninp, nhead, nhid, dropout)
+        self.transformer_encoder = TransformerEncoder(encoder_layers, nlayers // 2).to(device)
+
+    def _forward(self, src):
+        output = self.xlmr_embed(src)
+        output = self.transformer_encoder(output)
+        return output
+
+
+class CrossLingualMLMTaskShard2(CrossLingualMLMTaskBase):
+    def __init__(self, device, ntoken, ninp, nhead, nhid, nlayers, dropout=0.5):
+        super(CrossLingualMLMTaskShard2, self).__init__(device)
+        encoder_layers = TransformerEncoderLayer(ninp, nhead, nhid, dropout)
+        self.transformer_encoder = TransformerEncoder(encoder_layers, nlayers // 2).to(device)
+        self.mlm_span = Linear(ninp, ninp).to(device)
+        self.activation = F.gelu
+        self.norm_layer = LayerNorm(ninp, eps=1e-12).to(device)
+        self.mlm_head = Linear(ninp, ntoken).to(device)
+
+    def _forward(self, src):
+        output = self.transformer_encoder(src)
+        output = self.mlm_span(output)
+        output = self.activation(output)
+        output = self.norm_layer(output)
+        output = self.mlm_head(output)
+        return output
+
+
+class DistCrossLingualMLMTask(nn.Module):
+    """Two shards CrossLingualMLMTask"""
+
+    def __init__(self, split_size, workers, *args, **kwargs):
+        super(DistCrossLingualMLMTask, self).__init__()
+
+        self.split_size = split_size
+
+        # Put the first part of the ResNet50 on workers[0]
+        self.p1_rref = rpc.remote(
+            workers[0],
+            CrossLingualMLMTaskShard1,
+            args=(get_cuda_if_available(0),) + args,
+            kwargs=kwargs
+        )
+
+        # Put the second part of the ResNet50 on workers[1]
+        self.p2_rref = rpc.remote(
+            workers[1],
+            CrossLingualMLMTaskShard2,
+            args=(get_cuda_if_available(1),) + args,
+            kwargs=kwargs
+        )
+
+    def forward(self, xs):
+        # Split the input batch xs into micro-batches, and collect async RPC
+        # futures into a list
+        out_futures = []
+        for x in iter(xs.split(self.split_size, dim=0)):
+            x_rref = RRef(x)
+            y_rref = self.p1_rref.remote().forward(x_rref)
+            z_fut = self.p2_rref.rpc_async().forward(y_rref)
+            out_futures.append(z_fut)
+
+        # collect and cat all output tensors into one tensor.
+        return torch.cat(torch.futures.wait_all(out_futures))
+
+    def parameter_rrefs(self):
+        remote_params = []
+        remote_params.extend(self.p1_rref.remote().parameter_rrefs().to_here())
+        remote_params.extend(self.p2_rref.remote().parameter_rrefs().to_here())
+        return remote_params


### PR DESCRIPTION
I started with looking into the CrossLingualMLMTask model parameters using torchsummary. According to my measurements the Embedding layers has 195841536 params, then we have 12 x 7087872 = 85054464 params of the Encoder layers and 192842128 params on the end layers. 196M + 85M + 193M ~= 474M. Since the largest layers are the first one and the last one, it was quite obvious to split the model right in the middle to form 2 shards with almost equal number of params. XLMRModel holds about 3/5 of params and prevents from dividing the model into two equal parts. Therefore I had to "inline" XLMRModel layers into CrossLingualMLMTask and split its encoder to two sequential encoders. Then I used the pipeline parallelism tutorial and adopted it to DistCrossLingualMLMTask.
The code seems working, but don't judge me for this very early version. I need to fix grad clip and scheduler. It easily allows to increase most of hyper-params. I was able to use batch size of 32, emsiz of 1024, nhid of 4096, nlayers of 24 and nhead of 16.

python cross_lingual_mlm_task.py --num_lines 3000 --batch_size=32 --split_size=32 --nlayers=24 --nhead=16 --emsize=1024 --nhid=4096

| epoch   1 |    10/10781 batches | lr 00nan | ms/batch 8582.67 | loss 13.76 | ppl 942230.75
| epoch   1 |    20/10781 batches | lr 00nan | ms/batch 8199.55 | loss 12.29 | ppl 218385.44
| epoch   1 |    30/10781 batches | lr 00nan | ms/batch 8059.80 | loss 12.17 | ppl 192853.54
| epoch   1 |    40/10781 batches | lr 00nan | ms/batch 7069.72 | loss 12.01 | ppl 164905.54
| epoch   1 |    50/10781 batches | lr 00nan | ms/batch 8507.27 | loss 12.00 | ppl 162889.12
| epoch   1 |    60/10781 batches | lr 00nan | ms/batch 8764.98 | loss 11.76 | ppl 127593.91
| epoch   1 |    70/10781 batches | lr 00nan | ms/batch 6516.39 | loss 11.69 | ppl 119626.47
| epoch   1 |    80/10781 batches | lr 00nan | ms/batch 8618.86 | loss 11.58 | ppl 106942.64
| epoch   1 |    90/10781 batches | lr 00nan | ms/batch 8512.14 | loss 11.47 | ppl 96242.86
| epoch   1 |   100/10781 batches | lr 00nan | ms/batch 8598.28 | loss 12.19 | ppl 197643.46