### PR TITLE
Fix sphinx warnings and turn warnings into errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
+SPHINXOPTS    = -W  # turn warnings into errors
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = torchtext
 SOURCEDIR     = source

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = torchtext
 SOURCEDIR     = source

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,8 @@ extensions = [
 ]
 
 napoleon_use_ivar = True
+napoleon_numpy_docstring = False
+napoleon_google_docstring = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/torchtext/datasets/language_modeling.py
+++ b/torchtext/datasets/language_modeling.py
@@ -156,8 +156,7 @@ class PennTreebank(LanguageModelingDataset):
     """The Penn Treebank dataset.
     A relatively small dataset originally created for POS tagging.
 
-    References
-    ----------
+    References:
     Marcus, Mitchell P., Marcinkiewicz, Mary Ann & Santorini, Beatrice (1993).
     Building a Large Annotated Corpus of English: The Penn Treebank
     """

--- a/torchtext/datasets/text_classification.py
+++ b/torchtext/datasets/text_classification.py
@@ -144,11 +144,13 @@ def _setup_datasets(dataset_name, root='.data', ngrams=1, vocab=None, include_un
 
 def AG_NEWS(*args, **kwargs):
     """ Defines AG_NEWS datasets.
-        The labels includes:
-            - 0 : World
-            - 1 : Sports
-            - 2 : Business
-            - 3 : Sci/Tech
+
+    The labels include:
+
+        - 0 : World
+        - 1 : Sports
+        - 2 : Business
+        - 3 : Sci/Tech
 
     Create supervised learning dataset: AG_NEWS
 
@@ -172,12 +174,14 @@ def AG_NEWS(*args, **kwargs):
 
 def SogouNews(*args, **kwargs):
     """ Defines SogouNews datasets.
-        The labels includes:
-            - 0 : Sports
-            - 1 : Finance
-            - 2 : Entertainment
-            - 3 : Automobile
-            - 4 : Technology
+
+    The labels include:
+
+        - 0 : Sports
+        - 1 : Finance
+        - 2 : Entertainment
+        - 3 : Automobile
+        - 4 : Technology
 
     Create supervised learning dataset: SogouNews
 
@@ -201,21 +205,23 @@ def SogouNews(*args, **kwargs):
 
 def DBpedia(*args, **kwargs):
     """ Defines DBpedia datasets.
-        The labels includes:
-            - 0 : Company
-            - 1 : EducationalInstitution
-            - 2 : Artist
-            - 3 : Athlete
-            - 4 : OfficeHolder
-            - 5 : MeanOfTransportation
-            - 6 : Building
-            - 7 : NaturalPlace
-            - 8 : Village
-            - 9 : Animal
-            - 10 : Plant
-            - 11 : Album
-            - 12 : Film
-            - 13 : WrittenWork
+
+    The labels include:
+
+        - 0 : Company
+        - 1 : EducationalInstitution
+        - 2 : Artist
+        - 3 : Athlete
+        - 4 : OfficeHolder
+        - 5 : MeanOfTransportation
+        - 6 : Building
+        - 7 : NaturalPlace
+        - 8 : Village
+        - 9 : Animal
+        - 10 : Plant
+        - 11 : Album
+        - 12 : Film
+        - 13 : WrittenWork
 
     Create supervised learning dataset: DBpedia
 
@@ -239,9 +245,11 @@ def DBpedia(*args, **kwargs):
 
 def YelpReviewPolarity(*args, **kwargs):
     """ Defines YelpReviewPolarity datasets.
-        The labels includes:
-            - 0 : Negative polarity.
-            - 1 : Positive polarity.
+
+    The labels include:
+
+        - 0 : Negative polarity.
+        - 1 : Positive polarity.
 
     Create supervised learning dataset: YelpReviewPolarity
 
@@ -265,8 +273,10 @@ def YelpReviewPolarity(*args, **kwargs):
 
 def YelpReviewFull(*args, **kwargs):
     """ Defines YelpReviewFull datasets.
-        The labels includes:
-            0 - 4 : rating classes (4 is highly recommended).
+
+    The labels include:
+
+        0 - 4 : rating classes (4 is highly recommended).
 
     Create supervised learning dataset: YelpReviewFull
 
@@ -290,17 +300,19 @@ def YelpReviewFull(*args, **kwargs):
 
 def YahooAnswers(*args, **kwargs):
     """ Defines YahooAnswers datasets.
-        The labels includes:
-            - 0 : Society & Culture
-            - 1 : Science & Mathematics
-            - 2 : Health
-            - 3 : Education & Reference
-            - 4 : Computers & Internet
-            - 5 : Sports
-            - 6 : Business & Finance
-            - 7 : Entertainment & Music
-            - 8 : Family & Relationships
-            - 9 : Politics & Government
+
+    The labels include:
+
+        - 0 : Society & Culture
+        - 1 : Science & Mathematics
+        - 2 : Health
+        - 3 : Education & Reference
+        - 4 : Computers & Internet
+        - 5 : Sports
+        - 6 : Business & Finance
+        - 7 : Entertainment & Music
+        - 8 : Family & Relationships
+        - 9 : Politics & Government
 
     Create supervised learning dataset: YahooAnswers
 
@@ -324,9 +336,11 @@ def YahooAnswers(*args, **kwargs):
 
 def AmazonReviewPolarity(*args, **kwargs):
     """ Defines AmazonReviewPolarity datasets.
-        The labels includes:
-            - 0 : Negative polarity
-            - 1 : Positive polarity
+
+    The labels include:
+
+        - 0 : Negative polarity
+        - 1 : Positive polarity
 
     Create supervised learning dataset: AmazonReviewPolarity
 
@@ -350,8 +364,10 @@ def AmazonReviewPolarity(*args, **kwargs):
 
 def AmazonReviewFull(*args, **kwargs):
     """ Defines AmazonReviewFull datasets.
-        The labels includes:
-            0 - 4 : rating classes (4 is highly recommended)
+
+    The labels include:
+
+        0 - 4 : rating classes (4 is highly recommended)
 
     Create supervised learning dataset: AmazonReviewFull
 

--- a/torchtext/experimental/vectors.py
+++ b/torchtext/experimental/vectors.py
@@ -38,7 +38,7 @@ def FastText(language="en", unk_tensor=None, root=".data", validate_file=True, n
         num_cpus (int): the number of cpus to use when loading the vectors from file. Default: 10.
 
     Returns:
-        Vectors: a Vectors object.
+        torchtext.experimental.vectors.Vector: a Vectors object.
 
     Raises:
         ValueError: if duplicate tokens are found in FastText file.
@@ -99,7 +99,7 @@ def GloVe(name="840B", dim=300, unk_tensor=None, root=".data", validate_file=Tru
                               Should be `False` when running tests with a local asset.
         num_cpus (int): the number of cpus to use when loading the vectors from file. Default: 10.
     Returns:
-        Vectors: a Vectors object.
+        torchtext.experimental.vectors.Vector: a Vectors object.
 
     Raises:
         ValueError: if unexpected duplicate tokens are found in GloVe file.
@@ -185,6 +185,7 @@ def load_vectors_from_file_path(filepath, delimiter=",", unk_tensor=None, num_cp
 
 def build_vectors(tokens, vectors, unk_tensor=None):
     r"""Factory method for creating a vectors object which maps tokens to vectors.
+
     Args:
         tokens (List[str]): a list of tokens.
         vectors (torch.Tensor): a 2d tensor representing the vector associated with each token.
@@ -208,6 +209,7 @@ def build_vectors(tokens, vectors, unk_tensor=None):
 class Vectors(nn.Module):
     __jit_unused_properties__ = ["is_jitable"]
     r"""Creates a vectors object which maps tokens to vectors.
+
     Args:
         vectors (torch.classes.torchtext.Vectors or torchtext._torchtext.Vectors): a cpp vectors object.
     """
@@ -223,6 +225,7 @@ class Vectors(nn.Module):
     @torch.jit.export
     def forward(self, tokens: List[str]) -> Tensor:
         r"""Calls the `lookup_vectors` method
+
          Args:
             tokens: a list of string tokens
 
@@ -269,6 +272,7 @@ class Vectors(nn.Module):
     @torch.jit.export
     def lookup_vectors(self, tokens: List[str]) -> Tensor:
         """Look up embedding vectors for a list of tokens.
+
         Args:
             tokens: a list of tokens
 

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -35,7 +35,7 @@ def build_vocab_from_text_file(file_object, jited_tokenizer, min_freq=1, unk_tok
         num_cpus (int): the number of cpus to use when loading the vectors from file. Default: 4.
 
     Returns:
-        Vocab: a `Vocab` object.
+        torchtext.experimental.vocab.Vocab: a `Vocab` object.
 
     Examples:
         >>> from torchtext.experimental.vocab import build_vocab_from_text_file
@@ -69,7 +69,7 @@ def load_vocab_from_file(file_object, min_freq=1, unk_token='<unk>', num_cpus=4)
         num_cpus (int): the number of cpus to use when loading the vectors from file. Default: 4.
 
     Returns:
-        Vocab: a `Vocab` object.
+        torchtext.experimental.vocab.Vocab: a `Vocab` object.
 
     Examples:
         >>> from torchtext.experimental.vocab import load_vocab_from_file
@@ -162,6 +162,7 @@ class Vocab(nn.Module):
     @torch.jit.export
     def forward(self, tokens: List[str]) -> List[int]:
         r"""Calls the `lookup_indices` method
+
         Args:
             tokens (List[str]): a list of tokens used to lookup their corresponding `indices`.
 


### PR DESCRIPTION
Similar to what was done in `torchvision` https://github.com/pytorch/vision/pull/3290 and `torchaudio` https://github.com/pytorch/audio/pull/1247

This PR fixes sphinx warnings as well as some other doc layout issues, and sets the 

```py
napoleon_numpy_docstring = False
napoleon_google_docstring = True
```

for sphinx to issue warnings when the wrong parameter syntax is used.

The warnings are now turned into errors. Note: sphinx will now stop compilation at the first warning/error it sees; if we relied on sphinx>=8, we could use the `--keep-going` option to let it finish.