### PR TITLE
Add and use parameterized for testing

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -18,4 +18,4 @@ git submodule update --init --recursive
 python setup.py develop
 
 printf "* Installing parameterized\n"
-conda install -y parameterized
+pip install parameterized

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -16,3 +16,6 @@ conda install -y -c "pytorch-${UPLOAD_CHANNEL}" pytorch cpuonly
 printf "* Installing torchtext\n"
 git submodule update --init --recursive
 python setup.py develop
+
+printf "* Installing parameterized\n"
+conda install -y parameterized

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -21,3 +21,6 @@ conda install -y -c "pytorch-${UPLOAD_CHANNEL}" pytorch cpuonly
 printf "* Installing torchtext\n"
 git submodule update --init --recursive
 "$root_dir/packaging/vc_env_helper.bat" python setup.py develop
+
+printf "* Installing parameterized\n"
+pip install parameterized

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -4,6 +4,8 @@ import os
 import torchtext.data as data
 import torch
 import torchtext
+import unittest
+from parameterized import parameterized
 from ..common.torchtext_test_case import TorchtextTestCase
 from ..common.assets import conditional_remove
 
@@ -143,23 +145,22 @@ class TestDataset(TorchtextTestCase):
         _data = [item for item in train_iter]
         self.assertEqual(len(_data), 119990)
 
-    def test_raw_datasets_split_argument(self):
-        from torchtext.experimental.datasets.raw import DATASETS
-        for dataset_name in sorted(DATASETS.keys()):
-            if 'drive.google' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
-                continue
-            if 'statmt' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
-                continue
-            dataset = DATASETS[dataset_name]
-            train1 = dataset(split='train')
-            train2, = dataset(split=('train',))
-            for d1, d2 in zip(train1, train2):
-                self.assertEqual(d1, d2)
-                # This test only aims to exercise the argument parsing and uses
-                # the first line as a litmus test for correctness.
-                break
-            # Exercise default constructor
-            _ = dataset()
+    @parameterized.expand(list(sorted(torchtext.experimental.datasets.raw.DATASETS.keys())))
+    def test_raw_datasets_split_argument(self, dataset_name):
+        if 'drive.google' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
+            return
+        if 'statmt' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
+            return
+        dataset = torchtext.experimental.datasets.raw.DATASETS[dataset_name]
+        train1 = dataset(split='train')
+        train2, = dataset(split=('train',))
+        for d1, d2 in zip(train1, train2):
+            self.assertEqual(d1, d2)
+            # This test only aims to exercise the argument parsing and uses
+            # the first line as a litmus test for correctness.
+            break
+        # Exercise default constructor
+        _ = dataset()
 
     def test_datasets_split_argument(self):
         from torchtext.experimental.datasets import DATASETS

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -4,7 +4,6 @@ import os
 import torchtext.data as data
 import torch
 import torchtext
-import unittest
 from parameterized import parameterized
 from ..common.torchtext_test_case import TorchtextTestCase
 from ..common.assets import conditional_remove

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -162,19 +162,18 @@ class TestDataset(TorchtextTestCase):
         # Exercise default constructor
         _ = dataset()
 
-    def test_datasets_split_argument(self):
-        from torchtext.experimental.datasets import DATASETS
-        for dataset_name in ["AG_NEWS", "WikiText2", "IMDB"]:
-            dataset = DATASETS[dataset_name]
-            train1 = dataset(split='train')
-            train2, = dataset(split=('train',))
-            for d1, d2 in zip(train1, train2):
-                self.assertEqual(d1, d2)
-                # This test only aims to exercise the argument parsing and uses
-                # the first line as a litmus test for correctness.
-                break
-            # Exercise default constructor
-            _ = dataset()
+    @parameterized.expand(["AG_NEWS", "WikiText2", "IMDB"])
+    def test_datasets_split_argument(self, dataset_name):
+        dataset = torchtext.experimental.datasets.DATASETS[dataset_name]
+        train1 = dataset(split='train')
+        train2, = dataset(split=('train',))
+        for d1, d2 in zip(train1, train2):
+            self.assertEqual(d1, d2)
+            # This test only aims to exercise the argument parsing and uses
+            # the first line as a litmus test for correctness.
+            break
+        # Exercise default constructor
+        _ = dataset()
 
     def test_offset_dataset(self):
         train_iter, test_iter = torchtext.experimental.datasets.raw.AG_NEWS(split=('train', 'test'),


### PR DESCRIPTION
Introduces the parameterized module to increase resolution of tests and allow one test per dataset written generically.

Changes include
- [x] Parameterization of test_raw_datasets_split_argument
- [x] Parameterization of test_datasets_split_argument
- [x] Add module as dependency to CI system

Follow-up to https://github.com/pytorch/text/pull/1147