### PR TITLE
Add raw datasets to website documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,7 +489,7 @@ jobs:
             set -x
             pushd docs
             pip install -r requirements.txt
-            make html SPHINXOPTS="-W -j 4"
+            make html
             popd
       - persist_to_workspace:
           root: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,7 +489,7 @@ jobs:
             set -x
             pushd docs
             pip install -r requirements.txt
-            make html
+            make html SPHINXOPTS="-W -j 4"
             popd
       - persist_to_workspace:
           root: ./

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -489,7 +489,7 @@ jobs:
             set -x
             pushd docs
             pip install -r requirements.txt
-            make html SPHINXOPTS="-W -j 4"
+            make html
             popd
       - persist_to_workspace:
           root: ./

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -489,7 +489,7 @@ jobs:
             set -x
             pushd docs
             pip install -r requirements.txt
-            make html
+            make html SPHINXOPTS="-W -j 4"
             popd
       - persist_to_workspace:
           root: ./

--- a/docs/source/experimental_datasets_raw.rst
+++ b/docs/source/experimental_datasets_raw.rst
@@ -1,25 +1,22 @@
-torchtext.experimental.datasets
+torchtext.experimental.datasets.raw
 ===============================
 
-.. currentmodule:: torchtext.experimental.datasets
+.. currentmodule:: torchtext.experimental.datasets.raw
 
-The following datasets have been rewritten and more compatible with ``torch.utils.data``. General use cases are as follows: ::
+General use cases are as follows: ::
 
 
     # import datasets
-    from torchtext.experimental.datasets import IMDB
+    from torchtext.experimental.datasets.raw import IMDB
 
-    # set up tokenizer (the default on is basic_english tokenizer)
-    from torchtext.data.utils import get_tokenizer
-    tokenizer = get_tokenizer("spacy")
+    train_iter = IMDB(split='train')
 
-    # obtain data and vocab with a custom tokenizer
-    train_dataset, test_dataset = IMDB(tokenizer=tokenizer)
-    vocab = train_dataset.get_vocab()
-
-    # use the default tokenizer
-    train_dataset, test_dataset = IMDB()
-    vocab = train_dataset.get_vocab()
+    def tokenize(label, line):
+        return line.split()
+     
+    tokens = []
+    for line in train_iter:
+        tokens += tokenize(line)
 
 The following datasets are available:
 
@@ -32,11 +29,6 @@ Text Classification
 
 TextClassificationDataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Text classification datasets are subclasses of ``TextClassificationDataset`` class.
-
-.. autoclass:: TextClassificationDataset
-  :members: __init__
 
 AG_NEWS
 ~~~~~~~
@@ -88,12 +80,6 @@ IMDb
 Language Modeling
 ^^^^^^^^^^^^^^^^^
 
-Language modeling datasets are subclasses of ``LanguageModelingDataset`` class.
-
-.. autoclass:: LanguageModelingDataset
-  :members: __init__
-
-
 WikiText-2
 ~~~~~~~~~~
 
@@ -121,12 +107,6 @@ WMTNewsCrawl
 Machine Translation
 ^^^^^^^^^^^^^^^^^^^
 
-Translation datasets are subclasses of ``TranslationDataset`` class.
-
-.. autoclass:: TranslationDataset
-  :members: __init__
-
-
 Multi30k
 ~~~~~~~~
 
@@ -148,11 +128,6 @@ WMT14
 Sequence Tagging
 ^^^^^^^^^^^^^^^^
 
-Sequence Tagging datasets are subclasses of ``SequenceTaggingDataset`` class.
-
-.. autoclass:: SequenceTaggingDataset
-  :members: __init__
-
 UDPOS
 ~~~~~
 
@@ -165,12 +140,6 @@ CoNLL2000Chunking
 
 Question Answer
 ^^^^^^^^^^^^^^^
-
-Question answer datasets are subclasses of ``QuestionAnswerDataset`` class.
-
-.. autoclass:: QuestionAnswerDataset
-  :members: __init__
-
 
 SQuAD 1.0
 ~~~~~~~~~

--- a/docs/source/experimental_datasets_raw.rst
+++ b/docs/source/experimental_datasets_raw.rst
@@ -1,5 +1,5 @@
 torchtext.experimental.datasets.raw
-===============================
+===================================
 
 .. currentmodule:: torchtext.experimental.datasets.raw
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ popular datasets for natural language.
    torchtext.vocab <vocab>
    torchtext.utils <utils>
    experimental_datasets
+   experimental_datasets_raw
    experimental_transforms
    experimental_vectors
    experimental_vocab

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -76,9 +76,11 @@ def dataset_docstring_header(fn):
     raise ValueError("default_split type expected to be of string or tuple but got {}".format(type(default_split)))
 
 
-def add_docstring_header(fn):
-    fn.__doc__ = dataset_docstring_header(fn)
-    return fn
+def add_docstring_header():
+    def docstring_decorator(fn):
+        fn.__doc__ = dataset_docstring_header(fn)
+        return fn
+    return docstring_decorator
 
 
 def wrap_split_argument(fn):

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -70,8 +70,7 @@ def dataset_docstring_header(fn):
             split: Only {default_split} is available.
                 Default: {default_split}
             offset: the number of the starting line.
-                Default: 0
-        """.format(fn.__name__, default_split=default_split) + fn.__doc__
+                Default: 0""".format(fn.__name__, default_split=default_split) + fn.__doc__
 
     raise ValueError("default_split type expected to be of string or tuple but got {}".format(type(default_split)))
 

--- a/torchtext/experimental/datasets/raw/language_modeling.py
+++ b/torchtext/experimental/datasets/raw/language_modeling.py
@@ -48,7 +48,7 @@ def _setup_datasets(dataset_name, root, split, year, language, offset):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def WikiText2(root='.data', split=('train', 'valid', 'test'), offset=0):
     """
     Examples:
@@ -62,7 +62,7 @@ def WikiText2(root='.data', split=('train', 'valid', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def WikiText103(root='.data', split=('train', 'valid', 'test'), offset=0):
     """
     Examples:
@@ -75,7 +75,7 @@ def WikiText103(root='.data', split=('train', 'valid', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def PennTreebank(root='.data', split=('train', 'valid', 'test'), offset=0):
     """
     Examples:
@@ -89,7 +89,7 @@ def PennTreebank(root='.data', split=('train', 'valid', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def WMTNewsCrawl(root='.data', split='train', offset=0, year=2010, language='en'):
     """    year: the year of the dataset (Default: 2010)
         language: the language of the dataset (Default: 'en')

--- a/torchtext/experimental/datasets/raw/language_modeling.py
+++ b/torchtext/experimental/datasets/raw/language_modeling.py
@@ -91,8 +91,11 @@ def PennTreebank(root='.data', split=('train', 'valid', 'test'), offset=0):
 @wrap_split_argument
 @add_docstring_header()
 def WMTNewsCrawl(root='.data', split='train', offset=0, year=2010, language='en'):
-    """    year: the year of the dataset (Default: 2010)
-        language: the language of the dataset (Default: 'en')
+    # """   year: the year of the dataset
+    #          (Default: 2010)
+    #       language: the language of the dataset
+    #          (Default: 'en')
+    """
 
     Note: WMTNewsCrawl provides datasets based on the year and language instead of train/valid/test.
     """

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -41,18 +41,20 @@ def _setup_datasets(dataset_name, root, split, offset):
 @add_docstring_header()
 def SQuAD1(root='.data', split=('train', 'dev'), offset=0):
     """
+
     Examples:
         >>> train_dataset, dev_dataset = torchtext.experimental.datasets.raw.SQuAD1()
         >>> for idx, (context, question, answer, ans_pos) in enumerate(train_dataset):
         >>>     print(idx, (context, question, answer, ans_pos))
-
-    The iterator yields a tuple of (raw context, raw question, a list of raw answer,
-    a list of answer positions in the raw context).
-    For example, ('Architecturally, the school has a Catholic character. Atop the ...',
-                  'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?',
-                  ['Saint Bernadette Soubirous'],
-                  [515])
     """
+
+    # The iterator yields a tuple of (raw context, raw question, a list of raw answer,
+    # a list of answer positions in the raw context).
+    # For example, ('Architecturally, the school has a Catholic character. Atop the ...',
+    #               'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?',
+    #               ['Saint Bernadette Soubirous'],
+    #               [515])
+    # """
 
     return _setup_datasets("SQuAD1", root, split, offset)
 
@@ -61,18 +63,20 @@ def SQuAD1(root='.data', split=('train', 'dev'), offset=0):
 @add_docstring_header()
 def SQuAD2(root='.data', split=('train', 'dev'), offset=0):
     """
+
     Examples:
         >>> train_dataset, dev_dataset = torchtext.experimental.datasets.raw.SQuAD2()
         >>> for idx, (context, question, answer, ans_pos) in enumerate(train_dataset):
         >>>     print(idx, (context, question, answer, ans_pos))
-
-    The iterator yields a tuple of (raw context, raw question, a list of raw answer,
-    a list of answer positions in the raw context).
-    For example, ('Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981) is an ...',
-                  'When did Beyonce start becoming popular?',
-                  ['in the late 1990s'],
-                  [269])
     """
+
+    # The iterator yields a tuple of (raw context, raw question, a list of raw answer,
+    # a list of answer positions in the raw context).
+    # For example, ('Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981) is an ...',
+    #               'When did Beyonce start becoming popular?',
+    #               ['in the late 1990s'],
+    #               [269])
+    # """
 
     return _setup_datasets("SQuAD2", root, split, offset)
 

--- a/torchtext/experimental/datasets/raw/question_answer.py
+++ b/torchtext/experimental/datasets/raw/question_answer.py
@@ -38,7 +38,7 @@ def _setup_datasets(dataset_name, root, split, offset):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def SQuAD1(root='.data', split=('train', 'dev'), offset=0):
     """
     Examples:
@@ -58,7 +58,7 @@ def SQuAD1(root='.data', split=('train', 'dev'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def SQuAD2(root='.data', split=('train', 'dev'), offset=0):
     """
     Examples:

--- a/torchtext/experimental/datasets/raw/sequence_tagging.py
+++ b/torchtext/experimental/datasets/raw/sequence_tagging.py
@@ -65,7 +65,7 @@ def _setup_datasets(dataset_name, separator, root, split, offset):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def UDPOS(root=".data", split=('train', 'valid', 'test'), offset=0):
     """
     Examples:
@@ -76,7 +76,7 @@ def UDPOS(root=".data", split=('train', 'valid', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def CoNLL2000Chunking(root=".data", split=('train', 'test'), offset=0):
     """
     Examples:

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -72,7 +72,7 @@ def _setup_datasets(dataset_name, root, split, offset):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def AG_NEWS(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -83,7 +83,7 @@ def AG_NEWS(root='.data', split=('train', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def SogouNews(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -94,7 +94,7 @@ def SogouNews(root='.data', split=('train', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def DBpedia(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -105,7 +105,7 @@ def DBpedia(root='.data', split=('train', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def YelpReviewPolarity(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -116,7 +116,7 @@ def YelpReviewPolarity(root='.data', split=('train', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def YelpReviewFull(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -127,7 +127,7 @@ def YelpReviewFull(root='.data', split=('train', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def YahooAnswers(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -138,7 +138,7 @@ def YahooAnswers(root='.data', split=('train', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def AmazonReviewPolarity(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -149,7 +149,7 @@ def AmazonReviewPolarity(root='.data', split=('train', 'test'), offset=0):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def AmazonReviewFull(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:
@@ -170,7 +170,7 @@ def generate_imdb_data(key, extracted_files):
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def IMDB(root='.data', split=('train', 'test'), offset=0):
     """
     Examples:

--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -190,7 +190,7 @@ def _setup_datasets(dataset_name,
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def Multi30k(root='.data', split=('train', 'valid', 'test'), offset=0,
              train_filenames=("train.de", "train.en"),
              valid_filenames=("val.de", "val.en"),
@@ -261,7 +261,7 @@ def Multi30k(root='.data', split=('train', 'valid', 'test'), offset=0,
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def IWSLT(root='.data', split=('train', 'valid', 'test'), offset=0,
           train_filenames=('train.de-en.de', 'train.de-en.en'),
           valid_filenames=('IWSLT16.TED.tst2013.de-en.de',
@@ -420,7 +420,7 @@ def IWSLT(root='.data', split=('train', 'valid', 'test'), offset=0,
 
 
 @wrap_split_argument
-@add_docstring_header
+@add_docstring_header()
 def WMT14(root='.data', split=('train', 'valid', 'test'), offset=0,
           train_filenames=('train.tok.clean.bpe.32000.de',
                            'train.tok.clean.bpe.32000.en'),


### PR DESCRIPTION
This change adds a basic overview of of the raw text datasets in the experimental folder to http://pytorch.org/text/master/.