### PR TITLE
[WIP][Do Not Review] enabling tests that depends on downloading from google drive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YYYY-WW $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:
@@ -395,7 +395,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YYYY-WW $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:
@@ -448,7 +448,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YYYY-WW $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:
@@ -395,7 +395,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:
@@ -448,7 +448,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,18 +343,18 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:
-            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
 
       - run:
           name: Setup
           command: .circleci/unittest/linux/scripts/setup_env.sh
       - save_cache:
 
-          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
 
           paths:
             - conda
@@ -365,7 +365,7 @@ jobs:
       - restore_cache:
           keys:
 
-            - data-linux-v1-{{ checksum ".circleci-weekly" }}
+            - data-linux-v1-{{ checksum ".circleci-weekly-refresh" }}
 
       - run:
           name: Run tests
@@ -374,7 +374,7 @@ jobs:
           command: .circleci/unittest/linux/scripts/run_test.sh
       - save_cache:
 
-          key: data-linux-v1-{{ checksum ".circleci-weekly" }}
+          key: data-linux-v1-{{ checksum ".circleci-weekly-refresh" }}
 
           paths:
             - .vector_cache
@@ -395,18 +395,18 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:
-            - env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+            - env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
 
       - run:
           name: Setup
           command: .circleci/unittest/windows/scripts/setup_env.sh
       - save_cache:
 
-          key: env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          key: env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
 
           paths:
             - conda
@@ -417,7 +417,7 @@ jobs:
       - restore_cache:
           keys:
 
-            - data-windows-v1-{{ checksum ".circleci-weekly" }}
+            - data-windows-v1-{{ checksum ".circleci-weekly-refresh" }}
 
       - run:
           name: Run tests
@@ -426,7 +426,7 @@ jobs:
           command: .circleci/unittest/windows/scripts/run_test.sh
       - save_cache:
 
-          key: data-windows-v1-{{ checksum ".circleci-weekly" }}
+          key: data-windows-v1-{{ checksum ".circleci-weekly-refresh" }}
 
           paths:
             - .vector_cache
@@ -442,24 +442,24 @@ jobs:
     docker:
       - image: "pytorch/manylinux-cuda100"
     resource_class: medium
-    steps:
+    step:
       - checkout
       - designate_upload_channel
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
 
           keys:
-            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
 
       - run:
           name: Setup
           command: .circleci/unittest/linux/scripts/setup_env.sh
       - save_cache:
 
-          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
 
           paths:
             - conda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,7 +442,7 @@ jobs:
     docker:
       - image: "pytorch/manylinux-cuda100"
     resource_class: medium
-    step:
+    steps:
       - checkout
       - designate_upload_channel
       - run:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -343,7 +343,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YYYY-WW $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:
@@ -395,7 +395,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YYYY-WW $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:
@@ -448,7 +448,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YYYY-WW $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -343,18 +343,18 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:
-            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
       - run:
           name: Setup
           command: .circleci/unittest/linux/scripts/setup_env.sh
       - save_cache:
           {% raw %}
-          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
           paths:
             - conda
@@ -365,7 +365,7 @@ jobs:
       - restore_cache:
           keys:
           {% raw %}
-            - data-linux-v1-{{ checksum ".circleci-weekly" }}
+            - data-linux-v1-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
       - run:
           name: Run tests
@@ -374,7 +374,7 @@ jobs:
           command: .circleci/unittest/linux/scripts/run_test.sh
       - save_cache:
           {% raw %}
-          key: data-linux-v1-{{ checksum ".circleci-weekly" }}
+          key: data-linux-v1-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
           paths:
             - .vector_cache
@@ -395,18 +395,18 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:
-            - env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+            - env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
       - run:
           name: Setup
           command: .circleci/unittest/windows/scripts/setup_env.sh
       - save_cache:
           {% raw %}
-          key: env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          key: env-v1-windows-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/windows/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
           paths:
             - conda
@@ -417,7 +417,7 @@ jobs:
       - restore_cache:
           keys:
           {% raw %}
-            - data-windows-v1-{{ checksum ".circleci-weekly" }}
+            - data-windows-v1-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
       - run:
           name: Run tests
@@ -426,7 +426,7 @@ jobs:
           command: .circleci/unittest/windows/scripts/run_test.sh
       - save_cache:
           {% raw %}
-          key: data-windows-v1-{{ checksum ".circleci-weekly" }}
+          key: data-windows-v1-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
           paths:
             - .vector_cache
@@ -448,18 +448,18 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly
+          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:
-            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
       - run:
           name: Setup
           command: .circleci/unittest/linux/scripts/setup_env.sh
       - save_cache:
           {% raw %}
-          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/environment.yml" }}-{{ checksum ".circleci-weekly-refresh" }}
           {% endraw %}
           paths:
             - conda

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -343,7 +343,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:
@@ -395,7 +395,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:
@@ -448,7 +448,7 @@ jobs:
       - run:
           name: Generate cache key
           # This will refresh cache on Sundays, nightly build should generate new cache.
-          command: echo "$(date +"%Y-%U")" > .circleci-weekly-refresh
+          command: echo "YEAR-WEEK $(date +"%Y-%U")" > .circleci-weekly-refresh
       - restore_cache:
           {% raw %}
           keys:

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -9,19 +9,6 @@ from ..common.torchtext_test_case import TorchtextTestCase
 from ..common.parameterized_utils import load_params
 from ..common.assets import conditional_remove
 
-GOOGLE_DRIVE_BASED_DATASETS = [
-    'AmazonReviewFull',
-    'AmazonReviewPolarity',
-    'DBpedia',
-    'IMDB',
-    'IWSLT',
-    'SogouNews',
-    'WMT14',
-    'YahooAnswers',
-    'YelpReviewFull',
-    'YelpReviewPolarity'
-]
-
 
 def _raw_text_custom_name_func(testcase_func, param_num, param):
     info = param.args[0]
@@ -168,8 +155,6 @@ class TestDataset(TorchtextTestCase):
         name_func=_raw_text_custom_name_func)
     def test_raw_text_classification(self, info):
         dataset_name = info['dataset_name']
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
 
         # Currently disabled due to incredibly slow download
         if dataset_name == "WMTNewsCrawl":
@@ -193,8 +178,6 @@ class TestDataset(TorchtextTestCase):
 
     @parameterized.expand(list(sorted(torchtext.experimental.datasets.raw.DATASETS.keys())))
     def test_raw_datasets_split_argument(self, dataset_name):
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
         if 'statmt' in torchtext.experimental.datasets.raw.URLS[dataset_name]:
             return
         dataset = torchtext.experimental.datasets.raw.DATASETS[dataset_name]
@@ -210,8 +193,6 @@ class TestDataset(TorchtextTestCase):
 
     @parameterized.expand(["AG_NEWS", "WikiText2", "IMDB"])
     def test_datasets_split_argument(self, dataset_name):
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
         dataset = torchtext.experimental.datasets.DATASETS[dataset_name]
         train1 = dataset(split='train')
         train2, = dataset(split=('train',))


### PR DESCRIPTION
Enabling back all the tests that depend on downloading data from google drive (essentially reversing what was done in #1171)

Our current understanding is that based on:
1) we are caching .data folder (where all the data downloaded goes during testing) which is refreshed every week.
2) Based on merge of #1176, all the google drive data now have defined path in .data folder (defined using _PATH variable) 
3) If data is available in .data folder, it will used during testing (and will not trigger the download: refer https://github.com/pytorch/text/blob/1197514eb8cc33ccff10f588534f405b43908660/torchtext/utils.py#L79) 

Ideally this should ensure that we do not download if the data is already cached by CCI. Any blind spot here?