### PR TITLE
Add support for string-typed split values to raw datasets.

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -146,8 +146,6 @@ class TestDataset(TorchtextTestCase):
     def test_raw_datasets_split_argument(self):
         from torchtext.experimental.datasets.raw import DATASETS
         for dataset_name in sorted(DATASETS.keys()):
-            if 'drive.google' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
-                continue
             if 'statmt' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
                 continue
             dataset = DATASETS[dataset_name]

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -130,7 +130,7 @@ class TestDataset(TorchtextTestCase):
                                [2351, 758, 96, 38581, 2351, 220, 5, 396, 3, 14786])
 
         # Add test for the subset of the standard datasets
-        train_dataset, = AG_NEWS(split=('train'))
+        train_dataset = AG_NEWS(split='train')
         self._helper_test_func(len(train_dataset), 120000, train_dataset[-1][1][:10],
                                [2155, 223, 2405, 30, 3010, 2204, 54, 3603, 4930, 2405])
         train_iter, test_iter = torchtext.experimental.datasets.raw.AG_NEWS()
@@ -208,7 +208,7 @@ class TestDataset(TorchtextTestCase):
         new_train_data, new_test_data = IMDB(vocab=new_vocab)
 
         # Add test for the subset of the standard datasets
-        train_dataset, = IMDB(split=('train'))
+        train_dataset = IMDB(split='train')
         self._helper_test_func(len(train_dataset), 25000, train_dataset[0][1][:10],
                                [13, 1568, 13, 246, 35468, 43, 64, 398, 1135, 92])
         train_iter, test_iter = torchtext.experimental.datasets.raw.IMDB()
@@ -296,7 +296,7 @@ class TestDataset(TorchtextTestCase):
                                ' '.join(['Eine Gruppe von Männern lädt Baumwolle auf einen Lastwagen\n',
                                          'A group of men are loading cotton onto a truck\n']))
         del train_iter, valid_iter
-        train_dataset, = Multi30k(split=('train'))
+        train_dataset = Multi30k(split='train')
 
         # This change is due to the BC breaking in spacy 3.0
         self._helper_test_func(len(train_dataset), 29000, train_dataset[20],
@@ -359,7 +359,7 @@ class TestDataset(TorchtextTestCase):
         self.assertEqual(tokens_ids, [1206, 8, 69, 60, 157, 452])
 
         # Add test for the subset of the standard datasets
-        train_dataset, = UDPOS(split=('train'))
+        train_dataset = UDPOS(split='train')
         self._helper_test_func(len(train_dataset), 12543, (train_dataset[0][0][:10], train_dataset[-1][2][:10]),
                                ([262, 16, 5728, 45, 289, 701, 1160, 4436, 10660, 585],
                                 [6, 20, 8, 10, 8, 8, 24, 13, 8, 15]))
@@ -406,7 +406,7 @@ class TestDataset(TorchtextTestCase):
         self.assertEqual(tokens_ids, [970, 5, 135, 43, 214, 690])
 
         # Add test for the subset of the standard datasets
-        train_dataset, = CoNLL2000Chunking(split=('train'))
+        train_dataset = CoNLL2000Chunking(split='train')
         self._helper_test_func(len(train_dataset), 8936, (train_dataset[0][0][:10], train_dataset[0][1][:10],
                                                           train_dataset[0][2][:10], train_dataset[-1][0][:10],
                                                           train_dataset[-1][1][:10], train_dataset[-1][2][:10]),
@@ -441,7 +441,7 @@ class TestDataset(TorchtextTestCase):
         new_train_data, new_test_data = SQuAD1(vocab=new_vocab)
 
         # Add test for the subset of the standard datasets
-        train_dataset, = SQuAD1(split=('train'))
+        train_dataset = SQuAD1(split='train')
         context, question, answers, ans_pos = train_dataset[100]
         self._helper_test_func(len(train_dataset), 87599, (question[:5], ans_pos[0]),
                                ([7, 24, 86, 52, 2], [72, 72]))
@@ -470,7 +470,7 @@ class TestDataset(TorchtextTestCase):
         new_train_data, new_test_data = SQuAD2(vocab=new_vocab)
 
         # Add test for the subset of the standard datasets
-        train_dataset, = SQuAD2(split=('train'))
+        train_dataset = SQuAD2(split='train')
         context, question, answers, ans_pos = train_dataset[200]
         self._helper_test_func(len(train_dataset), 130319, (question[:5], ans_pos[0]),
                                ([84, 50, 1421, 12, 5439], [9, 9]))

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -143,6 +143,33 @@ class TestDataset(TorchtextTestCase):
         _data = [item for item in train_iter]
         self.assertEqual(len(_data), 119990)
 
+    def test_raw_datasets_split_argument(self):
+        from torchtext.experimental.datasets.raw import DATASETS
+        for dataset_name in sorted(DATASETS.keys()):
+            print("dataset_name: ", dataset_name)
+            dataset = DATASETS[dataset_name]
+            if dataset_name in ["PennTreebank", "AmazonReviewFull", "AmazonReviewPolarity"]: # Download is waaaay too slow for this dataset
+                continue
+            cachedir = os.path.join(self.project_root, ".data", dataset_name)
+            conditional_remove(cachedir)
+            cachedir=".data"
+            os.makedirs(cachedir, exist_ok=True)
+            train1 = dataset(split='train', root=cachedir)
+            print("type(train1): ", type(train1))
+            train2, = dataset(split=('train',), root=cachedir)
+            print("type(train2): ", type(train2))
+            for d1, d2 in zip(train1, train2):
+                print(dataset)
+                print(d1)
+                print(d2)
+                self.assertEqual(d1, d2)
+                # This test only aims to exercise the argument parsing and uses
+                # the first line as a litmus test for correctness.
+                break
+            # Exercise default constructor
+            all_datasets = dataset(root=cachedir)
+            conditional_remove(cachedir)
+
     def test_offset_dataset(self):
         train_iter, test_iter = torchtext.experimental.datasets.raw.AG_NEWS(split=('train', 'test'),
                                                                             offset=10)

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -146,22 +146,12 @@ class TestDataset(TorchtextTestCase):
     def test_raw_datasets_split_argument(self):
         from torchtext.experimental.datasets.raw import DATASETS
         for dataset_name in sorted(DATASETS.keys()):
-            print("dataset_name: ", dataset_name)
             dataset = DATASETS[dataset_name]
-            if dataset_name in ["PennTreebank", "AmazonReviewFull", "AmazonReviewPolarity"]: # Download is waaaay too slow for this dataset
-                continue
             cachedir = os.path.join(self.project_root, ".data", dataset_name)
             conditional_remove(cachedir)
-            cachedir=".data"
-            os.makedirs(cachedir, exist_ok=True)
             train1 = dataset(split='train', root=cachedir)
-            print("type(train1): ", type(train1))
             train2, = dataset(split=('train',), root=cachedir)
-            print("type(train2): ", type(train2))
             for d1, d2 in zip(train1, train2):
-                print(dataset)
-                print(d1)
-                print(d2)
                 self.assertEqual(d1, d2)
                 # This test only aims to exercise the argument parsing and uses
                 # the first line as a litmus test for correctness.

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -146,6 +146,10 @@ class TestDataset(TorchtextTestCase):
     def test_raw_datasets_split_argument(self):
         from torchtext.experimental.datasets.raw import DATASETS
         for dataset_name in sorted(DATASETS.keys()):
+            if 'drive.google' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
+                continue
+            if 'statmt' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
+                continue
             dataset = DATASETS[dataset_name]
             train1 = dataset(split='train')
             train2, = dataset(split=('train',))

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -160,6 +160,23 @@ class TestDataset(TorchtextTestCase):
             _ = dataset(root=cachedir)
             conditional_remove(cachedir)
 
+    def test_datasets_split_argument(self):
+        from torchtext.experimental.datasets import DATASETS
+        for dataset_name in ["AG_NEWS", "WikiText2", "IMDB"]:
+            dataset = DATASETS[dataset_name]
+            cachedir = os.path.join(self.project_root, ".data", dataset_name)
+            conditional_remove(cachedir)
+            train1 = dataset(split='train', root=cachedir)
+            train2, = dataset(split=('train',), root=cachedir)
+            for d1, d2 in zip(train1, train2):
+                self.assertEqual(d1, d2)
+                # This test only aims to exercise the argument parsing and uses
+                # the first line as a litmus test for correctness.
+                break
+            # Exercise default constructor
+            _ = dataset(root=cachedir)
+            conditional_remove(cachedir)
+
     def test_offset_dataset(self):
         train_iter, test_iter = torchtext.experimental.datasets.raw.AG_NEWS(split=('train', 'test'),
                                                                             offset=10)

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -146,6 +146,8 @@ class TestDataset(TorchtextTestCase):
     def test_raw_datasets_split_argument(self):
         from torchtext.experimental.datasets.raw import DATASETS
         for dataset_name in sorted(DATASETS.keys()):
+            if 'drive.google' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
+                continue
             if 'statmt' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
                 continue
             dataset = DATASETS[dataset_name]

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -157,7 +157,7 @@ class TestDataset(TorchtextTestCase):
                 # the first line as a litmus test for correctness.
                 break
             # Exercise default constructor
-            all_datasets = dataset(root=cachedir)
+            _ = dataset(root=cachedir)
             conditional_remove(cachedir)
 
     def test_offset_dataset(self):

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -147,35 +147,29 @@ class TestDataset(TorchtextTestCase):
         from torchtext.experimental.datasets.raw import DATASETS
         for dataset_name in sorted(DATASETS.keys()):
             dataset = DATASETS[dataset_name]
-            cachedir = os.path.join(self.project_root, ".data", dataset_name)
-            conditional_remove(cachedir)
-            train1 = dataset(split='train', root=cachedir)
-            train2, = dataset(split=('train',), root=cachedir)
+            train1 = dataset(split='train')
+            train2, = dataset(split=('train',))
             for d1, d2 in zip(train1, train2):
                 self.assertEqual(d1, d2)
                 # This test only aims to exercise the argument parsing and uses
                 # the first line as a litmus test for correctness.
                 break
             # Exercise default constructor
-            _ = dataset(root=cachedir)
-            conditional_remove(cachedir)
+            _ = dataset()
 
     def test_datasets_split_argument(self):
         from torchtext.experimental.datasets import DATASETS
         for dataset_name in ["AG_NEWS", "WikiText2", "IMDB"]:
             dataset = DATASETS[dataset_name]
-            cachedir = os.path.join(self.project_root, ".data", dataset_name)
-            conditional_remove(cachedir)
-            train1 = dataset(split='train', root=cachedir)
-            train2, = dataset(split=('train',), root=cachedir)
+            train1 = dataset(split='train')
+            train2, = dataset(split=('train',))
             for d1, d2 in zip(train1, train2):
                 self.assertEqual(d1, d2)
                 # This test only aims to exercise the argument parsing and uses
                 # the first line as a litmus test for correctness.
                 break
             # Exercise default constructor
-            _ = dataset(root=cachedir)
-            conditional_remove(cachedir)
+            _ = dataset()
 
     def test_offset_dataset(self):
         train_iter, test_iter = torchtext.experimental.datasets.raw.AG_NEWS(split=('train', 'test'),

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -4,6 +4,7 @@ from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import language_modeling as raw
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 
 logger_ = logging.getLogger(__name__)
 
@@ -84,8 +85,8 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, split, year, language)
         raw_datasets = raw.DATASETS[dataset_name](root=root, split=split)
     raw_data = {name: list(map(text_transform, raw_dataset)) for name, raw_dataset in zip(split, raw_datasets)}
     logger_.info('Building datasets for {}'.format(split))
-    return tuple(LanguageModelingDataset(raw_data[item], vocab, text_transform)
-                 for item in split)
+    return wrap_datasets(tuple(LanguageModelingDataset(raw_data[item], vocab, text_transform)
+                               for item in split), split)
 
 
 def WikiText2(tokenizer=None, root='.data', vocab=None, split=('train', 'valid', 'test')):

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -59,11 +59,11 @@ class LanguageModelingDataset(torch.utils.data.Dataset):
         return self.vocab
 
 
-def _setup_datasets(dataset_name, tokenizer, root, vocab, split, year, language):
+def _setup_datasets(dataset_name, tokenizer, root, vocab, split_, year, language):
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
 
-    split = check_default_set(split, ('train', 'test', 'valid'), dataset_name)
+    split = check_default_set(split_, ('train', 'test', 'valid'), dataset_name)
 
     if vocab is None:
         if 'train' not in split:
@@ -86,7 +86,7 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, split, year, language)
     raw_data = {name: list(map(text_transform, raw_dataset)) for name, raw_dataset in zip(split, raw_datasets)}
     logger_.info('Building datasets for {}'.format(split))
     return wrap_datasets(tuple(LanguageModelingDataset(raw_data[item], vocab, text_transform)
-                               for item in split), split)
+                               for item in split), split_)
 
 
 def WikiText2(tokenizer=None, root='.data', vocab=None, split=('train', 'valid', 'test')):

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -62,7 +62,7 @@ def _setup_datasets(dataset_name, tokenizer, root, vocab, split, year, language)
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
 
-    split = check_default_set(split, ('train', 'test', 'valid'))
+    split = check_default_set(split, ('train', 'test', 'valid'), dataset_name)
 
     if vocab is None:
         if 'train' not in split:

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -66,7 +66,7 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, split):
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
     text_transform = sequential_transforms(tokenizer)
-    split = check_default_set(split, ('train', 'dev'))
+    split = check_default_set(split, ('train', 'dev'), dataset_name)
     raw_datasets = raw.DATASETS[dataset_name](root=root, split=split)
     raw_data = {name: list(raw_dataset) for name, raw_dataset in zip(split, raw_datasets)}
     if vocab is None:

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -4,6 +4,7 @@ from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import question_answer as raw
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 from torchtext.experimental.functional import (
     totensor,
     vocab_func,
@@ -86,7 +87,7 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, split):
     transforms = {'context': text_transform, 'question': text_transform,
                   'answers': text_transform, 'ans_pos': totensor(dtype=torch.long)}
     logger_.info('Building datasets for {}'.format(split))
-    return tuple(QuestionAnswerDataset(raw_data[item], vocab, transforms) for item in split)
+    return wrap_datasets(tuple(QuestionAnswerDataset(raw_data[item], vocab, transforms) for item in split), split)
 
 
 def SQuAD1(root='.data', vocab=None, tokenizer=None, split=('train', 'dev')):

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -62,12 +62,12 @@ class QuestionAnswerDataset(torch.utils.data.Dataset):
         return self.vocab
 
 
-def _setup_datasets(dataset_name, root, vocab, tokenizer, split):
+def _setup_datasets(dataset_name, root, vocab, tokenizer, split_):
     text_transform = []
     if tokenizer is None:
         tokenizer = get_tokenizer('basic_english')
     text_transform = sequential_transforms(tokenizer)
-    split = check_default_set(split, ('train', 'dev'), dataset_name)
+    split = check_default_set(split_, ('train', 'dev'), dataset_name)
     raw_datasets = raw.DATASETS[dataset_name](root=root, split=split)
     raw_data = {name: list(raw_dataset) for name, raw_dataset in zip(split, raw_datasets)}
     if vocab is None:
@@ -87,7 +87,7 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, split):
     transforms = {'context': text_transform, 'question': text_transform,
                   'answers': text_transform, 'ans_pos': totensor(dtype=torch.long)}
     logger_.info('Building datasets for {}'.format(split))
-    return wrap_datasets(tuple(QuestionAnswerDataset(raw_data[item], vocab, transforms) for item in split), split)
+    return wrap_datasets(tuple(QuestionAnswerDataset(raw_data[item], vocab, transforms) for item in split), split_)
 
 
 def SQuAD1(root='.data', vocab=None, tokenizer=None, split=('train', 'dev')):

--- a/torchtext/experimental/datasets/raw/__init__.py
+++ b/torchtext/experimental/datasets/raw/__init__.py
@@ -27,4 +27,16 @@ DATASETS = {'IMDB': IMDB,
             'SQuAD1': SQuAD1,
             'SQuAD2': SQuAD2}
 
+from .text_classification import URLS as text_classification_URLS
+from .sequence_tagging import URLS as sequence_tagging_URLS
+from .translation import URLS as translation_URLS
+from .language_modeling import URLS as language_modeling_URLS
+from .question_answer import URLS as question_answer_URLS
+
+URLS = text_classification_URLS
+URLS.update(sequence_tagging_URLS)
+URLS.update(translation_URLS)
+URLS.update(language_modeling_URLS)
+URLS.update(question_answer_URLS)
+
 __all__ = sorted(list(map(str, DATASETS.keys())))

--- a/torchtext/experimental/datasets/raw/language_modeling.py
+++ b/torchtext/experimental/datasets/raw/language_modeling.py
@@ -63,15 +63,13 @@ def WikiText2(root='.data', split=('train', 'valid', 'test'), offset=0):
         split: a string or tuple for the returned datasets. Default: ('train', 'valid, 'test')
             By default, all the three datasets (train, test, valid) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
-            just a string 'train'. If 'train' is not in the tuple or string, a vocab
-            object should be provided which will be used to process valid and/or test
-            data.
+            just a string 'train'.
         offset: the number of the starting line. Default: 0
 
     Examples:
         >>> from torchtext.experimental.raw.datasets import WikiText2
         >>> train_dataset, valid_dataset, test_dataset = WikiText2()
-        >>> valid_dataset, = WikiText2(split='valid')
+        >>> valid_dataset = WikiText2(split='valid')
 
     """
 
@@ -89,14 +87,12 @@ def WikiText103(root='.data', split=('train', 'valid', 'test'), offset=0):
         split: the returned datasets. Default: ('train', 'valid','test')
             By default, all the three datasets (train, test, valid) are generated. Users
             could also choose any one or two of them, for example ('train', 'test').
-            If 'train' is not in the tuple, an vocab object should be provided which will
-            be used to process valid and/or test data.
         offset: the number of the starting line. Default: 0
 
     Examples:
         >>> from torchtext.experimental.datasets.raw import WikiText103
         >>> train_dataset, valid_dataset, test_dataset = WikiText103()
-        >>> valid_dataset, = WikiText103(split='valid')
+        >>> valid_dataset = WikiText103(split='valid')
     """
 
     return _setup_datasets("WikiText103", root, split, None, None, offset)
@@ -114,15 +110,13 @@ def PennTreebank(root='.data', split=('train', 'valid', 'test'), offset=0):
             (Default: ('train', 'test','valid'))
             By default, all the three datasets ('train', 'valid', 'test') are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
-            just a string 'train'. If 'train' is not in the tuple or string, a vocab
-            object should be provided which will be used to process valid and/or test
-            data.
+            just a string 'train'.
         offset: the number of the starting line. Default: 0
 
     Examples:
         >>> from torchtext.experimental.datasets.raw import PennTreebank
         >>> train_dataset, valid_dataset, test_dataset = PennTreebank()
-        >>> valid_dataset, = PennTreebank(split='valid')
+        >>> valid_dataset = PennTreebank(split='valid')
 
     """
 

--- a/torchtext/experimental/datasets/raw/language_modeling.py
+++ b/torchtext/experimental/datasets/raw/language_modeling.py
@@ -19,11 +19,11 @@ URLS = {
 }
 
 
-def _setup_datasets(dataset_name, root, split, year, language, offset):
+def _setup_datasets(dataset_name, root, split_, year, language, offset):
     if dataset_name == 'WMTNewsCrawl':
-        split = check_default_set(split, ('train'), dataset_name)
+        split = check_default_set(split_, ('train',), dataset_name)
     else:
-        split = check_default_set(split, ('train', 'test', 'valid'), dataset_name)
+        split = check_default_set(split_, ('train', 'test', 'valid'), dataset_name)
 
     if dataset_name == 'PennTreebank':
         extracted_files = [download_from_url(URLS['PennTreebank'][key],
@@ -49,7 +49,7 @@ def _setup_datasets(dataset_name, root, split, year, language, offset):
         datasets.append(RawTextIterableDataset(dataset_name,
                                                NUM_LINES[dataset_name][item], iter(io.open(path[item], encoding="utf8")), offset=offset))
 
-    return wrap_datasets(tuple(datasets), split)
+    return wrap_datasets(tuple(datasets), split_)
 
 
 def WikiText2(root='.data', split=('train', 'valid', 'test'), offset=0):

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -30,7 +30,7 @@ def _create_data_from_json(data_path):
 
 
 def _setup_datasets(dataset_name, root, split, offset):
-    split = check_default_set(split, ('train', 'dev'))
+    split = check_default_set(split, ('train', 'dev'), dataset_name)
     extracted_files = {key: download_from_url(URLS[dataset_name][key], root=root,
                                               hash_value=MD5[dataset_name][key], hash_type='md5') for key in split}
     return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -2,6 +2,7 @@ from torchtext.utils import download_from_url
 import json
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 
 URLS = {
     'SQuAD1':
@@ -33,8 +34,8 @@ def _setup_datasets(dataset_name, root, split, offset):
     split = check_default_set(split, ('train', 'dev'), dataset_name)
     extracted_files = {key: download_from_url(URLS[dataset_name][key], root=root,
                                               hash_value=MD5[dataset_name][key], hash_type='md5') for key in split}
-    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
-                 _create_data_from_json(extracted_files[item]), offset=offset) for item in split)
+    return wrap_datasets(tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
+                                                      _create_data_from_json(extracted_files[item]), offset=offset) for item in split), split)
 
 
 def SQuAD1(root='.data', split=('train', 'dev'), offset=0):

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -30,12 +30,12 @@ def _create_data_from_json(data_path):
                     yield (_context, _question, _answers, _answer_start)
 
 
-def _setup_datasets(dataset_name, root, split, offset):
-    split = check_default_set(split, ('train', 'dev'), dataset_name)
+def _setup_datasets(dataset_name, root, split_, offset):
+    split = check_default_set(split_, ('train', 'dev'), dataset_name)
     extracted_files = {key: download_from_url(URLS[dataset_name][key], root=root,
                                               hash_value=MD5[dataset_name][key], hash_type='md5') for key in split}
     return wrap_datasets(tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
-                                                      _create_data_from_json(extracted_files[item]), offset=offset) for item in split), split)
+                                                      _create_data_from_json(extracted_files[item]), offset=offset) for item in split), split_)
 
 
 def SQuAD1(root='.data', split=('train', 'dev'), offset=0):

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -40,8 +40,8 @@ def _construct_filepath(paths, file_suffix):
     return None
 
 
-def _setup_datasets(dataset_name, separator, root, split, offset):
-    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
+def _setup_datasets(dataset_name, separator, root, split_, offset):
+    split = check_default_set(split_, ('train', 'valid', 'test'), dataset_name)
     extracted_files = []
     if isinstance(URLS[dataset_name], dict):
         for name, item in URLS[dataset_name].items():
@@ -62,7 +62,7 @@ def _setup_datasets(dataset_name, separator, root, split, offset):
     }
     return wrap_datasets(tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
                  _create_data_from_iob(data_filenames[item], separator), offset=offset)
-                 if data_filenames[item] is not None else None for item in split), split)
+                 if data_filenames[item] is not None else None for item in split), split_)
 
 
 def UDPOS(root=".data", split=('train', 'valid', 'test'), offset=0):

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -40,7 +40,7 @@ def _construct_filepath(paths, file_suffix):
 
 
 def _setup_datasets(dataset_name, separator, root, split, offset):
-    split = check_default_set(split, target_select=('train', 'valid', 'test'))
+    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
     extracted_files = []
     if isinstance(URLS[dataset_name], dict):
         for name, item in URLS[dataset_name].items():

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -1,6 +1,7 @@
 from torchtext.utils import download_from_url, extract_archive
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 
 URLS = {
     "UDPOS":
@@ -59,9 +60,9 @@ def _setup_datasets(dataset_name, separator, root, split, offset):
         "valid": _construct_filepath(extracted_files, "dev.txt"),
         "test": _construct_filepath(extracted_files, "test.txt")
     }
-    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
+    return wrap_datasets(tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
                  _create_data_from_iob(data_filenames[item], separator), offset=offset)
-                 if data_filenames[item] is not None else None for item in split)
+                 if data_filenames[item] is not None else None for item in split), split)
 
 
 def UDPOS(root=".data", split=('train', 'valid', 'test'), offset=0):

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -61,8 +61,8 @@ def _setup_datasets(dataset_name, separator, root, split_, offset):
         "test": _construct_filepath(extracted_files, "test.txt")
     }
     return wrap_datasets(tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
-                 _create_data_from_iob(data_filenames[item], separator), offset=offset)
-                 if data_filenames[item] is not None else None for item in split), split_)
+                                                      _create_data_from_iob(data_filenames[item], separator), offset=offset)
+                               if data_filenames[item] is not None else None for item in split), split_)
 
 
 def UDPOS(root=".data", split=('train', 'valid', 'test'), offset=0):

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -34,7 +34,7 @@ def _create_data_from_csv(data_path):
 
 
 def _setup_datasets(dataset_name, root, split, offset):
-    split = check_default_set(split, target_select=('train', 'test'))
+    split = check_default_set(split, ('train', 'test'), dataset_name)
     if dataset_name == 'AG_NEWS':
         extracted_files = [download_from_url(URLS[dataset_name][item], root=root,
                                              hash_value=MD5['AG_NEWS'][item],

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -2,6 +2,7 @@ import io
 from torchtext.utils import download_from_url, extract_archive, unicode_csv_reader
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 
 URLS = {
     'AG_NEWS':
@@ -50,8 +51,8 @@ def _setup_datasets(dataset_name, root, split, offset):
             cvs_path['train'] = fname
         if fname.endswith('test.csv'):
             cvs_path['test'] = fname
-    return tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
-                                        _create_data_from_csv(cvs_path[item]), offset=offset) for item in split)
+    return wrap_datasets(tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
+                                        _create_data_from_csv(cvs_path[item]), offset=offset) for item in split), split)
 
 
 def AG_NEWS(root='.data', split=('train', 'test'), offset=0):

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -34,8 +34,8 @@ def _create_data_from_csv(data_path):
             yield int(row[0]), ' '.join(row[1:])
 
 
-def _setup_datasets(dataset_name, root, split, offset):
-    split = check_default_set(split, ('train', 'test'), dataset_name)
+def _setup_datasets(dataset_name, root, split_, offset):
+    split = check_default_set(split_, ('train', 'test'), dataset_name)
     if dataset_name == 'AG_NEWS':
         extracted_files = [download_from_url(URLS[dataset_name][item], root=root,
                                              hash_value=MD5['AG_NEWS'][item],
@@ -52,7 +52,7 @@ def _setup_datasets(dataset_name, root, split, offset):
         if fname.endswith('test.csv'):
             cvs_path['test'] = fname
     return wrap_datasets(tuple(RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][item],
-                                        _create_data_from_csv(cvs_path[item]), offset=offset) for item in split), split)
+                                                      _create_data_from_csv(cvs_path[item]), offset=offset) for item in split), split_)
 
 
 def AG_NEWS(root='.data', split=('train', 'test'), offset=0):
@@ -250,13 +250,13 @@ def IMDB(root='.data', split=('train', 'test'), offset=0):
     Examples:
         >>> train, test = torchtext.experimental.datasets.raw.IMDB()
     """
-    split = check_default_set(split, target_select=('train', 'test'))
+    split_ = check_default_set(split, ('train', 'test'), 'IMDB')
     dataset_tar = download_from_url(URLS['IMDB'], root=root,
                                     hash_value=MD5['IMDB'], hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
-    return tuple(RawTextIterableDataset("IMDB", NUM_LINES["IMDB"][item],
-                                        generate_imdb_data(item,
-                                                           extracted_files), offset=offset) for item in split)
+    return wrap_datasets(tuple(RawTextIterableDataset("IMDB", NUM_LINES["IMDB"][item],
+                                                      generate_imdb_data(item,
+                                                                         extracted_files), offset=offset) for item in split_), split)
 
 
 DATASETS = {

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -117,7 +117,7 @@ def _construct_filepaths(paths, src_filename, tgt_filename):
 def _setup_datasets(dataset_name,
                     train_filenames, valid_filenames, test_filenames,
                     split, root, offset):
-    split = check_default_set(split, ('train', 'valid', 'test'))
+    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
     if not isinstance(train_filenames, tuple) and not isinstance(valid_filenames, tuple) \
             and not isinstance(test_filenames, tuple):
         raise ValueError("All filenames must be tuples")

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from torchtext.utils import (download_from_url, extract_archive)
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 
 URLS = {
     'Multi30k': [
@@ -186,7 +187,7 @@ def _setup_datasets(dataset_name,
         datasets.append(
             RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][key], _iter(src_data_iter, tgt_data_iter), offset=offset))
 
-    return tuple(datasets)
+    return wrap_datasets(tuple(datasets), split)
 
 
 def Multi30k(train_filenames=("train.de", "train.en"),

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -117,8 +117,8 @@ def _construct_filepaths(paths, src_filename, tgt_filename):
 
 def _setup_datasets(dataset_name,
                     train_filenames, valid_filenames, test_filenames,
-                    split, root, offset):
-    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
+                    split_, root, offset):
+    split = check_default_set(split_, ('train', 'valid', 'test'), dataset_name)
     if not isinstance(train_filenames, tuple) and not isinstance(valid_filenames, tuple) \
             and not isinstance(test_filenames, tuple):
         raise ValueError("All filenames must be tuples")
@@ -187,7 +187,7 @@ def _setup_datasets(dataset_name,
         datasets.append(
             RawTextIterableDataset(dataset_name, NUM_LINES[dataset_name][key], _iter(src_data_iter, tgt_data_iter), offset=offset))
 
-    return wrap_datasets(tuple(datasets), split)
+    return wrap_datasets(tuple(datasets), split_)
 
 
 def Multi30k(train_filenames=("train.de", "train.en"),

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -257,8 +257,7 @@ def Multi30k(train_filenames=("train.de", "train.en"),
         split: a string or tuple for the returned datasets, Default: ('train', 'valid', 'test')
             By default, all the three datasets (train, valid, test) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
-            just a string 'train'. If 'train' is not in the tuple or string, a vocab
-            object should be provided which will be used to process valid and/or test data.
+            just a string 'train'.
         root: Directory where the datasets are saved. Default: ".data"
         offset: the number of the starting line. Default: 0
 
@@ -424,8 +423,7 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
         split: a string or tuple for the returned datasets, Default: ('train', 'valid', 'test')
             By default, all the three datasets (train, valid, test) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
-            just a string 'train'. If 'train' is not in the tuple or string, a vocab
-            object should be provided which will be used to process valid and/or test data.
+            just a string 'train'.
         root: Directory where the datasets are saved. Default: ".data"
         offset: the number of the starting line. Default: 0
 
@@ -507,8 +505,7 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
         split: a string or tuple for the returned datasets, Default: ('train', 'valid', 'test')
             By default, all the three datasets (train, valid, test) are generated. Users
             could also choose any one or two of them, for example ('train', 'test') or
-            just a string 'train'. If 'train' is not in the tuple or string, a vocab
-            object should be provided which will be used to process valid and/or test data.
+            just a string 'train'.
         root: Directory where the datasets are saved. Default: ".data"
         offset: the number of the starting line. Default: 0
 

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -27,7 +27,7 @@ def build_vocab(data):
 
 
 def _setup_datasets(dataset_name, root, vocabs, split):
-    split = check_default_set(split, ('train', 'valid', 'test'))
+    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
     raw_iter_tuple = raw.DATASETS[dataset_name](root=root, split=split)
     raw_data = {}
     for name, raw_iter in zip(split, raw_iter_tuple):

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -27,8 +27,8 @@ def build_vocab(data):
     return vocabs
 
 
-def _setup_datasets(dataset_name, root, vocabs, split):
-    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
+def _setup_datasets(dataset_name, root, vocabs, split_):
+    split = check_default_set(split_, ('train', 'valid', 'test'), dataset_name)
     raw_iter_tuple = raw.DATASETS[dataset_name](root=root, split=split)
     raw_data = {}
     for name, raw_iter in zip(split, raw_iter_tuple):
@@ -60,7 +60,7 @@ def _setup_datasets(dataset_name, root, vocabs, split):
         for idx in range(len(vocabs))
     ]
     logger_.info('Building datasets for {}'.format(split))
-    return wrap_datasets(tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in split), split)
+    return wrap_datasets(tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in split), split_)
 
 
 class SequenceTaggingDataset(torch.utils.data.Dataset):

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -1,6 +1,7 @@
 import torch
 import logging
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 from torchtext.experimental.datasets import raw
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.functional import (
@@ -59,7 +60,7 @@ def _setup_datasets(dataset_name, root, vocabs, split):
         for idx in range(len(vocabs))
     ]
     logger_.info('Building datasets for {}'.format(split))
-    return tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in split)
+    return wrap_datasets(tuple(SequenceTaggingDataset(raw_data[item], vocabs, transformers) for item in split), split)
 
 
 class SequenceTaggingDataset(torch.utils.data.Dataset):

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -4,6 +4,7 @@ from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.datasets.raw import text_classification as raw
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 from torchtext.experimental.functional import (
     vocab_func,
     totensor,
@@ -93,12 +94,12 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, split):
     else:
         label_transform = sequential_transforms(totensor(dtype=torch.long))
     logger_.info('Building datasets for {}'.format(split))
-    return tuple(
+    return wrap_datasets(tuple(
         TextClassificationDataset(
             raw_data[item], vocab, (label_transform, text_transform)
         )
         for item in split
-    )
+    ), split)
 
 
 def AG_NEWS(root='.data', ngrams=1, vocab=None, tokenizer=None, split=('train', 'test')):

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -74,7 +74,7 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, split):
     if tokenizer is None:
         tokenizer = get_tokenizer("basic_english")
     text_transform = sequential_transforms(tokenizer, ngrams_func(ngrams))
-    split = check_default_set(split, ('train', 'test'))
+    split = check_default_set(split, ('train', 'test'), dataset_name)
     raw_datasets = raw.DATASETS[dataset_name](root=root, split=split)
     # Materialize raw text iterable dataset
     raw_data = {name: list(raw_dataset) for name, raw_dataset in zip(split, raw_datasets)}

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -70,12 +70,12 @@ class TextClassificationDataset(torch.utils.data.Dataset):
         return self.vocab
 
 
-def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, split):
+def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, split_):
     text_transform = []
     if tokenizer is None:
         tokenizer = get_tokenizer("basic_english")
     text_transform = sequential_transforms(tokenizer, ngrams_func(ngrams))
-    split = check_default_set(split, ('train', 'test'), dataset_name)
+    split = check_default_set(split_, ('train', 'test'), dataset_name)
     raw_datasets = raw.DATASETS[dataset_name](root=root, split=split)
     # Materialize raw text iterable dataset
     raw_data = {name: list(raw_dataset) for name, raw_dataset in zip(split, raw_datasets)}
@@ -99,7 +99,7 @@ def _setup_datasets(dataset_name, root, ngrams, vocab, tokenizer, split):
             raw_data[item], vocab, (label_transform, text_transform)
         )
         for item in split
-    ), split)
+    ), split_)
 
 
 def AG_NEWS(root='.data', ngrams=1, vocab=None, tokenizer=None, split=('train', 'test')):

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -19,7 +19,7 @@ def build_vocab(data, transforms, index):
 def _setup_datasets(dataset_name,
                     train_filenames, valid_filenames, test_filenames,
                     split, root, vocab, tokenizer):
-    split = check_default_set(split, ('train', 'valid', 'test'))
+    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
     src_vocab, tgt_vocab = vocab
     if tokenizer is None:
         src_tokenizer = get_tokenizer("spacy", language='de_core_news_sm')

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -1,6 +1,7 @@
 import torch
 import logging
 from torchtext.experimental.datasets.raw.common import check_default_set
+from torchtext.experimental.datasets.raw.common import wrap_datasets
 from torchtext.experimental.datasets import raw
 from torchtext.vocab import Vocab, build_vocab_from_iterator
 from torchtext.data.utils import get_tokenizer
@@ -79,7 +80,7 @@ def _setup_datasets(dataset_name,
             TranslationDataset(raw_data[key], (src_vocab, tgt_vocab),
                                (src_text_transform, tgt_text_transform)))
 
-    return tuple(datasets)
+    return wrap_datasets(tuple(datasets), split)
 
 
 class TranslationDataset(torch.utils.data.Dataset):
@@ -139,7 +140,6 @@ def Multi30k(train_filenames=("train.de", "train.en"),
              root='.data',
              vocab=(None, None),
              tokenizer=None):
-
     """ Define translation datasets: Multi30k
     Separately returns train/valid/test datasets as a tuple
 
@@ -240,7 +240,6 @@ def IWSLT(train_filenames=('train.de-en.de', 'train.de-en.en'),
           root='.data',
           vocab=(None, None),
           tokenizer=None):
-
     """ Define translation datasets: IWSLT
     Separately returns train/valid/test datasets
     The available datasets include:
@@ -430,7 +429,6 @@ def WMT14(train_filenames=('train.tok.clean.bpe.32000.de',
           root='.data',
           vocab=(None, None),
           tokenizer=None):
-
     """ Define translation datasets: WMT14
     Separately returns train/valid/test datasets
     The available datasets include:

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -19,8 +19,8 @@ def build_vocab(data, transforms, index):
 
 def _setup_datasets(dataset_name,
                     train_filenames, valid_filenames, test_filenames,
-                    split, root, vocab, tokenizer):
-    split = check_default_set(split, ('train', 'valid', 'test'), dataset_name)
+                    split_, root, vocab, tokenizer):
+    split = check_default_set(split_, ('train', 'valid', 'test'), dataset_name)
     src_vocab, tgt_vocab = vocab
     if tokenizer is None:
         src_tokenizer = get_tokenizer("spacy", language='de_core_news_sm')
@@ -80,7 +80,7 @@ def _setup_datasets(dataset_name,
             TranslationDataset(raw_data[key], (src_vocab, tgt_vocab),
                                (src_text_transform, tgt_text_transform)))
 
-    return wrap_datasets(tuple(datasets), split)
+    return wrap_datasets(tuple(datasets), split_)
 
 
 class TranslationDataset(torch.utils.data.Dataset):

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -57,7 +57,7 @@ def download_from_url(url, path=None, root='.data', overwrite=False, hash_value=
         if hash_value:
             with open(path, "rb") as file_obj:
                 if not validate_file(file_obj, hash_value, hash_type):
-                    raise RuntimeError("The hash of {} does not match. Delete the file manually and retry.".format(path))
+                    raise RuntimeError("The hash of {} does not match. Delete the file manually and retry.".format(os.path.abspath(path)))
 
     def _process_response(r, root, filename):
         chunk_size = 16 * 1024


### PR DESCRIPTION
Add support for the following behavior

```
train = Multi30k(split='train')
```

currently the user has to do

```
train, = Multi30k(split=('train',))
```

Changes include
- [x] Generic argument checking and return value constructor
- [x] Raw dataset tests
- [x] Regular dataset tests
- [x] Updated documentation
- [x] torchtext.experimental.datasets.raw.URLS dictionary that maps a dataset to the corresponding URL(s)

Follow-up:
- [ ] Use parameterized (as in [torchaudio](https://github.com/pytorch/audio/blob/7ee1c46b7831cdd5a66a46f23e4f32ffda1d0b52/test/torchaudio_unittest/functional/batch_consistency_test.py#L56)) to create one test per dataset.
- [ ] Re-enable tests for datasets hosted on statmt
- [ ] - [ ] Re-enable tests for datasets hosted on google drive