### PR TITLE
added unit tests to do sanity check on raw data download

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -214,6 +214,9 @@ class TestDataset(TorchtextTestCase):
         if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
             return
 
+        if dataset_name == 'WMTNewsCrawl':
+            return
+
         with tempfile.TemporaryDirectory() as tmpdirname:
             _ = torchtext.experimental.datasets.raw.DATASETS[dataset_name](root=tmpdirname, split='train')
             # This ensures that the data downloads in given root directory

--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -4,6 +4,7 @@ import os
 import torch
 import torchtext
 import unittest
+import tempfile
 from torchtext.legacy import data
 from parameterized import parameterized
 from ..common.torchtext_test_case import TorchtextTestCase
@@ -193,6 +194,34 @@ class TestDataset(TorchtextTestCase):
             self.assertEqual(torchtext.datasets.URLS[dataset_name], info['URL'])
             self.assertEqual(torchtext.datasets.MD5[dataset_name], info['MD5'])
         del data_iter
+
+    @parameterized.expand(list(torchtext.datasets.DATASETS))
+    def test_raw_datasets_download(self, dataset_name):
+        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
+            return
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            _ = torchtext.datasets.DATASETS[dataset_name](root=tmpdirname, split='train')
+            # This ensures that the data downloads in given root directory
+            self.assertIsNot(len(os.listdir(tmpdirname)), 0)
+            # This ensure that we do not pollute root diretory.
+            # Every dataset is expected to create a dedicated dir inside root dir
+            # if the number expected files are more than 1
+            self.assertLessEqual(len(os.listdir(tmpdirname)), 2)
+
+    @parameterized.expand(list(torchtext.experimental.datasets.raw.DATASETS))
+    def test_raw_experimental_datasets_download(self, dataset_name):
+        if dataset_name in GOOGLE_DRIVE_BASED_DATASETS:
+            return
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            _ = torchtext.experimental.datasets.raw.DATASETS[dataset_name](root=tmpdirname, split='train')
+            # This ensures that the data downloads in given root directory
+            self.assertIsNot(len(os.listdir(tmpdirname)), 0)
+            # This ensure that we do not pollute root diretory.
+            # Every dataset is expected to create a dedicated dir inside root dir
+            # if the number expected files are more than 1
+            self.assertLessEqual(len(os.listdir(tmpdirname)), 2)
 
     @parameterized.expand(list(sorted(torchtext.datasets.DATASETS.keys())))
     def test_raw_datasets_split_argument(self, dataset_name):

--- a/torchtext/experimental/datasets/raw/multi30k.py
+++ b/torchtext/experimental/datasets/raw/multi30k.py
@@ -506,6 +506,7 @@ def Multi30k(root, split,
             current_url.append(url)
             current_md5.append(md5)
 
+    root = os.path.join(root, 'multi30k')
     for url, md5 in zip(current_url, current_md5):
         dataset_tar = download_from_url(
             url, path=os.path.join(root, os.path.basename(url)), root=root, hash_value=md5, hash_type='md5')

--- a/torchtext/experimental/datasets/raw/wmtnewscrawl.py
+++ b/torchtext/experimental/datasets/raw/wmtnewscrawl.py
@@ -3,6 +3,7 @@ from torchtext.data.datasets_utils import wrap_split_argument
 from torchtext.data.datasets_utils import add_docstring_header
 from torchtext.data.datasets_utils import download_extract_validate
 import io
+import os
 import logging
 
 URL = 'http://www.statmt.org/wmt11/training-monolingual-news-2010.tgz'
@@ -48,7 +49,7 @@ def WMTNewsCrawl(root, split, year=2010, language='en'):
         raise ValueError("{} not available. Please choose from years {}".format(year, _AVAILABLE_YEARS))
     if language not in _AVAILABLE_LANGUAGES:
         raise ValueError("{} not available. Please choose from languages {}".format(language, _AVAILABLE_LANGUAGES))
-    path = download_extract_validate(root, URL, MD5, _PATH, _EXTRACTED_FILES[language],
+    path = download_extract_validate(root, URL, MD5, os.path.join(root, _PATH), _EXTRACTED_FILES[language],
                                      _EXTRACTED_FILES_MD5[language], hash_type="md5")
     logging.info('Creating {} data'.format(split))
     return RawTextIterableDataset("WMTNewsCrawl",


### PR DESCRIPTION
We would like to do basic sanity checks on data download

- The download should be in the provided root directory (and it's subdirectories) 
- We want to ensure that root directory does not get polluted by downloaded and extracted files. So any raw data download is not allowed to create more than two top level files. So creators of new raw datasets must ensure that if the downloaded/extracted data creates multiple files, they should be in dedicated subdirectories of the root directory