### PR TITLE
Pass an embedding layer to the constructor of the BertModel class

### DIFF
--- a/examples/BERT/model.py
+++ b/examples/BERT/model.py
@@ -99,10 +99,10 @@ class TransformerEncoderLayer(nn.Module):
 class BertModel(nn.Module):
     """Contain a transformer encoder."""
 
-    def __init__(self, ntoken, ninp, nhead, nhid, nlayers, dropout=0.5):
+    def __init__(self, ntoken, ninp, nhead, nhid, nlayers, embed_layer, dropout=0.5):
         super(BertModel, self).__init__()
         self.model_type = 'Transformer'
-        self.bert_embed = BertEmbedding(ntoken, ninp)
+        self.bert_embed = embed_layer
         encoder_layers = TransformerEncoderLayer(ninp, nhead, nhid, dropout)
         self.transformer_encoder = TransformerEncoder(encoder_layers, nlayers)
         self.ninp = ninp
@@ -118,7 +118,8 @@ class MLMTask(nn.Module):
 
     def __init__(self, ntoken, ninp, nhead, nhid, nlayers, dropout=0.5):
         super(MLMTask, self).__init__()
-        self.bert_model = BertModel(ntoken, ninp, nhead, nhid, nlayers, dropout=0.5)
+        embed_layer = BertEmbedding(ntoken, ninp)
+        self.bert_model = BertModel(ntoken, ninp, nhead, nhid, nlayers, embed_layer, dropout=0.5)
         self.mlm_span = Linear(ninp, ninp)
         self.activation = F.gelu
         self.norm_layer = LayerNorm(ninp, eps=1e-12)

--- a/examples/BERT/ns_task.py
+++ b/examples/BERT/ns_task.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
-from model import NextSentenceTask, BertModel
+from model import NextSentenceTask, BertModel, BertEmbedding
 from utils import run_demo, run_ddp, wrap_up
 
 
@@ -149,7 +149,8 @@ def run_main(args, rank=None):
     if args.checkpoint != 'None':
         model = torch.load(args.checkpoint)
     else:
-        pretrained_bert = BertModel(len(vocab), args.emsize, args.nhead, args.nhid, args.nlayers, args.dropout)
+        embed_layer = BertEmbedding(len(vocab), args.emsize)
+        pretrained_bert = BertModel(len(vocab), args.emsize, args.nhead, args.nhid, args.nlayers, embed_layer, args.dropout)
         pretrained_bert.load_state_dict(torch.load(args.bert_model))
         model = NextSentenceTask(pretrained_bert)
 

--- a/examples/BERT/qa_task.py
+++ b/examples/BERT/qa_task.py
@@ -9,7 +9,7 @@ from torchtext.experimental.datasets import SQuAD1
 from model import QuestionAnswerTask
 from metrics import compute_qa_exact, compute_qa_f1
 from utils import print_loss_log
-from model import BertModel
+from model import BertModel, BertEmbedding
 
 
 def process_raw_data(data):
@@ -174,7 +174,8 @@ if __name__ == "__main__":
     train_dataset = process_raw_data(train_dataset)
     dev_dataset = process_raw_data(dev_dataset)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    pretrained_bert = BertModel(len(vocab), args.emsize, args.nhead, args.nhid, args.nlayers, args.dropout)
+    embed_layer = BertEmbedding(len(vocab), args.emsize)
+    pretrained_bert = BertModel(len(vocab), args.emsize, args.nhead, args.nhid, args.nlayers, embed_layer, args.dropout)
     pretrained_bert.load_state_dict(torch.load(args.bert_model))
     model = QuestionAnswerTask(pretrained_bert).to(device)
     criterion = nn.CrossEntropyLoss()


### PR DESCRIPTION
Users now can build a custom embedding layer outside the BertModel and pass it there. For example, in XLM-R model, there is no token type embedding layer so users can build a customized embedding layer.