### PR TITLE
Avoid unnecessary downloads and extraction for some raw datasets, WMTNewsCrawl input sanitization, more logging

### DIFF
--- a/torchtext/experimental/datasets/raw/ag_news.py
+++ b/torchtext/experimental/datasets/raw/ag_news.py
@@ -2,7 +2,6 @@ from torchtext.utils import download_from_url, unicode_csv_reader
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import wrap_split_argument
 from torchtext.experimental.datasets.raw.common import add_docstring_header
-from torchtext.experimental.datasets.raw.common import find_match
 import os
 import io
 

--- a/torchtext/experimental/datasets/raw/ag_news.py
+++ b/torchtext/experimental/datasets/raw/ag_news.py
@@ -25,20 +25,18 @@ NUM_LINES = {
 @wrap_split_argument
 @add_docstring_header()
 def AG_NEWS(root='.data', split=('train', 'test'), offset=0):
-
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)
             for row in reader:
                 yield int(row[0]), ' '.join(row[1:])
 
-    extracted_files = [download_from_url(URL[item], root=root,
-                                         path=os.path.join(root, item + ".csv"),
-                                         hash_value=MD5[item],
-                                         hash_type='md5') for item in ('train', 'test')]
     datasets = []
     for item in split:
-        path = find_match(item + '.csv', extracted_files)
+        path = download_from_url(URL[item], root=root,
+                                 path=os.path.join(root, item + ".csv"),
+                                 hash_value=MD5[item],
+                                 hash_type='md5')
         datasets.append(RawTextIterableDataset("AG_NEWS", NUM_LINES[item],
                                                _create_data_from_csv(path), offset=offset))
     return datasets

--- a/torchtext/experimental/datasets/raw/amazonreviewfull.py
+++ b/torchtext/experimental/datasets/raw/amazonreviewfull.py
@@ -5,6 +5,7 @@ from torchtext.experimental.datasets.raw.common import add_docstring_header
 from torchtext.experimental.datasets.raw.common import find_match
 import os
 import io
+import logging
 
 URL = 'https://drive.google.com/uc?export=download&id=0Bz8a_Dbh9QhbZVhsUnRWRDhETzA'
 
@@ -34,6 +35,7 @@ def AmazonReviewFull(root='.data', split=('train', 'test'), offset=0):
     datasets = []
     for item in split:
         path = find_match(item + '.csv', extracted_files)
+        logging.info('Creating {} data'.format(item))
         datasets.append(RawTextIterableDataset("AmazonReviewFull", NUM_LINES[item],
                                                _create_data_from_csv(path), offset=offset))
     return datasets

--- a/torchtext/experimental/datasets/raw/conll2000chunking.py
+++ b/torchtext/experimental/datasets/raw/conll2000chunking.py
@@ -19,7 +19,7 @@ NUM_LINES = {
 }
 
 
-def _create_data_from_iob(data_path, separator="\t"):
+def _create_data_from_iob(data_path, separator):
     with open(data_path, encoding="utf-8") as input_file:
         columns = []
         for line in input_file:
@@ -49,16 +49,11 @@ def _construct_filepath(paths, file_suffix):
 @wrap_split_argument
 @add_docstring_header()
 def CoNLL2000Chunking(root='.data', split=('train', 'test'), offset=0):
-    extracted_files = []
-    for name, item in URL.items():
-        dataset_tar = download_from_url(item, root=root, hash_value=MD5[name], hash_type='md5')
-        extracted_files.extend(extract_archive(dataset_tar))
-
-    data_filenames = {
-        "train": _construct_filepath(extracted_files, "train.txt"),
-        "valid": _construct_filepath(extracted_files, "dev.txt"),
-        "test": _construct_filepath(extracted_files, "test.txt")
-    }
-    return [RawTextIterableDataset("CoNLL2000Chunking", NUM_LINES[item],
-                                   _create_data_from_iob(data_filenames[item], " "), offset=offset)
-            if data_filenames[item] is not None else None for item in split]
+    datasets = []
+    for item in split:
+        dataset_tar = download_from_url(item, root=root, hash_value=MD5[item], hash_type='md5')
+        extracted_files = extract_archive(dataset_tar)
+        data_filenames = _construct_filepath(extracted_files, split + ".txt")
+        datasets.append(RawTextIterableDataset("CoNLL2000Chunking", NUM_LINES[item],
+                                               _create_data_from_iob(data_filenames[item], " "), offset=offset))
+    return datasets

--- a/torchtext/experimental/datasets/raw/conll2000chunking.py
+++ b/torchtext/experimental/datasets/raw/conll2000chunking.py
@@ -2,6 +2,7 @@ from torchtext.utils import download_from_url, extract_archive
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import wrap_split_argument
 from torchtext.experimental.datasets.raw.common import add_docstring_header
+from torchtext.experimental.datasets.raw.common import find_match
 
 URL = {
     'train': "https://www.clips.uantwerpen.be/conll2000/chunking/train.txt.gz",
@@ -37,23 +38,14 @@ def _create_data_from_iob(data_path, separator):
             yield columns
 
 
-def _construct_filepath(paths, file_suffix):
-    if file_suffix:
-        path = None
-        for p in paths:
-            path = p if p.endswith(file_suffix) else path
-        return path
-    return None
-
-
 @wrap_split_argument
 @add_docstring_header()
 def CoNLL2000Chunking(root='.data', split=('train', 'test'), offset=0):
     datasets = []
     for item in split:
-        dataset_tar = download_from_url(item, root=root, hash_value=MD5[item], hash_type='md5')
+        dataset_tar = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')
         extracted_files = extract_archive(dataset_tar)
-        data_filenames = _construct_filepath(extracted_files, split + ".txt")
+        data_filename = find_match(item + ".txt", extracted_files)
         datasets.append(RawTextIterableDataset("CoNLL2000Chunking", NUM_LINES[item],
-                                               _create_data_from_iob(data_filenames[item], " "), offset=offset))
+                                               _create_data_from_iob(data_filename, " "), offset=offset))
     return datasets

--- a/torchtext/experimental/datasets/raw/penntreebank.py
+++ b/torchtext/experimental/datasets/raw/penntreebank.py
@@ -28,16 +28,14 @@ NUM_LINES = {
 @wrap_split_argument
 @add_docstring_header()
 def PennTreebank(root='.data', split=('train', 'valid', 'test'), offset=0):
-    extracted_files = [download_from_url(URL[key],
-                                         root=root, hash_value=MD5[key],
-                                         hash_type='md5') for key in split]
     datasets = []
     for item in split:
-        path = find_match(item, extracted_files)
+        path = download_from_url(URL[item],
+                                 root=root, hash_value=MD5[item],
+                                 hash_type='md5')
         logging.info('Creating {} data'.format(item))
         datasets.append(RawTextIterableDataset('PennTreebank',
                                                NUM_LINES[item],
                                                iter(io.open(path, encoding="utf8")),
                                                offset=offset))
-
     return datasets

--- a/torchtext/experimental/datasets/raw/penntreebank.py
+++ b/torchtext/experimental/datasets/raw/penntreebank.py
@@ -3,7 +3,6 @@ from torchtext.utils import download_from_url
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import wrap_split_argument
 from torchtext.experimental.datasets.raw.common import add_docstring_header
-from torchtext.experimental.datasets.raw.common import find_match
 import io
 
 URL = {

--- a/torchtext/experimental/datasets/raw/squad1.py
+++ b/torchtext/experimental/datasets/raw/squad1.py
@@ -39,7 +39,9 @@ def _create_data_from_json(data_path):
 @wrap_split_argument
 @add_docstring_header()
 def SQuAD1(root='.data', split=('train', 'dev'), offset=0):
-    extracted_files = {key: download_from_url(URL[key], root=root,
-                                              hash_value=MD5[key], hash_type='md5') for key in split}
-    return [RawTextIterableDataset('SQuAD1', NUM_LINES[item],
-                                   _create_data_from_json(extracted_files[item]), offset=offset) for item in split]
+    datasets = []
+    for item in split:
+        extracted_files = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')
+        datasets.append(RawTextIterableDataset('SQuAD1', NUM_LINES[item],
+                                               _create_data_from_json(extracted_files), offset=offset))
+    return datasets

--- a/torchtext/experimental/datasets/raw/squad2.py
+++ b/torchtext/experimental/datasets/raw/squad2.py
@@ -39,7 +39,9 @@ def _create_data_from_json(data_path):
 @wrap_split_argument
 @add_docstring_header()
 def SQuAD2(root='.data', split=('train', 'dev'), offset=0):
-    extracted_files = {key: download_from_url(URL[key], root=root,
-                                              hash_value=MD5[key], hash_type='md5') for key in split}
-    return [RawTextIterableDataset('SQuAD2', NUM_LINES[item],
-                                   _create_data_from_json(extracted_files[item]), offset=offset) for item in split]
+    datasets = []
+    for item in split:
+        extracted_files = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')
+        datasets.append(RawTextIterableDataset('SQuAD2', NUM_LINES[item],
+                                               _create_data_from_json(extracted_files), offset=offset))
+    return datasets

--- a/torchtext/experimental/datasets/raw/udpos.py
+++ b/torchtext/experimental/datasets/raw/udpos.py
@@ -44,14 +44,14 @@ def _construct_filepath(paths, file_suffix):
 @wrap_split_argument
 @add_docstring_header()
 def UDPOS(root='.data', split=('train', 'valid', 'test'), offset=0):
-    dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
-    extracted_files = extract_archive(dataset_tar)
-
-    data_filenames = {
-        "train": _construct_filepath(extracted_files, "train.txt"),
-        "valid": _construct_filepath(extracted_files, "dev.txt"),
-        "test": _construct_filepath(extracted_files, "test.txt")
-    }
-    return [RawTextIterableDataset("UDPOS", NUM_LINES[item],
-                                   _create_data_from_iob(data_filenames[item]), offset=offset)
-            if data_filenames[item] is not None else None for item in split]
+    datasets = []
+    for item in split:
+        dataset_tar = download_from_url(item, root=root, hash_value=MD5[item], hash_type='md5')
+        extracted_files = extract_archive(dataset_tar)
+        if split == "valid":
+            data_filenames = _construct_filepath(extracted_files, "dev.txt")
+        else:
+            data_filenames = _construct_filepath(extracted_files, split + ".txt")
+        datasets.append(RawTextIterableDataset("UDPOS", NUM_LINES[item],
+                                               _create_data_from_iob(data_filenames[item], " "), offset=offset))
+    return datasets

--- a/torchtext/experimental/datasets/raw/udpos.py
+++ b/torchtext/experimental/datasets/raw/udpos.py
@@ -2,6 +2,7 @@ from torchtext.utils import download_from_url, extract_archive
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import wrap_split_argument
 from torchtext.experimental.datasets.raw.common import add_docstring_header
+from torchtext.experimental.datasets.raw.common import find_match
 
 URL = 'https://bitbucket.org/sivareddyg/public/downloads/en-ud-v2.zip'
 
@@ -32,26 +33,17 @@ def _create_data_from_iob(data_path, separator="\t"):
             yield columns
 
 
-def _construct_filepath(paths, file_suffix):
-    if file_suffix:
-        path = None
-        for p in paths:
-            path = p if p.endswith(file_suffix) else path
-        return path
-    return None
-
-
 @wrap_split_argument
 @add_docstring_header()
 def UDPOS(root='.data', split=('train', 'valid', 'test'), offset=0):
+    dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
+    extracted_files = extract_archive(dataset_tar)
     datasets = []
     for item in split:
-        dataset_tar = download_from_url(item, root=root, hash_value=MD5[item], hash_type='md5')
-        extracted_files = extract_archive(dataset_tar)
-        if split == "valid":
-            data_filenames = _construct_filepath(extracted_files, "dev.txt")
+        if item == 'valid':
+            path = find_match("dev.txt", extracted_files)
         else:
-            data_filenames = _construct_filepath(extracted_files, split + ".txt")
+            path = find_match(item + ".txt", extracted_files)
         datasets.append(RawTextIterableDataset("UDPOS", NUM_LINES[item],
-                                               _create_data_from_iob(data_filenames[item], " "), offset=offset))
+                                               _create_data_from_iob(path), offset=offset))
     return datasets

--- a/torchtext/experimental/datasets/raw/wmtnewscrawl.py
+++ b/torchtext/experimental/datasets/raw/wmtnewscrawl.py
@@ -14,19 +14,28 @@ NUM_LINES = {
     'train': 17676013,
 }
 
+_AVAILABLE_YEARS = [2010]
+_AVAILABLE_LANGUAGES = [
+    "cs",
+    "en",
+    "fr",
+    "es",
+    "de"
+]
+
 
 @wrap_split_argument
 @add_docstring_header()
-def WMTNewsCrawl(root='.data', split='train', offset=0):
+def WMTNewsCrawl(root='.data', split='train', offset=0, year=2010, language='en'):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
+    if year not in _AVAILABLE_YEARS:
+        raise ValueError("{} not available. Please choose from years {}".format(year, _AVAILABLE_YEARS))
+    if language not in _AVAILABLE_LANGUAGES:
+        raise ValueError("{} not available. Please choose from languages {}".format(language, _AVAILABLE_LANGUAGES))
     file_name = 'news.{}.{}.shuffled'.format(year, language)
     extracted_files = [f for f in extracted_files if file_name in f]
-
-    datasets = []
-    for item in split:
-        path = find_match(item, extracted_files)
-        logging.info('Creating {} data'.format(item))
-        datasets.append(RawTextIterableDataset('WMTNewsCrawl',
-                                               NUM_LINES[item], iter(io.open(path, encoding="utf8")), offset=offset))
-    return datasets
+    path = extracted_files[0]
+    logging.info('Creating {} data'.format(split[0]))
+    return [RawTextIterableDataset('WMTNewsCrawl',
+                                   NUM_LINES[split[0]], iter(io.open(path, encoding="utf8")), offset=offset)]

--- a/torchtext/experimental/datasets/raw/wmtnewscrawl.py
+++ b/torchtext/experimental/datasets/raw/wmtnewscrawl.py
@@ -3,7 +3,6 @@ from torchtext.utils import download_from_url, extract_archive
 from torchtext.experimental.datasets.raw.common import RawTextIterableDataset
 from torchtext.experimental.datasets.raw.common import wrap_split_argument
 from torchtext.experimental.datasets.raw.common import add_docstring_header
-from torchtext.experimental.datasets.raw.common import find_match
 import io
 
 URL = 'http://www.statmt.org/wmt11/training-monolingual-news-2010.tgz'

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -219,6 +219,7 @@ def extract_archive(from_path, to_path=None, overwrite=False):
                         if not overwrite:
                             continue
                 tar.extract(file_, to_path)
+            logging.info('Finished extracting tar file {}.'.format(from_path))
             return files
 
     elif from_path.endswith('.zip'):
@@ -235,9 +236,11 @@ def extract_archive(from_path, to_path=None, overwrite=False):
                         continue
                 zfile.extract(file_, to_path)
         files = [f for f in files if os.path.isfile(f)]
+        logging.info('Finished extracting zip file {}.'.format(from_path))
         return files
 
     elif from_path.endswith('.gz'):
+        logging.info('Opening gz file {}.'.format(from_path))
         default_block_size = 65536
         filename = from_path[:-3]
         files = [filename]
@@ -250,6 +253,7 @@ def extract_archive(from_path, to_path=None, overwrite=False):
                 else:
                     d_file.write(block)
             d_file.write(block)
+        logging.info('Finished extracting gz file {}.'.format(from_path))
         return files
 
     else:


### PR DESCRIPTION
A few datasets, by default, download all dataset splits even if the user may have only requested a subset. This PR addresses that. It also adds language and year as kwargs to WMTNewsCrawl with corresponding input sanitization. It further standardizes logging in extract_archive across all three compression formats.