### PR TITLE
Fix broken CI tests due to spacy 3.0 release

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -17,5 +17,5 @@ dependencies:
     - sphinx
     - sphinx-rtd-theme
     - tqdm
-    - https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.2.5/de_core_news_sm-2.2.5.tar.gz#egg=de_core_news_sm==2.2.5
-    - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.5/en_core_web_sm-2.2.5.tar.gz#egg=en_core_web_sm==2.2.5
+    - https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.0.0/de_core_news_sm-3.0.0.tar.gz#egg=de_core_news_sm==3.0.0
+    - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm==3.0.0

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -45,6 +45,6 @@ fi
 
 # 4. Download
 printf "* Downloading SpaCy English models\n"
-python -m spacy download en_core_web_md 
+python -m spacy download en_core_web_sd 
 printf "* Downloading SpaCy German models\n"
-python -m spacy download de_core_news_md 
+python -m spacy download de_core_news_sd 

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -45,4 +45,6 @@ fi
 
 # 4. Download
 printf "* Downloading SpaCy English models\n"
-python -m spacy download en
+python -m spacy download en_core_web_md 
+printf "* Downloading SpaCy German models\n"
+python -m spacy download de_core_news_md 

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -45,6 +45,6 @@ fi
 
 # 4. Download
 printf "* Downloading SpaCy English models\n"
-python -m spacy download en_core_web_sd 
+python -m spacy download en_core_web_sm
 printf "* Downloading SpaCy German models\n"
-python -m spacy download de_core_news_sd 
+python -m spacy download de_core_news_sm 

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -19,5 +19,5 @@ dependencies:
     - tqdm
     - certifi
     - future
-    - https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.2.5/de_core_news_sm-2.2.5.tar.gz#egg=de_core_news_sm==2.2.5
-    - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.5/en_core_web_sm-2.2.5.tar.gz#egg=en_core_web_sm==2.2.5
+    - https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.0.0/de_core_news_sm-3.0.0.tar.gz#egg=de_core_news_sm==3.0.0
+    - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm==3.0.0

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -39,6 +39,6 @@ conda env update --file "${this_dir}/environment.yml" --prune
 
 # 4. Download
 printf "* Downloading SpaCy English models\n"
-python -m spacy download en_core_web_md 
+python -m spacy download en_core_web_sd 
 printf "* Downloading SpaCy German models\n"
-python -m spacy download de_core_news_md 
+python -m spacy download de_core_news_sd 

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -39,4 +39,6 @@ conda env update --file "${this_dir}/environment.yml" --prune
 
 # 4. Download
 printf "* Downloading SpaCy English models\n"
-python -m spacy download en
+python -m spacy download en_core_web_md 
+printf "* Downloading SpaCy German models\n"
+python -m spacy download de_core_news_md 

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -39,6 +39,6 @@ conda env update --file "${this_dir}/environment.yml" --prune
 
 # 4. Download
 printf "* Downloading SpaCy English models\n"
-python -m spacy download en_core_web_sd 
+python -m spacy download en_core_web_sm
 printf "* Downloading SpaCy German models\n"
-python -m spacy download de_core_news_sd 
+python -m spacy download de_core_news_sm 

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -222,7 +222,9 @@ class TestDataset(TorchtextTestCase):
             de_vocab[token] for token in
             'Zwei Männer verpacken Donuts in Kunststofffolie'.split()
         ]
-        self.assertEqual(de_tokens_ids, [20, 30, 18705, 4448, 6, 6241])
+        # This change is due to the BC breaking in spacy 3.0
+        # self.assertEqual(de_tokens_ids, [20, 30, 18705, 4448, 6, 6241])
+        self.assertEqual(de_tokens_ids, [20, 30, 18714, 4447, 6, 6239])
 
         en_tokens_ids = [
             en_vocab[token] for token in

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -200,14 +200,21 @@ class TestDataset(TorchtextTestCase):
         from torchtext.experimental.datasets import Multi30k
         # smoke test to ensure multi30k works properly
         train_dataset, valid_dataset, test_dataset = Multi30k()
+
+        # This change is due to the BC breaking in spacy 3.0
         self._helper_test_func(len(train_dataset), 29000, train_dataset[20],
-                               ([4, 444, 2531, 47, 17480, 7423, 8, 158, 10, 12, 5849, 3, 2],
+                               # ([4, 444, 2531, 47, 17480, 7423, 8, 158, 10, 12, 5849, 3, 2],
+                               ([4, 444, 2529, 47, 17490, 7422, 8, 158, 10, 12, 5846, 3, 2],
                                 [5, 61, 530, 137, 1494, 10, 9, 280, 6, 2, 3749, 4, 3]))
+
         self._helper_test_func(len(valid_dataset), 1014, valid_dataset[30],
                                ([4, 179, 26, 85, 1005, 57, 19, 154, 3, 2],
                                 [5, 24, 32, 81, 47, 1348, 6, 2, 119, 4, 3]))
+
+        # This change is due to the BC breaking in spacy 3.0
         self._helper_test_func(len(test_dataset), 1000, test_dataset[40],
-                               ([4, 26, 6, 12, 3915, 1538, 21, 64, 3, 2],
+                               # ([4, 26, 6, 12, 3915, 1538, 21, 64, 3, 2],
+                               ([4, 26, 6, 12, 3913, 1537, 21, 64, 3, 2],
                                 [5, 32, 20, 2, 747, 345, 1915, 6, 46, 4, 3]))
 
         de_vocab, en_vocab = train_dataset.get_vocab()
@@ -234,8 +241,11 @@ class TestDataset(TorchtextTestCase):
                                          'A group of men are loading cotton onto a truck\n']))
         del train_iter, valid_iter
         train_dataset, = Multi30k(data_select=('train'))
+
+        # This change is due to the BC breaking in spacy 3.0
         self._helper_test_func(len(train_dataset), 29000, train_dataset[20],
-                               ([4, 444, 2531, 47, 17480, 7423, 8, 158, 10, 12, 5849, 3, 2],
+                               # ([4, 444, 2531, 47, 17480, 7423, 8, 158, 10, 12, 5849, 3, 2],
+                               ([4, 444, 2529, 47, 17490, 7422, 8, 158, 10, 12, 5846, 3, 2],
                                 [5, 61, 530, 137, 1494, 10, 9, 280, 6, 2, 3749, 4, 3]))
 
         datafile = os.path.join(self.project_root, ".data", "train*")

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -107,7 +107,7 @@ class TestDataUtils(TorchtextTestCase):
 
     def test_get_tokenizer_spacy(self):
         # Test SpaCy option, and verify it properly handles punctuation.
-        assert torchtext.data.get_tokenizer("spacy")(str(self.TEST_STR)) == [
+        assert torchtext.data.get_tokenizer("spacy", language='en_core_web_sm')(str(self.TEST_STR)) == [
             "A", "string", ",", "particularly", "one", "with", "slightly",
             "complex", "punctuation", "."]
 

--- a/test/translation.py
+++ b/test/translation.py
@@ -4,8 +4,8 @@ from torchtext import datasets
 import re
 import spacy
 
-spacy_de = spacy.load('de')
-spacy_en = spacy.load('en')
+spacy_de = spacy.load('de_core_news_sm')
+spacy_en = spacy.load('en_core_web_sm')
 
 url = re.compile('(<url>.*</url>)')
 

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -143,7 +143,7 @@ class Field(RawField):
     def __init__(self, sequential=True, use_vocab=True, init_token=None,
                  eos_token=None, fix_length=None, dtype=torch.long,
                  preprocessing=None, postprocessing=None, lower=False,
-                 tokenize=None, tokenizer_language='en_core_web_sm', include_lengths=False,
+                 tokenize=None, tokenizer_language='en', include_lengths=False,
                  batch_first=False, pad_token="<pad>", unk_token="<unk>",
                  pad_first=False, truncate_first=False, stop_words=None,
                  is_target=False):
@@ -492,7 +492,7 @@ class NestedField(Field):
 
     def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
                  fix_length=None, dtype=torch.long, preprocessing=None,
-                 postprocessing=None, tokenize=None, tokenizer_language='en_core_web_sm',
+                 postprocessing=None, tokenize=None, tokenizer_language='en',
                  include_lengths=False, pad_token='<pad>',
                  pad_first=False, truncate_first=False):
         warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -492,7 +492,7 @@ class NestedField(Field):
 
     def __init__(self, nesting_field, use_vocab=True, init_token=None, eos_token=None,
                  fix_length=None, dtype=torch.long, preprocessing=None,
-                 postprocessing=None, tokenize=None, tokenizer_language='en',
+                 postprocessing=None, tokenize=None, tokenizer_language='en_core_web_sm',
                  include_lengths=False, pad_token='<pad>',
                  pad_first=False, truncate_first=False):
         warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)

--- a/torchtext/data/field.py
+++ b/torchtext/data/field.py
@@ -143,7 +143,7 @@ class Field(RawField):
     def __init__(self, sequential=True, use_vocab=True, init_token=None,
                  eos_token=None, fix_length=None, dtype=torch.long,
                  preprocessing=None, postprocessing=None, lower=False,
-                 tokenize=None, tokenizer_language='en', include_lengths=False,
+                 tokenize=None, tokenizer_language='en_core_web_sm', include_lengths=False,
                  batch_first=False, pad_token="<pad>", unk_token="<unk>",
                  pad_first=False, truncate_first=False, stop_words=None,
                  is_target=False):

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -72,7 +72,7 @@ def _basic_english_normalize(line):
     return line.split()
 
 
-def get_tokenizer(tokenizer, language='en'):
+def get_tokenizer(tokenizer, language='en_core_web_sm'):
     r"""
     Generate tokenizer function for a string sentence.
 
@@ -101,8 +101,6 @@ def get_tokenizer(tokenizer, language='en'):
         return _split_tokenizer
 
     if tokenizer == "basic_english":
-        if language != 'en':
-            raise ValueError("Basic normalization is only available for Enlish(en)")
         return _basic_english_normalize
 
     # simply return if a function is passed

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -72,7 +72,7 @@ def _basic_english_normalize(line):
     return line.split()
 
 
-def get_tokenizer(tokenizer, language='en_core_web_sm'):
+def get_tokenizer(tokenizer, language='en'):
     r"""
     Generate tokenizer function for a string sentence.
 
@@ -101,6 +101,8 @@ def get_tokenizer(tokenizer, language='en_core_web_sm'):
         return _split_tokenizer
 
     if tokenizer == "basic_english":
+        if language != 'en':
+            raise ValueError("Basic normalization is only available for Enlish(en)")
         return _basic_english_normalize
 
     # simply return if a function is passed
@@ -108,6 +110,8 @@ def get_tokenizer(tokenizer, language='en_core_web_sm'):
         return tokenizer
 
     if tokenizer == "spacy":
+        if language == 'en':
+            raise RuntimeError("The en package has been deprecated in Spacy 3.0 release. Please switch to en_core_web_sm.")
         try:
             import spacy
             spacy = spacy.load(language)

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -2,7 +2,7 @@ import random
 from contextlib import contextmanager
 from copy import deepcopy
 import re
-
+import warnings
 from functools import partial
 
 
@@ -111,7 +111,11 @@ def get_tokenizer(tokenizer, language='en'):
 
     if tokenizer == "spacy":
         if language == 'en':
-            raise RuntimeError("The en package has been deprecated in Spacy 3.0 release. Please switch to en_core_web_sm.")
+            warnings.warn("The en package has been deprecated in Spacy 3.0 release. Please switch the language argument in get_tokenizer to en_core_web_sm.", UserWarning)
+            language = 'en_core_web_sm'
+        elif language == 'de':
+            warnings.warn("The de package has been deprecated in Spacy 3.0 release. Please switch the language argument in get_tokenizer to de_core_news_sm.", UserWarning)
+            language = 'de_core_news_sm'
         try:
             import spacy
             spacy = spacy.load(language)

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -2,7 +2,6 @@ import random
 from contextlib import contextmanager
 from copy import deepcopy
 import re
-import warnings
 from functools import partial
 
 
@@ -110,12 +109,6 @@ def get_tokenizer(tokenizer, language='en'):
         return tokenizer
 
     if tokenizer == "spacy":
-        if language == 'en':
-            warnings.warn("The en package has been deprecated in Spacy 3.0 release. Please switch the language argument in get_tokenizer to en_core_web_sm.", UserWarning)
-            language = 'en_core_web_sm'
-        elif language == 'de':
-            warnings.warn("The de package has been deprecated in Spacy 3.0 release. Please switch the language argument in get_tokenizer to de_core_news_sm.", UserWarning)
-            language = 'de_core_news_sm'
         try:
             import spacy
             try:


### PR DESCRIPTION
In spacy 3.0 release, the shortcut "en" and "de" have been depreciated. The new language packages in spacy 3.0 introduce BC breaking and this propagates to our datasets. 

However, since the Multi30k dataset is in the nightly release, we don't need to add [BC Breaking] tag.