### PR TITLE
Add _PATHS to text classification datasets, add global MD5 and NUM_LINES.

### DIFF
--- a/torchtext/experimental/datasets/raw/__init__.py
+++ b/torchtext/experimental/datasets/raw/__init__.py
@@ -39,4 +39,28 @@ URLS.update(translation_URLS)
 URLS.update(language_modeling_URLS)
 URLS.update(question_answer_URLS)
 
+from .text_classification import NUM_LINES as text_classification_NUM_LINES
+from .sequence_tagging import NUM_LINES as sequence_tagging_NUM_LINES
+from .translation import NUM_LINES as translation_NUM_LINES
+from .language_modeling import NUM_LINES as language_modeling_NUM_LINES
+from .question_answer import NUM_LINES as question_answer_NUM_LINES
+
+NUM_LINES = text_classification_NUM_LINES
+NUM_LINES.update(sequence_tagging_NUM_LINES)
+NUM_LINES.update(translation_NUM_LINES)
+NUM_LINES.update(language_modeling_NUM_LINES)
+NUM_LINES.update(question_answer_NUM_LINES)
+
+from .text_classification import MD5 as text_classification_MD5
+from .sequence_tagging import MD5 as sequence_tagging_MD5
+from .translation import MD5 as translation_MD5
+from .language_modeling import MD5 as language_modeling_MD5
+from .question_answer import MD5 as question_answer_MD5
+
+MD5 = text_classification_MD5
+MD5.update(sequence_tagging_MD5)
+MD5.update(translation_MD5)
+MD5.update(language_modeling_MD5)
+MD5.update(question_answer_MD5)
+
 __all__ = sorted(list(map(str, DATASETS.keys())))

--- a/torchtext/experimental/datasets/raw/common.py
+++ b/torchtext/experimental/datasets/raw/common.py
@@ -114,18 +114,19 @@ def wrap_split_argument(fn):
     # keyword arguments with default values only, so only  a dictionary of default
     # values is needed to support that behavior for new_fn as well.
     fn_kwargs_dict = {}
-    for arg, default in zip(argspec.args, argspec.defaults):
+    for arg, default in zip(argspec.args[3:], argspec.defaults[3:]):
         fn_kwargs_dict[arg] = default
 
     @functools.wraps(fn)
-    def new_fn(**kwargs):
+    def new_fn(root='.data', split=argspec.defaults[1], offset=0, **kwargs):
         for arg in fn_kwargs_dict:
             if arg not in kwargs:
                 kwargs[arg] = fn_kwargs_dict[arg]
-        orig_split = kwargs["split"]
-        kwargs["split"] = check_default_set(orig_split, argspec.defaults[1], fn.__name__)
+        kwargs["root"] = root
+        kwargs["offset"] = offset
+        kwargs["split"] = check_default_set(split, argspec.defaults[1], fn.__name__)
         result = fn(**kwargs)
-        return wrap_datasets(tuple(result), orig_split)
+        return wrap_datasets(tuple(result), split)
 
     return new_fn
 

--- a/torchtext/experimental/datasets/raw/text_classification.py
+++ b/torchtext/experimental/datasets/raw/text_classification.py
@@ -1,4 +1,5 @@
 import io
+import os
 from torchtext.utils import download_from_url, extract_archive, unicode_csv_reader
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import wrap_split_argument
@@ -26,6 +27,20 @@ URLS = {
         'http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz'
 }
 
+_PATHS = {
+    'AG_NEWS':
+        {'train': 'train.csv',
+         'test': 'test.csv'},
+    'SogouNews': 'sogou_news_csv.tar.gz',
+    'DBpedia': 'dbpedia_csv.tar.gz',
+    'YelpReviewPolarity': 'yelp_review_polarity_csv.tar.gz',
+    'YelpReviewFull': 'yelp_review_full_csv.tar.gz',
+    'YahooAnswers': 'yahoo_answers_csv.tar.gz',
+    'AmazonReviewPolarity': 'amazon_review_polarity_csv.tar.gz',
+    'AmazonReviewFull': 'amazon_review_full_csv.tar.gz',
+    'IMDB': 'aclImdb_v1.tar.gz'
+}
+
 
 def _create_data_from_csv(data_path):
     with io.open(data_path, encoding="utf8") as f:
@@ -37,10 +52,12 @@ def _create_data_from_csv(data_path):
 def _setup_datasets(dataset_name, root, split, offset):
     if dataset_name == 'AG_NEWS':
         extracted_files = [download_from_url(URLS[dataset_name][item], root=root,
+                                             path=os.path.join(root, _PATHS[dataset_name][item]),
                                              hash_value=MD5['AG_NEWS'][item],
                                              hash_type='md5') for item in ('train', 'test')]
     else:
         dataset_tar = download_from_url(URLS[dataset_name], root=root,
+                                        path=os.path.join(root, _PATHS[dataset_name]),
                                         hash_value=MD5[dataset_name], hash_type='md5')
         extracted_files = extract_archive(dataset_tar)
 


### PR DESCRIPTION
Currently text classification datasets will download from google drive even if the result already exists on disk, because google drive URLs do not allow to infer the path at which the download result will be stored. This PR addresses this for translation datasets and further introduces torchtext.experimental.datasets.raw.MD5 and NUM_LINES dictionaries to allow for easier access of this meta information. It also fixes meta information for the wrapped dataset factory function to actually contain the defaults for split, root and offset.