### PR TITLE
Avoid slow extraction of some datasets by storing additional hashes

### DIFF
--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -157,12 +157,14 @@ def download_extract_validate(root, url, url_md5, downloaded_file, extracted_fil
     path = os.path.join(root, extracted_file)
     if os.path.exists(path):
         with open(os.path.join(root, extracted_file), 'rb') as f:
-            if not validate_file(f, extracted_file_md5, hash_type):
-                dataset_tar = download_from_url(url, root=root,
-                                                path=os.path.join(root, downloaded_file),
-                                                hash_value=url_md5, hash_type='md5')
-                extracted_files = extract_archive(dataset_tar)
-                assert path == find_match(extracted_file, extracted_files)
+            if validate_file(f, extracted_file_md5, hash_type):
+                return path
+
+    dataset_tar = download_from_url(url, root=root,
+                                    path=os.path.join(root, downloaded_file),
+                                    hash_value=url_md5, hash_type=hash_type)
+    extracted_files = extract_archive(dataset_tar)
+    assert path == find_match(extracted_file, extracted_files)
     return path
 
 

--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -1,6 +1,10 @@
-import torch
-import inspect
 import functools
+import inspect
+import os
+import torch
+from torchtext.utils import validate_file
+from torchtext.utils import download_from_url
+from torchtext.utils import extract_archive
 
 """
 These functions and classes are meant solely for use in torchtext.datasets and not
@@ -146,6 +150,20 @@ def wrap_split_argument(splits):
     def new_fn(fn):
         return _wrap_split_argument(fn, splits)
     return new_fn
+
+
+def download_extract_validate(root, url, url_md5, downloaded_file, extracted_file, extracted_file_md5,
+                              hash_type="sha256"):
+    path = os.path.join(root, extracted_file)
+    if os.path.exists(path):
+        with open(os.path.join(root, extracted_file), 'rb') as f:
+            if not validate_file(f, extracted_file_md5, hash_type):
+                dataset_tar = download_from_url(url, root=root,
+                                                path=os.path.join(root, downloaded_file),
+                                                hash_value=url_md5, hash_type='md5')
+                extracted_files = extract_archive(dataset_tar)
+                assert path == find_match(extracted_file, extracted_files)
+    return path
 
 
 class RawTextIterableDataset(torch.utils.data.IterableDataset):

--- a/torchtext/datasets/amazonreviewfull.py
+++ b/torchtext/datasets/amazonreviewfull.py
@@ -1,9 +1,8 @@
-from torchtext.utils import download_from_url, extract_archive, unicode_csv_reader
+from torchtext.utils import unicode_csv_reader
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
-from torchtext.data.datasets_utils import find_match
-import os
+from torchtext.data.datasets_utils import download_extract_validate
 import io
 import logging
 
@@ -18,6 +17,16 @@ NUM_LINES = {
 
 _PATH = 'amazon_review_full_csv.tar.gz'
 
+_EXTRACTED_FILES = {
+    'train': 'amazon_review_full_csv/train.csv',
+    'test': 'amazon_review_full_csv/test.csv'
+}
+
+_EXTRACTED_FILES_MD5 = {
+    'train': "31b268b09fd794e0ca5a1f59a0358677",
+    'test': "0f1e78ab60f625f2a30eab6810ef987c"
+}
+
 
 @add_docstring_header()
 @wrap_split_argument(('train', 'test'))
@@ -27,12 +36,9 @@ def AmazonReviewFull(root, split):
             reader = unicode_csv_reader(f)
             for row in reader:
                 yield int(row[0]), ' '.join(row[1:])
-    dataset_tar = download_from_url(URL, root=root,
-                                    path=os.path.join(root, _PATH),
-                                    hash_value=MD5, hash_type='md5')
-    extracted_files = extract_archive(dataset_tar)
 
-    path = find_match(split + '.csv', extracted_files)
+    path = download_extract_validate(root, URL, MD5, _PATH, _EXTRACTED_FILES[split],
+                                     _EXTRACTED_FILES_MD5[split], hash_type="md5")
     logging.info('Creating {} data'.format(split))
     return RawTextIterableDataset("AmazonReviewFull", NUM_LINES[split],
                                   _create_data_from_csv(path))

--- a/torchtext/datasets/amazonreviewpolarity.py
+++ b/torchtext/datasets/amazonreviewpolarity.py
@@ -1,10 +1,10 @@
-from torchtext.utils import download_from_url, extract_archive, unicode_csv_reader
+from torchtext.utils import unicode_csv_reader
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
-from torchtext.data.datasets_utils import find_match
-import os
+from torchtext.data.datasets_utils import download_extract_validate
 import io
+import logging
 
 URL = 'https://drive.google.com/uc?export=download&id=0Bz8a_Dbh9QhbaW12WVVZS2drcnM'
 
@@ -17,6 +17,16 @@ NUM_LINES = {
 
 _PATH = 'amazon_review_polarity_csv.tar.gz'
 
+_EXTRACTED_FILES = {
+    'train': 'amazon_review_polarity_csv/train.csv',
+    'test': 'amazon_review_polarity_csv/test.csv'
+}
+
+_EXTRACTED_FILES_MD5 = {
+    'train': "520937107c39a2d1d1f66cd410e9ed9e",
+    'test': "f4c8bded2ecbde5f996b675db6228f16"
+}
+
 
 @add_docstring_header()
 @wrap_split_argument(('train', 'test'))
@@ -26,11 +36,8 @@ def AmazonReviewPolarity(root, split):
             reader = unicode_csv_reader(f)
             for row in reader:
                 yield int(row[0]), ' '.join(row[1:])
-    dataset_tar = download_from_url(URL, root=root,
-                                    path=os.path.join(root, _PATH),
-                                    hash_value=MD5, hash_type='md5')
-    extracted_files = extract_archive(dataset_tar)
-
-    path = find_match(split + '.csv', extracted_files)
+    path = download_extract_validate(root, URL, MD5, _PATH, _EXTRACTED_FILES[split],
+                                     _EXTRACTED_FILES_MD5[split], hash_type="md5")
+    logging.info('Creating {} data'.format(split))
     return RawTextIterableDataset("AmazonReviewPolarity", NUM_LINES[split],
                                   _create_data_from_csv(path))

--- a/torchtext/datasets/sogounews.py
+++ b/torchtext/datasets/sogounews.py
@@ -1,10 +1,10 @@
-from torchtext.utils import download_from_url, extract_archive, unicode_csv_reader
+from torchtext.utils import unicode_csv_reader
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
-from torchtext.data.datasets_utils import find_match
-import os
+from torchtext.data.datasets_utils import download_extract_validate
 import io
+import logging
 
 URL = 'https://drive.google.com/uc?export=download&id=0Bz8a_Dbh9QhbUkVqNEszd0pHaFE'
 
@@ -17,6 +17,16 @@ NUM_LINES = {
 
 _PATH = 'sogou_news_csv.tar.gz'
 
+_EXTRACTED_FILES = {
+    'train': 'sogou_news_csv/train.csv',
+    'test': 'sogou_news_csv/test.csv'
+}
+
+_EXTRACTED_FILES_MD5 = {
+    'train': "f36156164e6eac2feda0e30ad857eef0",
+    'test': "59e493c41cee050329446d8c45615b38"
+}
+
 
 @add_docstring_header()
 @wrap_split_argument(('train', 'test'))
@@ -26,11 +36,8 @@ def SogouNews(root, split):
             reader = unicode_csv_reader(f)
             for row in reader:
                 yield int(row[0]), ' '.join(row[1:])
-    dataset_tar = download_from_url(URL, root=root,
-                                    path=os.path.join(root, _PATH),
-                                    hash_value=MD5, hash_type='md5')
-    extracted_files = extract_archive(dataset_tar)
-
-    path = find_match(split + '.csv', extracted_files)
+    path = download_extract_validate(root, URL, MD5, _PATH, _EXTRACTED_FILES[split],
+                                     _EXTRACTED_FILES_MD5[split], hash_type="md5")
+    logging.info('Creating {} data'.format(split))
     return RawTextIterableDataset("SogouNews", NUM_LINES[split],
                                   _create_data_from_csv(path))

--- a/torchtext/datasets/wmtnewscrawl.py
+++ b/torchtext/datasets/wmtnewscrawl.py
@@ -1,9 +1,9 @@
-import logging
-from torchtext.utils import download_from_url, extract_archive
 from torchtext.data.datasets_utils import RawTextIterableDataset
 from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
+from torchtext.data.datasets_utils import download_extract_validate
 import io
+import logging
 
 URL = 'http://www.statmt.org/wmt11/training-monolingual-news-2010.tgz'
 
@@ -12,6 +12,8 @@ MD5 = 'c70da2ba79db33fb0fc9119cbad16260'
 NUM_LINES = {
     'train': 17676013,
 }
+
+_PATH = "training-monolingual-news-2010.tgz"
 
 _AVAILABLE_YEARS = [2010]
 _AVAILABLE_LANGUAGES = [
@@ -22,19 +24,32 @@ _AVAILABLE_LANGUAGES = [
     "de"
 ]
 
+_EXTRACTED_FILES = {
+    "cs": "training-monolingual/news.2010.cs.shuffled",
+    "de": "training-monolingual/news.2010.de.shuffled",
+    "en": "training-monolingual/news.2010.en.shuffled",
+    "es": "training-monolingual/news.2010.es.shuffled",
+    "fr": "training-monolingual/news.2010.fr.shuffled"
+}
+
+_EXTRACTED_FILES_MD5 = {
+    "cs": "b60fdbf95a2e97bae3a7d04cc81df925",
+    "de": "e59a0f0c6eeeb2113c0da1873a2e1035",
+    "en": "234a50914d87158754815a0bd86d7b9d",
+    "es": "aee3d773a0c054c5ac313a42d08b7020",
+    "fr": "066d671533f78bfe139cf7052574fd5a"
+}
+
 
 @add_docstring_header()
 @wrap_split_argument(('train',))
 def WMTNewsCrawl(root, split, year=2010, language='en'):
-    dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')
-    extracted_files = extract_archive(dataset_tar)
     if year not in _AVAILABLE_YEARS:
         raise ValueError("{} not available. Please choose from years {}".format(year, _AVAILABLE_YEARS))
     if language not in _AVAILABLE_LANGUAGES:
         raise ValueError("{} not available. Please choose from languages {}".format(language, _AVAILABLE_LANGUAGES))
-    file_name = 'news.{}.{}.shuffled'.format(year, language)
-    extracted_files = [f for f in extracted_files if file_name in f]
-    path = extracted_files[0]
+    path = download_extract_validate(root, URL, MD5, _PATH, _EXTRACTED_FILES[language],
+                                     _EXTRACTED_FILES_MD5[language], hash_type="md5")
     logging.info('Creating {} data'.format(split))
     return RawTextIterableDataset("WMTNewsCrawl",
                                   NUM_LINES[split], iter(io.open(path, encoding="utf8")))

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -287,3 +287,19 @@ def validate_file(file_obj, hash_value, hash_type="sha256"):
             break
         hash_func.update(chunk)
     return hash_func.hexdigest() == hash_value
+
+
+def validate_file_path(file_path, hash_value, hash_type="sha256"):
+    """Validate a file located at given file path
+
+    Args:
+        file_path: File path to open and validate
+        hash_value (str): Hash for url.
+        hash_type (str, optional): Hash type, among "sha256" and "md5" (Default: ``"sha256"``).
+    Returns:
+        bool: return True if its a valid file, else False.
+
+    """
+
+    with open(file_path, 'rb') as f:
+        return validate_file(f, hash_value, hash_type)

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -287,19 +287,3 @@ def validate_file(file_obj, hash_value, hash_type="sha256"):
             break
         hash_func.update(chunk)
     return hash_func.hexdigest() == hash_value
-
-
-def validate_file_path(file_path, hash_value, hash_type="sha256"):
-    """Validate a file located at given file path
-
-    Args:
-        file_path: File path to open and validate
-        hash_value (str): Hash for url.
-        hash_type (str, optional): Hash type, among "sha256" and "md5" (Default: ``"sha256"``).
-    Returns:
-        bool: return True if its a valid file, else False.
-
-    """
-
-    with open(file_path, 'rb') as f:
-        return validate_file(f, hash_value, hash_type)


### PR DESCRIPTION
The creation of some datasets can take up to 20s even if the data has already been downloaded and extracted before. Below is a table of timings on master including scripts that measure it.

```
$ python /tmp/asdf4.py
Dataset,Time(s)
AG_NEWS(split=train),0.04942941665649414
AmazonReviewFull(split=train),10.727782011032104
AmazonReviewPolarity(split=train),11.451766014099121
CoNLL2000Chunking(split=train),0.016519546508789062
DBpedia(split=train),1.1978952884674072
EnWik9(split=train),0.5390405654907227
IMDB(split=train),6.395325183868408
IWSLT(split=train),2.6959946155548096
Multi30k(split=train),0.19001436233520508
PennTreebank(split=train),0.009076595306396484
SQuAD1(split=train),0.049971580505371094
SQuAD2(split=train),0.0696258544921875
SogouNews(split=train),7.2132861614227295
UDPOS(split=train),0.0017843246459960938
WMT14(split=train),8.764551877975464
WMTNewsCrawl(split=train),23.839908361434937
WikiText103(split=train),0.30898594856262207
WikiText2(split=train),0.008335590362548828
YahooAnswers(split=train),5.196086645126343
YelpReviewFull(split=train),3.248976945877075
YelpReviewPolarity(split=train),2.7608695030212402

$ cat /tmp/timings.py
import torchtext
import time

print("Dataset,Time(s)")
for d in torchtext.datasets.DATASETS.values():
    t0 = time.time()
    train_iter = d(split='train')
    print("{},{}".format(str(train_iter), time.time() - t0))
```

This PR improves upon the construction time of some of the worst offenders (AmazonReviewFull, AmazonReviewPolarity and WMTNewsCrawl) by storing additional hashes to verify whether existing files match the expected outcome of extraction. In particular these datasets store their data as tar gzip files, which make it very slow to read their table of contents and avoid costly construction. A private helper function download_extract_validate is created to provide a single helper. Follow-up PRs can expand this approach to further datasets such as IMDB, SogouNew or YahooAnswers. Constructing a dataset iterator should be very fast and this is a step in that direction.

The measured improvements are
| dataset name| improvement|
| ---- | ---- |
| AmazonReviewFull | 10.727782011032104 -> 2.18523907661438|
| AmazonReviewPolarity | 11.451766014099121 -> 2.5508639812469482|
| WMTNewsCrawl | 23.839908361434937 -> 3.309438943862915|

The leftover time is likely dominated by the md5 algorithm we use to verify the integrity of files. For additional performance we could eventually choose to allow the user to disable this.