### PR TITLE
Add _PATHS to raw WMT14 and IWSLT

### DIFF
--- a/torchtext/experimental/datasets/raw/translation.py
+++ b/torchtext/experimental/datasets/raw/translation.py
@@ -66,6 +66,11 @@ URLS = {
     'https://drive.google.com/uc?id=1l5y6Giag9aRPwGtuZHswh3w5v3qEz8D8'
 }
 
+_PATHS = {
+    'WMT14': 'wmt16_en_de.tar.gz',
+    'IWSLT': '2016-01.tgz'
+}
+
 
 def _read_text_iterator(path):
     with io.open(path, encoding="utf8") as f:
@@ -132,7 +137,7 @@ def _setup_datasets(dataset_name,
                 f, root=root, hash_value=MD5[dataset_name][idx], hash_type='md5')
             extracted_files.extend(extract_archive(dataset_tar))
     elif isinstance(URLS[dataset_name], str):
-        dataset_tar = download_from_url(URLS[dataset_name], root=root, hash_value=MD5[dataset_name], hash_type='md5')
+        dataset_tar = download_from_url(URLS[dataset_name], root=root, hash_value=MD5[dataset_name], path=_PATHS[dataset_name], hash_type='md5')
         extracted_dataset_tar = extract_archive(dataset_tar)
         if dataset_name == 'IWSLT':
             # IWSLT dataset's url downloads a multilingual tgz.

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -93,7 +93,7 @@ def download_from_url(url, path=None, root='.data', overwrite=False, hash_value=
     if path is None:
         _, filename = os.path.split(url)
     else:
-        root, filename = os.path.split(path)
+        root, filename = os.path.split(os.path.abspath(path))
 
     if not os.path.exists(root):
         try:


### PR DESCRIPTION
Both WMT14 and IWSLT use Google drive as the data source, but don't check whether the file already exists.

This PR further addresses a bug in download_from_url, where a given relative path would result in an incorrectly inferred root directory without prior path normalization (abspath).