### PR TITLE
convert version text to link

### DIFF
--- a/0.8.1/data.html
+++ b/0.8.1/data.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/data_functional.html
+++ b/0.8.1/data_functional.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/data_metrics.html
+++ b/0.8.1/data_metrics.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/data_utils.html
+++ b/0.8.1/data_utils.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/datasets.html
+++ b/0.8.1/datasets.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/examples.html
+++ b/0.8.1/examples.html
@@ -183,7 +183,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/genindex.html
+++ b/0.8.1/genindex.html
@@ -183,7 +183,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/index.html
+++ b/0.8.1/index.html
@@ -183,7 +183,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/nn_modules.html
+++ b/0.8.1/nn_modules.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/py-modindex.html
+++ b/0.8.1/py-modindex.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/search.html
+++ b/0.8.1/search.html
@@ -182,7 +182,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/utils.html
+++ b/0.8.1/utils.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8.1/vocab.html
+++ b/0.8.1/vocab.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.8.1
+                  <a href=https://pytorch.org/text/versions.html>0.8.1  &#x25BC</a>
                 </div>
               
             

--- a/0.8/data.html
+++ b/0.8/data.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/data_functional.html
+++ b/0.8/data_functional.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/data_metrics.html
+++ b/0.8/data_metrics.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/data_utils.html
+++ b/0.8/data_utils.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/datasets.html
+++ b/0.8/datasets.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/examples.html
+++ b/0.8/examples.html
@@ -154,7 +154,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/genindex.html
+++ b/0.8/genindex.html
@@ -154,7 +154,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/index.html
+++ b/0.8/index.html
@@ -154,7 +154,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/nn_modules.html
+++ b/0.8/nn_modules.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/py-modindex.html
+++ b/0.8/py-modindex.html
@@ -156,7 +156,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/search.html
+++ b/0.8/search.html
@@ -153,7 +153,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/utils.html
+++ b/0.8/utils.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             

--- a/0.8/vocab.html
+++ b/0.8/vocab.html
@@ -155,7 +155,7 @@
               
               
                 <div class="version">
-                  0.8.0
+                  <a href=https://pytorch.org/text/versions.html>0.8.0  &#x25BC</a>
                 </div>
               
             


### PR DESCRIPTION
Convert the static version text to links in the 0.8 and 0.8.1 documentation

@brianjo 