### PR TITLE
Build docs in parallel and turn warnings into errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,7 +489,7 @@ jobs:
             set -x
             pushd docs
             pip install -r requirements.txt
-            make html
+            make html SPHINXOPTS="-W -j 4"
             popd
       - persist_to_workspace:
           root: ./

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -489,7 +489,7 @@ jobs:
             set -x
             pushd docs
             pip install -r requirements.txt
-            make html
+            make html SPHINXOPTS="-W -j 4"
             popd
       - persist_to_workspace:
           root: ./


### PR DESCRIPTION
This reduces build time and catches issues in documentation earlier on by turning warnings into errors.