### PR TITLE
Detect when Google drive link exceeds quota and throw an error.

### DIFF
--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -63,6 +63,8 @@ def download_from_url(url, path=None, root='.data', overwrite=False, hash_value=
         chunk_size = 16 * 1024
         total_size = int(r.headers.get('Content-length', 0))
         if filename is None:
+            if 'content-disposition' not in r.headers:
+                raise RuntimeError("Internal error: headers don't contain content-disposition.")
             d = r.headers['content-disposition']
             filename = re.findall("filename=\"(.+)\"", d)
             if filename is None:
@@ -123,6 +125,15 @@ def download_from_url(url, path=None, root='.data', overwrite=False, hash_value=
     for k, v in response.cookies.items():
         if k.startswith("download_warning"):
             confirm_token = v
+    if confirm_token is None:
+        if "Quota exceeded" in str(response.content):
+            raise RuntimeError(
+                "Google drive link {} is currently unavailable, because the quota was exceeded.".format(
+                    url
+                ))
+        else:
+            raise RuntimeError("Internal error: confirm_token was not found in Google drive link with response content {}.".format(
+                response.content))
 
     if confirm_token:
         url = url + "&confirm=" + confirm_token

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -132,8 +132,7 @@ def download_from_url(url, path=None, root='.data', overwrite=False, hash_value=
                     url
                 ))
         else:
-            raise RuntimeError("Internal error: confirm_token was not found in Google drive link with response content {}.".format(
-                response.content))
+            raise RuntimeError("Internal error: confirm_token was not found in Google drive link.")
 
     if confirm_token:
         url = url + "&confirm=" + confirm_token


### PR DESCRIPTION
Google drive URLs are flaky, because the process sending the request might run into quota limits. This is currently not obvious to the user. In particular they'll see the following confusing error.

```
$ python -c "import torchtext; torchtext.experimental.datasets.raw.AmazonReviewFull()"
Traceback (most recent call last):
[...]
KeyError: 'content-disposition'
```

This PR attempts to detect this situation and throw a more readable exception instead.


```
$ python -c "import torchtext; torchtext.experimental.datasets.raw.AmazonReviewFull()"
Traceback (most recent call last):
[...]
RuntimeError: Google drive link https://drive.google.com/uc?export=download&id=0Bz8a_Dbh9QhbZVhsUnRWRDhETzA is currently unavailable, because the quota was exceeded.
```

Unfortunately it doesn't actually solve the problem of relying on a flaky host.