### PR TITLE
[WIP][Do not review] enabling tests based on google drive

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -9,19 +9,6 @@ from ..common.torchtext_test_case import TorchtextTestCase
 from ..common.parameterized_utils import load_params
 from ..common.assets import conditional_remove
 
-GOOGLE_DRIVE_BASED_DATASETS = [
-    'AmazonReviewFull',
-    'AmazonReviewPolarity',
-    'DBpedia',
-    'IMDB',
-    'IWSLT',
-    'SogouNews',
-    'WMT14',
-    'YahooAnswers',
-    'YelpReviewFull',
-    'YelpReviewPolarity'
-]
-
 
 def _raw_text_custom_name_func(testcase_func, param_num, param):
     info = param.args[0]
@@ -168,8 +155,6 @@ class TestDataset(TorchtextTestCase):
         name_func=_raw_text_custom_name_func)
     def test_raw_text_classification(self, info):
         dataset_name = info['dataset_name']
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
 
         # Currently disabled due to incredibly slow download
         if dataset_name == "WMTNewsCrawl":
@@ -193,8 +178,6 @@ class TestDataset(TorchtextTestCase):
 
     @parameterized.expand(list(sorted(torchtext.experimental.datasets.raw.DATASETS.keys())))
     def test_raw_datasets_split_argument(self, dataset_name):
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
         if 'statmt' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
             return
         dataset = torchtext.experimental.datasets.raw.DATASETS[dataset_name]
@@ -210,8 +193,6 @@ class TestDataset(TorchtextTestCase):
 
     @parameterized.expand(["AG_NEWS", "WikiText2", "IMDB"])
     def test_datasets_split_argument(self, dataset_name):
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
         dataset = torchtext.experimental.datasets.DATASETS[dataset_name]
         train1 = dataset(split='train')
         train2, = dataset(split=('train',))


### PR DESCRIPTION
#1171 

Enabling back all the tests that depend on downloading data from google drive (essentially reversing what was done in #1171)

Our current understanding is that based on:
1) we are caching .data folder (where all the data downloaded goes during testing) which is refreshed every week.
2) Based on merge of #1176, all the google drive data now have defined path in .data folder (defined using _PATH variable) 
3) If data is available in .data folder, it will used during testing (and will not trigger the download: refer https://github.com/pytorch/text/blob/1197514eb8cc33ccff10f588534f405b43908660/torchtext/utils.py#L79) 

Ideally this should ensure that we do not download if the data is already cached by CCI. Any blind spot here?

