### PR TITLE
Document the number of lines per split

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -1,5 +1,5 @@
-torchtext.experimental.datasets.raw
-===================================
+torchtext.datasets
+==================
 
 .. currentmodule:: torchtext.datasets
 
@@ -7,7 +7,7 @@ General use cases are as follows: ::
 
 
     # import datasets
-    from torchtext.experimental.datasets.raw import IMDB
+    from torchtext.datasets import IMDB
 
     train_iter = IMDB(split='train')
 

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -255,6 +255,7 @@ class TestDataset(TorchtextTestCase):
         self._helper_test_func(len(test_iter), 25000, next(test_iter)[1][:25], 'I love sci-fi and am will')
         del train_iter, test_iter
 
+    @unittest.skip("Dataset depends on Google drive")
     def test_iwslt(self):
         from torchtext.experimental.datasets import IWSLT
 

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -3,6 +3,7 @@
 import os
 import torch
 import torchtext
+import unittest
 from torchtext.legacy import data
 from parameterized import parameterized
 from ..common.torchtext_test_case import TorchtextTestCase

--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -45,7 +45,7 @@ def find_match(match, lst):
     return None
 
 
-def dataset_docstring_header(fn):
+def dataset_docstring_header(fn, num_lines=None):
     """
     Returns docstring for a dataset based on function arguments.
 
@@ -57,41 +57,41 @@ def dataset_docstring_header(fn):
         raise ValueError("Internal Error: Given function {} did not adhere to standard signature.".format(fn))
     default_split = argspec.defaults[1]
 
+    if not (isinstance(default_split, tuple) or isinstance(default_split, str)):
+        raise ValueError("default_split type expected to be of string or tuple but got {}".format(type(default_split)))
+
+    header_s = fn.__name__ + " dataset\n"
+
     if isinstance(default_split, tuple):
-        example_subset = default_split[:2]
-        if len(default_split) < 3:
-            example_subset = (default_split[0],)
-        return """{} dataset
-
-        Separately returns the {} split
-
-        Args:
-            root: Directory where the datasets are saved.
-                Default: ".data"
-            split: split or splits to be returned. Can be a string or tuple of strings.
-                By default, all three datasets are generated. Users
-                could also choose any subset of them, for example {} or just 'train'.
-                Default: {}
-        """.format(fn.__name__, "/".join(default_split), str(example_subset), str(default_split))
+        header_s += "\nSeparately returns the {} split".format("/".join(default_split))
 
     if isinstance(default_split, str):
-        return """{} dataset
+        header_s += "\nOnly returns the {} split".format(default_split)
 
-        Only returns the {default_split} split
+    if num_lines is not None:
+        header_s += "\n\nNumber of lines per split:"
+        for k, v in num_lines.items():
+            header_s += f"\n    {k}: {v}"
 
-        Args:
-            root: Directory where the datasets are saved.
-                Default: ".data"
-            split: Only {default_split} is available.
-                Default: {default_split}""".format(fn.__name__, default_split=default_split)
+    args_s = "\nArgs:"
+    args_s += "\n    root: Directory where the datasets are saved."
+    args_s += "\n        Default: .data"
 
-    raise ValueError("default_split type expected to be of string or tuple but got {}".format(type(default_split)))
+    if isinstance(default_split, tuple):
+        args_s += "\n    split: split or splits to be returned. Can be a string or tuple of strings."
+        args_s += "\n        Default: {}""".format(str(default_split))
+
+    if isinstance(default_split, str):
+        args_s += "\n     split: Only {default_split} is available."
+        args_s += "\n         Default: {default_split}.format(default_split=default_split)"
+
+    return "\n".join([header_s, args_s]) + "\n"
 
 
-def add_docstring_header(docstring=None):
+def add_docstring_header(docstring=None, num_lines=None):
     def docstring_decorator(fn):
         old_doc = fn.__doc__
-        fn.__doc__ = dataset_docstring_header(fn)
+        fn.__doc__ = dataset_docstring_header(fn, num_lines)
         if docstring is not None:
             fn.__doc__ += docstring
         if old_doc is not None:

--- a/torchtext/datasets/ag_news.py
+++ b/torchtext/datasets/ag_news.py
@@ -21,7 +21,7 @@ NUM_LINES = {
 }
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def AG_NEWS(root, split):
     def _create_data_from_csv(data_path):

--- a/torchtext/datasets/amazonreviewfull.py
+++ b/torchtext/datasets/amazonreviewfull.py
@@ -19,7 +19,7 @@ NUM_LINES = {
 _PATH = 'amazon_review_full_csv.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def AmazonReviewFull(root, split):
     def _create_data_from_csv(data_path):

--- a/torchtext/datasets/amazonreviewpolarity.py
+++ b/torchtext/datasets/amazonreviewpolarity.py
@@ -18,7 +18,7 @@ NUM_LINES = {
 _PATH = 'amazon_review_polarity_csv.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def AmazonReviewPolarity(root, split):
     def _create_data_from_csv(data_path):

--- a/torchtext/datasets/conll2000chunking.py
+++ b/torchtext/datasets/conll2000chunking.py
@@ -38,7 +38,7 @@ def _create_data_from_iob(data_path, separator):
             yield columns
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def CoNLL2000Chunking(root, split):
     dataset_tar = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')

--- a/torchtext/datasets/dbpedia.py
+++ b/torchtext/datasets/dbpedia.py
@@ -18,7 +18,7 @@ NUM_LINES = {
 _PATH = 'dbpedia_csv.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def DBpedia(root, split):
     def _create_data_from_csv(data_path):

--- a/torchtext/datasets/enwik9.py
+++ b/torchtext/datasets/enwik9.py
@@ -14,7 +14,7 @@ NUM_LINES = {
 }
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train',))
 def EnWik9(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')

--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -16,7 +16,7 @@ NUM_LINES = {
 _PATH = 'aclImdb_v1.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def IMDB(root, split):
     def generate_imdb_data(key, extracted_files):

--- a/torchtext/datasets/iwslt.py
+++ b/torchtext/datasets/iwslt.py
@@ -68,7 +68,7 @@ def _construct_filepaths(paths, src_filename, tgt_filename):
     return (src_path, tgt_path)
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'valid', 'test'))
 def IWSLT(root, split,
           train_filenames=('train.de-en.de', 'train.de-en.en'),
@@ -77,11 +77,11 @@ def IWSLT(root, split,
           test_filenames=('IWSLT16.TED.tst2014.de-en.de',
                           'IWSLT16.TED.tst2014.de-en.en')):
     """    train_filenames: the source and target filenames for training.
-                Default: ('train.de-en.de', 'train.de-en.en')
-            valid_filenames: the source and target filenames for valid.
-                Default: ('IWSLT16.TED.tst2013.de-en.de', 'IWSLT16.TED.tst2013.de-en.en')
-            test_filenames: the source and target filenames for test.
-                Default: ('IWSLT16.TED.tst2014.de-en.de', 'IWSLT16.TED.tst2014.de-en.en')
+        Default: ('train.de-en.de', 'train.de-en.en')
+    valid_filenames: the source and target filenames for valid.
+        Default: ('IWSLT16.TED.tst2013.de-en.de', 'IWSLT16.TED.tst2013.de-en.en')
+    test_filenames: the source and target filenames for test.
+        Default: ('IWSLT16.TED.tst2014.de-en.de', 'IWSLT16.TED.tst2014.de-en.en')
 
     The available datasets include:
         IWSLT16.TED.dev2010.ar-en.ar

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -116,19 +116,19 @@ def _construct_filepaths(paths, src_filename, tgt_filename):
 
 _DOCSTRING = \
     """    train_filenames: the source and target filenames for training.
-                Default: ('train.de', 'train.en')
-            valid_filenames: the source and target filenames for valid.
-                Default: ('val.de', 'val.en')
-            test_filenames: the source and target filenames for test.
-                Default: ('test2016.de', 'test2016.en')
+        Default: ('train.de', 'train.en')
+    valid_filenames: the source and target filenames for valid.
+        Default: ('val.de', 'val.en')
+    test_filenames: the source and target filenames for test.
+        Default: ('test2016.de', 'test2016.en')
 
-        The available dataset include:"""
+    The available dataset include:"""
 
 for u in URL:
-    _DOCSTRING += ("\n            " + os.path.basename(u)[:-3])
+    _DOCSTRING += ("\n        " + os.path.basename(u)[:-3])
 
 
-@add_docstring_header(_DOCSTRING)
+@add_docstring_header(_DOCSTRING, NUM_LINES)
 @wrap_split_argument(('train', 'valid', 'test'))
 def Multi30k(root, split,
              train_filenames=("train.de", "train.en"),

--- a/torchtext/datasets/penntreebank.py
+++ b/torchtext/datasets/penntreebank.py
@@ -24,7 +24,7 @@ NUM_LINES = {
 }
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'valid', 'test'))
 def PennTreebank(root, split):
     path = download_from_url(URL[split],

--- a/torchtext/datasets/sogounews.py
+++ b/torchtext/datasets/sogounews.py
@@ -18,7 +18,7 @@ NUM_LINES = {
 _PATH = 'sogou_news_csv.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def SogouNews(root, split):
     def _create_data_from_csv(data_path):

--- a/torchtext/datasets/squad1.py
+++ b/torchtext/datasets/squad1.py
@@ -36,7 +36,7 @@ def _create_data_from_json(data_path):
                     yield (_context, _question, _answers, _answer_start)
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'dev'))
 def SQuAD1(root, split):
     extracted_files = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')

--- a/torchtext/datasets/squad2.py
+++ b/torchtext/datasets/squad2.py
@@ -36,7 +36,7 @@ def _create_data_from_json(data_path):
                     yield (_context, _question, _answers, _answer_start)
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'dev'))
 def SQuAD2(root, split):
     extracted_files = download_from_url(URL[split], root=root, hash_value=MD5[split], hash_type='md5')

--- a/torchtext/datasets/udpos.py
+++ b/torchtext/datasets/udpos.py
@@ -33,7 +33,7 @@ def _create_data_from_iob(data_path, separator="\t"):
             yield columns
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'valid', 'test'))
 def UDPOS(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')

--- a/torchtext/datasets/wikitext103.py
+++ b/torchtext/datasets/wikitext103.py
@@ -17,7 +17,7 @@ NUM_LINES = {
 }
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'valid', 'test'))
 def WikiText103(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')

--- a/torchtext/datasets/wikitext2.py
+++ b/torchtext/datasets/wikitext2.py
@@ -17,7 +17,7 @@ NUM_LINES = {
 }
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'valid', 'test'))
 def WikiText2(root, split):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')

--- a/torchtext/datasets/wmt14.py
+++ b/torchtext/datasets/wmt14.py
@@ -68,7 +68,7 @@ def _construct_filepaths(paths, src_filename, tgt_filename):
     return (src_path, tgt_path)
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'valid', 'test'))
 def WMT14(root, split,
           train_filenames=('train.tok.clean.bpe.32000.de',

--- a/torchtext/datasets/wmtnewscrawl.py
+++ b/torchtext/datasets/wmtnewscrawl.py
@@ -23,7 +23,7 @@ _AVAILABLE_LANGUAGES = [
 ]
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train',))
 def WMTNewsCrawl(root, split, year=2010, language='en'):
     dataset_tar = download_from_url(URL, root=root, hash_value=MD5, hash_type='md5')

--- a/torchtext/datasets/yahooanswers.py
+++ b/torchtext/datasets/yahooanswers.py
@@ -18,7 +18,7 @@ NUM_LINES = {
 _PATH = 'yahoo_answers_csv.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def YahooAnswers(root, split):
     def _create_data_from_csv(data_path):

--- a/torchtext/datasets/yelpreviewfull.py
+++ b/torchtext/datasets/yelpreviewfull.py
@@ -18,7 +18,7 @@ NUM_LINES = {
 _PATH = 'yelp_review_full_csv.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def YelpReviewFull(root, split):
     def _create_data_from_csv(data_path):

--- a/torchtext/datasets/yelpreviewpolarity.py
+++ b/torchtext/datasets/yelpreviewpolarity.py
@@ -18,7 +18,7 @@ NUM_LINES = {
 _PATH = 'yelp_review_polarity_csv.tar.gz'
 
 
-@add_docstring_header()
+@add_docstring_header(num_lines=NUM_LINES)
 @wrap_split_argument(('train', 'test'))
 def YelpReviewPolarity(root, split):
     def _create_data_from_csv(data_path):


### PR DESCRIPTION
This PR extends the docstring header decorator to also optionally take in the number of lines per available split and add them to the documentation. Example doc string:

```
Help on function AG_NEWS in module torchtext.datasets.ag_news:

AG_NEWS(root='.data', split=('train', 'test'))
    AG_NEWS dataset

    Separately returns the train/test split

    Number of lines per split:
        train: 120000
        test: 7600

    Args:
        root: Directory where the datasets are saved.
            Default: .data
        split: split or splits to be returned. Can be a string or tuple of strings.
            Default: ('train', 'test')
```