### PR TITLE
Move loops over splits from datasets into decorator

### DIFF
--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -127,9 +127,7 @@ def _wrap_split_argument(fn, splits):
     def new_fn(root='.data', split=splits, **kwargs):
         result = []
         for item in check_default_set(split, splits, fn.__name__):
-            kwargs["root"] = root
-            kwargs["split"] = item
-            result.append(fn(**kwargs))
+            result.append(fn(root, item, **kwargs))
         return wrap_datasets(tuple(result), split)
 
     new_sig = inspect.signature(new_fn)
@@ -148,13 +146,6 @@ def wrap_split_argument(splits):
     def new_fn(fn):
         return _wrap_split_argument(fn, splits)
     return new_fn
-
-
-def construct_dataset_description(dataset_name, root, split, **kwargs):
-    args_str = ["root=" + root, "split=" + str(split)]
-    for k, v in kwargs.items():
-        args_str.append(f"{k}={v}")
-    return dataset_name + "(" + ", ".join(args_str) + ")"
 
 
 class RawTextIterableDataset(torch.utils.data.IterableDataset):

--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -132,6 +132,15 @@ def _wrap_split_argument(fn, splits):
             result.append(fn(**kwargs))
         return wrap_datasets(tuple(result), split)
 
+    new_sig = inspect.signature(new_fn)
+    new_sig_params = new_sig.parameters
+    new_params = []
+    new_params.append(new_sig_params['root'].replace(default='.data'))
+    new_params.append(new_sig_params['split'].replace(default=splits))
+    new_params += [entry[1] for entry in list(new_sig_params.items())[2:]]
+    new_sig = new_sig.replace(parameters=tuple(new_params))
+    new_fn.__signature__ = new_sig
+
     return new_fn
 
 

--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -180,7 +180,7 @@ class RawTextIterableDataset(torch.utils.data.IterableDataset):
 
     def pos(self):
         """
-        Returns current position of the iterator. This is None
+        Returns current position of the iterator. This returns None
         if the iterator hasn't been used yet.
         """
         return self.current_pos

--- a/torchtext/datasets/ag_news.py
+++ b/torchtext/datasets/ag_news.py
@@ -2,6 +2,7 @@ from torchtext.utils import download_from_url, unicode_csv_reader
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
+from torchtext.data.datasets_utils import construct_dataset_description
 import os
 import io
 
@@ -21,9 +22,9 @@ NUM_LINES = {
 }
 
 
-@wrap_split_argument
 @add_docstring_header()
-def AG_NEWS(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def AG_NEWS(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)
@@ -36,6 +37,7 @@ def AG_NEWS(root='.data', split=('train', 'test')):
                                  path=os.path.join(root, item + ".csv"),
                                  hash_value=MD5[item],
                                  hash_type='md5')
-        datasets.append(RawTextIterableDataset("AG_NEWS", NUM_LINES[item],
+        description = construct_dataset_description("AG_NEWS", root, item)
+        datasets.append(RawTextIterableDataset(description, NUM_LINES[item],
                                                _create_data_from_csv(path)))
     return datasets

--- a/torchtext/datasets/ag_news.py
+++ b/torchtext/datasets/ag_news.py
@@ -2,7 +2,6 @@ from torchtext.utils import download_from_url, unicode_csv_reader
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
-from torchtext.data.datasets_utils import construct_dataset_description
 import os
 import io
 
@@ -35,6 +34,5 @@ def AG_NEWS(root, split):
                              path=os.path.join(root, split + ".csv"),
                              hash_value=MD5[split],
                              hash_type='md5')
-    description = construct_dataset_description("AG_NEWS", root, split)
-    return RawTextIterableDataset(description, NUM_LINES[split],
+    return RawTextIterableDataset("AG_NEWS", NUM_LINES[split],
                                   _create_data_from_csv(path))

--- a/torchtext/datasets/ag_news.py
+++ b/torchtext/datasets/ag_news.py
@@ -31,13 +31,10 @@ def AG_NEWS(root, split):
             for row in reader:
                 yield int(row[0]), ' '.join(row[1:])
 
-    datasets = []
-    for item in split:
-        path = download_from_url(URL[item], root=root,
-                                 path=os.path.join(root, item + ".csv"),
-                                 hash_value=MD5[item],
-                                 hash_type='md5')
-        description = construct_dataset_description("AG_NEWS", root, item)
-        datasets.append(RawTextIterableDataset(description, NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = download_from_url(URL[split], root=root,
+                             path=os.path.join(root, split + ".csv"),
+                             hash_value=MD5[split],
+                             hash_type='md5')
+    description = construct_dataset_description("AG_NEWS", root, split)
+    return RawTextIterableDataset(description, NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/amazonreviewfull.py
+++ b/torchtext/datasets/amazonreviewfull.py
@@ -32,10 +32,7 @@ def AmazonReviewFull(root, split):
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
 
-    datasets = []
-    for item in split:
-        path = find_match(item + '.csv', extracted_files)
-        logging.info('Creating {} data'.format(item))
-        datasets.append(RawTextIterableDataset("AmazonReviewFull", NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = find_match(split + '.csv', extracted_files)
+    logging.info('Creating {} data'.format(split))
+    return RawTextIterableDataset("AmazonReviewFull", NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/amazonreviewfull.py
+++ b/torchtext/datasets/amazonreviewfull.py
@@ -19,9 +19,9 @@ NUM_LINES = {
 _PATH = 'amazon_review_full_csv.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def AmazonReviewFull(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def AmazonReviewFull(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)

--- a/torchtext/datasets/amazonreviewpolarity.py
+++ b/torchtext/datasets/amazonreviewpolarity.py
@@ -18,9 +18,9 @@ NUM_LINES = {
 _PATH = 'amazon_review_polarity_csv.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def AmazonReviewPolarity(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def AmazonReviewPolarity(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)

--- a/torchtext/datasets/amazonreviewpolarity.py
+++ b/torchtext/datasets/amazonreviewpolarity.py
@@ -31,9 +31,6 @@ def AmazonReviewPolarity(root, split):
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
 
-    datasets = []
-    for item in split:
-        path = find_match(item + '.csv', extracted_files)
-        datasets.append(RawTextIterableDataset("AmazonReviewPolarity", NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = find_match(split + '.csv', extracted_files)
+    return RawTextIterableDataset("AmazonReviewPolarity", NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/conll2000chunking.py
+++ b/torchtext/datasets/conll2000chunking.py
@@ -41,11 +41,8 @@ def _create_data_from_iob(data_path, separator):
 @add_docstring_header()
 @wrap_split_argument(('train', 'test'))
 def CoNLL2000Chunking(root, split):
-    datasets = []
-    for item in split:
-        dataset_tar = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')
-        extracted_files = extract_archive(dataset_tar)
-        data_filename = find_match(item + ".txt", extracted_files)
-        datasets.append(RawTextIterableDataset("CoNLL2000Chunking", NUM_LINES[item],
-                                               _create_data_from_iob(data_filename, " ")))
-    return datasets
+    dataset_tar = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')
+    extracted_files = extract_archive(dataset_tar)
+    data_filename = find_match(split + ".txt", extracted_files)
+    return RawTextIterableDataset("CoNLL2000Chunking", NUM_LINES[split],
+                                  _create_data_from_iob(data_filename, " "))

--- a/torchtext/datasets/conll2000chunking.py
+++ b/torchtext/datasets/conll2000chunking.py
@@ -38,9 +38,9 @@ def _create_data_from_iob(data_path, separator):
             yield columns
 
 
-@wrap_split_argument
 @add_docstring_header()
-def CoNLL2000Chunking(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def CoNLL2000Chunking(root, split):
     datasets = []
     for item in split:
         dataset_tar = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')

--- a/torchtext/datasets/dbpedia.py
+++ b/torchtext/datasets/dbpedia.py
@@ -31,9 +31,6 @@ def DBpedia(root, split):
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
 
-    datasets = []
-    for item in split:
-        path = find_match(item + '.csv', extracted_files)
-        datasets.append(RawTextIterableDataset("DBpedia", NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = find_match(split + '.csv', extracted_files)
+    return RawTextIterableDataset("DBpedia", NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/dbpedia.py
+++ b/torchtext/datasets/dbpedia.py
@@ -18,9 +18,9 @@ NUM_LINES = {
 _PATH = 'dbpedia_csv.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def DBpedia(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def DBpedia(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)

--- a/torchtext/datasets/enwik9.py
+++ b/torchtext/datasets/enwik9.py
@@ -15,11 +15,11 @@ NUM_LINES = {
 
 
 @add_docstring_header()
-@wrap_split_argument(('train', 'test'))
+@wrap_split_argument(('train',))
 def EnWik9(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
     path = extracted_files[0]
-    logging.info('Creating {} data'.format(split[0]))
-    return [RawTextIterableDataset('EnWik9',
-                                   NUM_LINES[split[0]], iter(io.open(path, encoding="utf8")))]
+    logging.info('Creating {} data'.format(split))
+    return RawTextIterableDataset('EnWik9',
+                                  NUM_LINES[split], iter(io.open(path, encoding="utf8")))

--- a/torchtext/datasets/enwik9.py
+++ b/torchtext/datasets/enwik9.py
@@ -14,9 +14,9 @@ NUM_LINES = {
 }
 
 
-@wrap_split_argument
 @add_docstring_header()
-def EnWik9(root='.data', split='train'):
+@wrap_split_argument(('train', 'test'))
+def EnWik9(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
     path = extracted_files[0]

--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -30,8 +30,5 @@ def IMDB(root, split):
     dataset_tar = download_from_url(URL, root=root,
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
-    datasets = []
-    for item in split:
-        iterator = generate_imdb_data(item, extracted_files)
-        datasets.append(RawTextIterableDataset("IMDB", NUM_LINES[item], iterator))
-    return datasets
+    iterator = generate_imdb_data(split, extracted_files)
+    return RawTextIterableDataset("IMDB", NUM_LINES[split], iterator)

--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -16,9 +16,9 @@ NUM_LINES = {
 _PATH = 'aclImdb_v1.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def IMDB(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def IMDB(root, split):
     def generate_imdb_data(key, extracted_files):
         for fname in extracted_files:
             if 'urls' in fname:

--- a/torchtext/datasets/iwslt.py
+++ b/torchtext/datasets/iwslt.py
@@ -68,9 +68,9 @@ def _construct_filepaths(paths, src_filename, tgt_filename):
     return (src_path, tgt_path)
 
 
-@wrap_split_argument
 @add_docstring_header()
-def IWSLT(root='.data', split=('train', 'valid', 'test'), offset=0,
+@wrap_split_argument(('train', 'valid', 'test'))
+def IWSLT(root, split,
           train_filenames=('train.de-en.de', 'train.de-en.en'),
           valid_filenames=('IWSLT16.TED.tst2013.de-en.de',
                            'IWSLT16.TED.tst2013.de-en.en'),
@@ -239,7 +239,7 @@ def IWSLT(root='.data', split=('train', 'valid', 'test'), offset=0,
     src_language = train_filenames[0].split(".")[-1]
     tgt_language = train_filenames[1].split(".")[-1]
     languages = "-".join([src_language, tgt_language])
-    iwslt_tar = '.data/2016-01/texts/{}/{}/{}.tgz'
+    iwslt_tar = os.path.join(root, '2016-01/texts/{}/{}/{}.tgz')
     iwslt_tar = iwslt_tar.format(
         src_language, tgt_language, languages)
     extracted_dataset_tar = extract_archive(iwslt_tar)

--- a/torchtext/datasets/iwslt.py
+++ b/torchtext/datasets/iwslt.py
@@ -268,16 +268,11 @@ def IWSLT(root, split,
             raise FileNotFoundError(
                 "Files are not found for data type {}".format(key))
 
-    datasets = []
-    for key in split:
-        src_data_iter = _read_text_iterator(data_filenames[key][0])
-        tgt_data_iter = _read_text_iterator(data_filenames[key][1])
+    src_data_iter = _read_text_iterator(data_filenames[split][0])
+    tgt_data_iter = _read_text_iterator(data_filenames[split][1])
 
-        def _iter(src_data_iter, tgt_data_iter):
-            for item in zip(src_data_iter, tgt_data_iter):
-                yield item
+    def _iter(src_data_iter, tgt_data_iter):
+        for item in zip(src_data_iter, tgt_data_iter):
+            yield item
 
-        datasets.append(
-            RawTextIterableDataset("IWSLT", NUM_LINES[key], _iter(src_data_iter, tgt_data_iter)))
-
-    return datasets
+    return RawTextIterableDataset("IWSLT", NUM_LINES[split], _iter(src_data_iter, tgt_data_iter))

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -129,7 +129,7 @@ for u in URL:
 
 
 @add_docstring_header(_DOCSTRING)
-@wrap_split_argument(('train', 'test'))
+@wrap_split_argument(('train', 'valid', 'test'))
 def Multi30k(root, split,
              train_filenames=("train.de", "train.en"),
              valid_filenames=("val.de", "val.en"),

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -161,16 +161,11 @@ def Multi30k(root, split,
             raise FileNotFoundError(
                 "Files are not found for data type {}".format(key))
 
-    datasets = []
-    for key in split:
-        src_data_iter = _read_text_iterator(data_filenames[key][0])
-        tgt_data_iter = _read_text_iterator(data_filenames[key][1])
+    src_data_iter = _read_text_iterator(data_filenames[split][0])
+    tgt_data_iter = _read_text_iterator(data_filenames[split][1])
 
-        def _iter(src_data_iter, tgt_data_iter):
-            for item in zip(src_data_iter, tgt_data_iter):
-                yield item
+    def _iter(src_data_iter, tgt_data_iter):
+        for item in zip(src_data_iter, tgt_data_iter):
+            yield item
 
-        datasets.append(
-            RawTextIterableDataset("Multi30k", NUM_LINES[key], _iter(src_data_iter, tgt_data_iter)))
-
-    return datasets
+    return RawTextIterableDataset("Multi30k", NUM_LINES[split], _iter(src_data_iter, tgt_data_iter))

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -128,9 +128,9 @@ for u in URL:
     _DOCSTRING += ("\n            " + os.path.basename(u)[:-3])
 
 
-@wrap_split_argument
 @add_docstring_header(_DOCSTRING)
-def Multi30k(root='.data', split=('train', 'valid', 'test'), offset=0,
+@wrap_split_argument(('train', 'test'))
+def Multi30k(root, split,
              train_filenames=("train.de", "train.en"),
              valid_filenames=("val.de", "val.en"),
              test_filenames=("test_2016_flickr.de", "test_2016_flickr.en")):

--- a/torchtext/datasets/penntreebank.py
+++ b/torchtext/datasets/penntreebank.py
@@ -27,13 +27,10 @@ NUM_LINES = {
 @add_docstring_header()
 @wrap_split_argument(('train', 'test'))
 def PennTreebank(root, split):
-    datasets = []
-    for item in split:
-        path = download_from_url(URL[item],
-                                 root=root, hash_value=MD5[item],
-                                 hash_type='md5')
-        logging.info('Creating {} data'.format(item))
-        datasets.append(RawTextIterableDataset('PennTreebank',
-                                               NUM_LINES[item],
-                                               iter(io.open(path, encoding="utf8"))))
-    return datasets
+    path = download_from_url(URL[split],
+                             root=root, hash_value=MD5[split],
+                             hash_type='md5')
+    logging.info('Creating {} data'.format(split))
+    return RawTextIterableDataset('PennTreebank',
+                                  NUM_LINES[split],
+                                  iter(io.open(path, encoding="utf8")))

--- a/torchtext/datasets/penntreebank.py
+++ b/torchtext/datasets/penntreebank.py
@@ -25,7 +25,7 @@ NUM_LINES = {
 
 
 @add_docstring_header()
-@wrap_split_argument(('train', 'test'))
+@wrap_split_argument(('train', 'valid', 'test'))
 def PennTreebank(root, split):
     path = download_from_url(URL[split],
                              root=root, hash_value=MD5[split],

--- a/torchtext/datasets/penntreebank.py
+++ b/torchtext/datasets/penntreebank.py
@@ -24,9 +24,9 @@ NUM_LINES = {
 }
 
 
-@wrap_split_argument
 @add_docstring_header()
-def PennTreebank(root='.data', split=('train', 'valid', 'test')):
+@wrap_split_argument(('train', 'test'))
+def PennTreebank(root, split):
     datasets = []
     for item in split:
         path = download_from_url(URL[item],

--- a/torchtext/datasets/sogounews.py
+++ b/torchtext/datasets/sogounews.py
@@ -18,9 +18,9 @@ NUM_LINES = {
 _PATH = 'sogou_news_csv.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def SogouNews(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def SogouNews(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)

--- a/torchtext/datasets/sogounews.py
+++ b/torchtext/datasets/sogounews.py
@@ -31,9 +31,6 @@ def SogouNews(root, split):
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
 
-    datasets = []
-    for item in split:
-        path = find_match(item + '.csv', extracted_files)
-        datasets.append(RawTextIterableDataset("SogouNews", NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = find_match(split + '.csv', extracted_files)
+    return RawTextIterableDataset("SogouNews", NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/squad1.py
+++ b/torchtext/datasets/squad1.py
@@ -36,9 +36,9 @@ def _create_data_from_json(data_path):
                     yield (_context, _question, _answers, _answer_start)
 
 
-@wrap_split_argument
 @add_docstring_header()
-def SQuAD1(root='.data', split=('train', 'dev')):
+@wrap_split_argument(('train', 'test'))
+def SQuAD1(root, split):
     datasets = []
     for item in split:
         extracted_files = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')

--- a/torchtext/datasets/squad1.py
+++ b/torchtext/datasets/squad1.py
@@ -39,9 +39,6 @@ def _create_data_from_json(data_path):
 @add_docstring_header()
 @wrap_split_argument(('train', 'test'))
 def SQuAD1(root, split):
-    datasets = []
-    for item in split:
-        extracted_files = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')
-        datasets.append(RawTextIterableDataset('SQuAD1', NUM_LINES[item],
-                                               _create_data_from_json(extracted_files)))
-    return datasets
+    extracted_files = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')
+    return RawTextIterableDataset('SQuAD1', NUM_LINES[split],
+                                  _create_data_from_json(extracted_files))

--- a/torchtext/datasets/squad1.py
+++ b/torchtext/datasets/squad1.py
@@ -37,7 +37,7 @@ def _create_data_from_json(data_path):
 
 
 @add_docstring_header()
-@wrap_split_argument(('train', 'test'))
+@wrap_split_argument(('train', 'dev'))
 def SQuAD1(root, split):
     extracted_files = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')
     return RawTextIterableDataset('SQuAD1', NUM_LINES[split],

--- a/torchtext/datasets/squad2.py
+++ b/torchtext/datasets/squad2.py
@@ -39,9 +39,6 @@ def _create_data_from_json(data_path):
 @add_docstring_header()
 @wrap_split_argument(('train', 'test'))
 def SQuAD2(root, split):
-    datasets = []
-    for item in split:
-        extracted_files = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')
-        datasets.append(RawTextIterableDataset('SQuAD2', NUM_LINES[item],
-                                               _create_data_from_json(extracted_files)))
-    return datasets
+    extracted_files = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')
+    return RawTextIterableDataset('SQuAD2', NUM_LINES[split],
+                                  _create_data_from_json(extracted_files))

--- a/torchtext/datasets/squad2.py
+++ b/torchtext/datasets/squad2.py
@@ -37,7 +37,7 @@ def _create_data_from_json(data_path):
 
 
 @add_docstring_header()
-@wrap_split_argument(('train', 'test'))
+@wrap_split_argument(('train', 'dev'))
 def SQuAD2(root, split):
     extracted_files = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')
     return RawTextIterableDataset('SQuAD2', NUM_LINES[split],

--- a/torchtext/datasets/squad2.py
+++ b/torchtext/datasets/squad2.py
@@ -36,9 +36,9 @@ def _create_data_from_json(data_path):
                     yield (_context, _question, _answers, _answer_start)
 
 
-@wrap_split_argument
 @add_docstring_header()
-def SQuAD2(root='.data', split=('train', 'dev')):
+@wrap_split_argument(('train', 'test'))
+def SQuAD2(root, split):
     datasets = []
     for item in split:
         extracted_files = download_from_url(URL[item], root=root, hash_value=MD5[item], hash_type='md5')

--- a/torchtext/datasets/udpos.py
+++ b/torchtext/datasets/udpos.py
@@ -38,12 +38,9 @@ def _create_data_from_iob(data_path, separator="\t"):
 def UDPOS(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
-    datasets = []
-    for item in split:
-        if item == 'valid':
-            path = find_match("dev.txt", extracted_files)
-        else:
-            path = find_match(item + ".txt", extracted_files)
-        datasets.append(RawTextIterableDataset("UDPOS", NUM_LINES[item],
-                                               _create_data_from_iob(path)))
-    return datasets
+    if split == 'valid':
+        path = find_match("dev.txt", extracted_files)
+    else:
+        path = find_match(split + ".txt", extracted_files)
+    return RawTextIterableDataset("UDPOS", NUM_LINES[split],
+                                  _create_data_from_iob(path))

--- a/torchtext/datasets/udpos.py
+++ b/torchtext/datasets/udpos.py
@@ -33,9 +33,9 @@ def _create_data_from_iob(data_path, separator="\t"):
             yield columns
 
 
-@wrap_split_argument
 @add_docstring_header()
-def UDPOS(root='.data', split=('train', 'valid', 'test')):
+@wrap_split_argument(('train', 'valid', 'test'))
+def UDPOS(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
     datasets = []

--- a/torchtext/datasets/wikitext103.py
+++ b/torchtext/datasets/wikitext103.py
@@ -17,9 +17,9 @@ NUM_LINES = {
 }
 
 
-@wrap_split_argument
 @add_docstring_header()
-def WikiText103(root='.data', split=('train', 'valid', 'test')):
+@wrap_split_argument(('train', 'valid', 'test'))
+def WikiText103(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
     datasets = []

--- a/torchtext/datasets/wikitext103.py
+++ b/torchtext/datasets/wikitext103.py
@@ -22,10 +22,8 @@ NUM_LINES = {
 def WikiText103(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
-    datasets = []
-    for item in split:
-        path = find_match(item, extracted_files)
-        logging.info('Creating {} data'.format(item))
-        datasets.append(RawTextIterableDataset('WikiText103',
-                                               NUM_LINES[item], iter(io.open(path, encoding="utf8"))))
-    return datasets
+
+    path = find_match(split, extracted_files)
+    logging.info('Creating {} data'.format(split))
+    return RawTextIterableDataset('WikiText103',
+                                  NUM_LINES[split], iter(io.open(path, encoding="utf8")))

--- a/torchtext/datasets/wikitext2.py
+++ b/torchtext/datasets/wikitext2.py
@@ -17,9 +17,9 @@ NUM_LINES = {
 }
 
 
-@wrap_split_argument
 @add_docstring_header()
-def WikiText2(root='.data', split=('train', 'valid', 'test')):
+@wrap_split_argument(('train', 'valid', 'test'))
+def WikiText2(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
     datasets = []

--- a/torchtext/datasets/wikitext2.py
+++ b/torchtext/datasets/wikitext2.py
@@ -22,10 +22,7 @@ NUM_LINES = {
 def WikiText2(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
-    datasets = []
-    for item in split:
-        path = find_match(item, extracted_files)
-        logging.info('Creating {} data'.format(item))
-        datasets.append(RawTextIterableDataset('WikiText2',
-                                               NUM_LINES[item], iter(io.open(path, encoding="utf8"))))
-    return datasets
+    path = find_match(split, extracted_files)
+    logging.info('Creating {} data'.format(split))
+    return RawTextIterableDataset('WikiText2',
+                                  NUM_LINES[split], iter(io.open(path, encoding="utf8")))

--- a/torchtext/datasets/wmt14.py
+++ b/torchtext/datasets/wmt14.py
@@ -68,9 +68,9 @@ def _construct_filepaths(paths, src_filename, tgt_filename):
     return (src_path, tgt_path)
 
 
-@wrap_split_argument
 @add_docstring_header()
-def WMT14(root='.data', split=('train', 'valid', 'test'), offset=0,
+@wrap_split_argument(('train', 'valid', 'test'))
+def WMT14(root, split,
           train_filenames=('train.tok.clean.bpe.32000.de',
                            'train.tok.clean.bpe.32000.en'),
           valid_filenames=('newstest2013.tok.bpe.32000.de',

--- a/torchtext/datasets/wmt14.py
+++ b/torchtext/datasets/wmt14.py
@@ -169,16 +169,11 @@ def WMT14(root, split,
             raise FileNotFoundError(
                 "Files are not found for data type {}".format(key))
 
-    datasets = []
-    for key in split:
-        src_data_iter = _read_text_iterator(data_filenames[key][0])
-        tgt_data_iter = _read_text_iterator(data_filenames[key][1])
+    src_data_iter = _read_text_iterator(data_filenames[split][0])
+    tgt_data_iter = _read_text_iterator(data_filenames[split][1])
 
-        def _iter(src_data_iter, tgt_data_iter):
-            for item in zip(src_data_iter, tgt_data_iter):
-                yield item
+    def _iter(src_data_iter, tgt_data_iter):
+        for item in zip(src_data_iter, tgt_data_iter):
+            yield item
 
-        datasets.append(
-            RawTextIterableDataset("WMT14", NUM_LINES[key], _iter(src_data_iter, tgt_data_iter)))
-
-    return datasets
+    return RawTextIterableDataset("WMT14", NUM_LINES[split], _iter(src_data_iter, tgt_data_iter))

--- a/torchtext/datasets/wmtnewscrawl.py
+++ b/torchtext/datasets/wmtnewscrawl.py
@@ -3,6 +3,7 @@ from torchtext.utils import download_from_url, extract_archive
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
+from torchtext.data.datasets_utils import construct_dataset_description
 import io
 
 URL = 'http://www.statmt.org/wmt11/training-monolingual-news-2010.tgz'
@@ -23,9 +24,9 @@ _AVAILABLE_LANGUAGES = [
 ]
 
 
-@wrap_split_argument
 @add_docstring_header()
-def WMTNewsCrawl(root='.data', split='train', offset=0, year=2010, language='en'):
+@wrap_split_argument(('train',))
+def WMTNewsCrawl(root, split, year=2010, language='en'):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
     if year not in _AVAILABLE_YEARS:
@@ -36,5 +37,6 @@ def WMTNewsCrawl(root='.data', split='train', offset=0, year=2010, language='en'
     extracted_files = [f for f in extracted_files if file_name in f]
     path = extracted_files[0]
     logging.info('Creating {} data'.format(split[0]))
-    return [RawTextIterableDataset('WMTNewsCrawl',
+    description = construct_dataset_description("WMTNewsCrawl", root, split[0], year=year, language=language)
+    return [RawTextIterableDataset(description,
                                    NUM_LINES[split[0]], iter(io.open(path, encoding="utf8")))]

--- a/torchtext/datasets/wmtnewscrawl.py
+++ b/torchtext/datasets/wmtnewscrawl.py
@@ -36,7 +36,7 @@ def WMTNewsCrawl(root, split, year=2010, language='en'):
     file_name = 'news.{}.{}.shuffled'.format(year, language)
     extracted_files = [f for f in extracted_files if file_name in f]
     path = extracted_files[0]
-    logging.info('Creating {} data'.format(split[0]))
-    description = construct_dataset_description("WMTNewsCrawl", root, split[0], year=year, language=language)
-    return [RawTextIterableDataset(description,
-                                   NUM_LINES[split[0]], iter(io.open(path, encoding="utf8")))]
+    logging.info('Creating {} data'.format(split))
+    description = construct_dataset_description("WMTNewsCrawl", root, split, year=year, language=language)
+    return RawTextIterableDataset(description,
+                                   NUM_LINES[split], iter(io.open(path, encoding="utf8")))

--- a/torchtext/datasets/wmtnewscrawl.py
+++ b/torchtext/datasets/wmtnewscrawl.py
@@ -3,7 +3,6 @@ from torchtext.utils import download_from_url, extract_archive
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
-from torchtext.data.datasets_utils import construct_dataset_description
 import io
 
 URL = 'http://www.statmt.org/wmt11/training-monolingual-news-2010.tgz'
@@ -37,6 +36,5 @@ def WMTNewsCrawl(root, split, year=2010, language='en'):
     extracted_files = [f for f in extracted_files if file_name in f]
     path = extracted_files[0]
     logging.info('Creating {} data'.format(split))
-    description = construct_dataset_description("WMTNewsCrawl", root, split, year=year, language=language)
-    return RawTextIterableDataset(description,
-                                   NUM_LINES[split], iter(io.open(path, encoding="utf8")))
+    return RawTextIterableDataset("WMTNewsCrawl",
+                                  NUM_LINES[split], iter(io.open(path, encoding="utf8")))

--- a/torchtext/datasets/yahooanswers.py
+++ b/torchtext/datasets/yahooanswers.py
@@ -18,9 +18,9 @@ NUM_LINES = {
 _PATH = 'yahoo_answers_csv.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def YahooAnswers(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def YahooAnswers(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)

--- a/torchtext/datasets/yahooanswers.py
+++ b/torchtext/datasets/yahooanswers.py
@@ -31,9 +31,6 @@ def YahooAnswers(root, split):
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
 
-    datasets = []
-    for item in split:
-        path = find_match(item + '.csv', extracted_files)
-        datasets.append(RawTextIterableDataset("YahooAnswers", NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = find_match(split + '.csv', extracted_files)
+    return RawTextIterableDataset("YahooAnswers", NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/yelpreviewfull.py
+++ b/torchtext/datasets/yelpreviewfull.py
@@ -31,9 +31,6 @@ def YelpReviewFull(root, split):
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
 
-    datasets = []
-    for item in split:
-        path = find_match(item + '.csv', extracted_files)
-        datasets.append(RawTextIterableDataset("YelpReviewFull", NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = find_match(split + '.csv', extracted_files)
+    return RawTextIterableDataset("YelpReviewFull", NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/yelpreviewfull.py
+++ b/torchtext/datasets/yelpreviewfull.py
@@ -18,9 +18,9 @@ NUM_LINES = {
 _PATH = 'yelp_review_full_csv.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def YelpReviewFull(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def YelpReviewFull(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)

--- a/torchtext/datasets/yelpreviewpolarity.py
+++ b/torchtext/datasets/yelpreviewpolarity.py
@@ -31,9 +31,6 @@ def YelpReviewPolarity(root, split):
                                     hash_value=MD5, hash_type='md5')
     extracted_files = extract_archive(dataset_tar)
 
-    datasets = []
-    for item in split:
-        path = find_match(item + '.csv', extracted_files)
-        datasets.append(RawTextIterableDataset("YelpReviewPolarity", NUM_LINES[item],
-                                               _create_data_from_csv(path)))
-    return datasets
+    path = find_match(split + '.csv', extracted_files)
+    return RawTextIterableDataset("YelpReviewPolarity", NUM_LINES[split],
+                                  _create_data_from_csv(path))

--- a/torchtext/datasets/yelpreviewpolarity.py
+++ b/torchtext/datasets/yelpreviewpolarity.py
@@ -18,9 +18,9 @@ NUM_LINES = {
 _PATH = 'yelp_review_polarity_csv.tar.gz'
 
 
-@wrap_split_argument
 @add_docstring_header()
-def YelpReviewPolarity(root='.data', split=('train', 'test')):
+@wrap_split_argument(('train', 'test'))
+def YelpReviewPolarity(root, split):
     def _create_data_from_csv(data_path):
         with io.open(data_path, encoding="utf8") as f:
             reader = unicode_csv_reader(f)


### PR DESCRIPTION
Every dataset is currently passed a tuple of splits and expected to return a list of datasets. This PR moves this logic into the decorator and frees datasets that choose to use it to only worry about receiving one split and returning one dataset instead.