### PR TITLE
Reenable all google drive based tests

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -3,25 +3,11 @@
 import os
 import torch
 import torchtext
-import unittest
 from torchtext.legacy import data
 from parameterized import parameterized
 from ..common.torchtext_test_case import TorchtextTestCase
 from ..common.parameterized_utils import load_params
 from ..common.assets import conditional_remove
-
-GOOGLE_DRIVE_BASED_DATASETS = [
-    'AmazonReviewFull',
-    'AmazonReviewPolarity',
-    'DBpedia',
-    'IMDB',
-    'IWSLT',
-    'SogouNews',
-    'WMT14',
-    'YahooAnswers',
-    'YelpReviewFull',
-    'YelpReviewPolarity'
-]
 
 
 def _raw_text_custom_name_func(testcase_func, param_num, param):
@@ -169,8 +155,6 @@ class TestDataset(TorchtextTestCase):
         name_func=_raw_text_custom_name_func)
     def test_raw_text_classification(self, info):
         dataset_name = info['dataset_name']
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
 
         # Currently disabled due to incredibly slow download
         if dataset_name == "WMTNewsCrawl":
@@ -189,8 +173,6 @@ class TestDataset(TorchtextTestCase):
 
     @parameterized.expand(list(sorted(torchtext.datasets.DATASETS.keys())))
     def test_raw_datasets_split_argument(self, dataset_name):
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
         if 'statmt' in torchtext.datasets.URLS[dataset_name]:
             return
         dataset = torchtext.datasets.DATASETS[dataset_name]
@@ -206,8 +188,6 @@ class TestDataset(TorchtextTestCase):
 
     @parameterized.expand(["AG_NEWS", "WikiText2", "IMDB"])
     def test_datasets_split_argument(self, dataset_name):
-        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
-            return
         dataset = torchtext.experimental.datasets.DATASETS[dataset_name]
         train1 = dataset(split='train')
         train2, = dataset(split=('train',))
@@ -256,7 +236,6 @@ class TestDataset(TorchtextTestCase):
         self._helper_test_func(len(test_iter), 25000, next(test_iter)[1][:25], 'I love sci-fi and am will')
         del train_iter, test_iter
 
-    @unittest.skip("Dataset depends on Google drive")
     def test_iwslt(self):
         from torchtext.experimental.datasets import IWSLT
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests that requires external resources (Network access to fetch dataset)"""
 import os
+import unittest
 from collections import Counter
 
 import torch
@@ -294,6 +295,7 @@ class TestVocab(TorchtextTestCase):
 
             self.assertEqual(vectors[v.stoi['<unk>']], torch.zeros(300))
 
+    @unittest.skip("Download temp. slow.")
     def test_vectors_custom_cache(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})
         vector_cache = os.path.join('/tmp', 'vector_cache')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Note that all the tests in this module require dataset (either network access or cached)
 import os
+import unittest
 from torchtext import utils
 from .common.torchtext_test_case import TorchtextTestCase
 from test.common.assets import get_asset_path

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -153,6 +153,7 @@ class TestUtils(TorchtextTestCase):
             conditional_remove(f)
         conditional_remove(archive_path)
 
+    @unittest.skip("Download temp. slow.")
     def test_extract_non_tar_zip(self):
         # create root directory for downloading data
         root = '.data'

--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -164,7 +164,10 @@ def download_extract_validate(root, url, url_md5, downloaded_file, extracted_fil
                                     path=os.path.join(root, downloaded_file),
                                     hash_value=url_md5, hash_type=hash_type)
     extracted_files = extract_archive(dataset_tar)
-    assert path == find_match(extracted_file, extracted_files)
+    extracted_files = [os.path.abspath(p) for p in extracted_files]
+    abs_path = os.path.abspath(path)
+    found_path = find_match(extracted_file, extracted_files)
+    assert found_path == abs_path
     return path
 
 


### PR DESCRIPTION
This PR should trigger the inclusion of Google drive based datasets in the CI cache after the weekly clearing. Also see https://github.com/pytorch/text/pull/1180 . I will merge this once the CI runs clear and come next week we ideally won't see CI failures due to Google drive quota anymore.