### PR TITLE
Import version from legacy folder

### DIFF
--- a/torchtext/legacy/__init__.py
+++ b/torchtext/legacy/__init__.py
@@ -3,9 +3,11 @@ from .. import nn  # Not in the legacy folder
 from . import datasets
 from .. import utils  # Not in the legacy folder
 from .. import vocab  # Not in the legacy folder
+from torchtext import __version__, git_version, version
 
 __all__ = ['data',
            'nn',
            'datasets',
            'utils',
-           'vocab']
+           'vocab',
+           '__version__', 'git_version', 'version']

--- a/torchtext/legacy/__init__.py
+++ b/torchtext/legacy/__init__.py
@@ -3,11 +3,15 @@ from .. import nn  # Not in the legacy folder
 from . import datasets
 from .. import utils  # Not in the legacy folder
 from .. import vocab  # Not in the legacy folder
-from torchtext import __version__, git_version, version
+
+try:
+    from .. import version  # noqa: F401
+    from ..version import __version__, git_version  # noqa: F401
+except ImportError:
+    pass
 
 __all__ = ['data',
            'nn',
            'datasets',
            'utils',
-           'vocab',
-           '__version__', 'git_version', 'version']
+           'vocab']


### PR DESCRIPTION
With torchtext 0.8.1
```
import torchtext
dir_torchtext_0_8_1 = dir(torchtext)
print(dir_torchtext_0_8_1)

>>> ['__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', 'data', 'datasets', 'git_version', 'nn', 'utils', 'version', 'vocab']
```

With this PR
```
from torchtext import legacy
dir_torchtext = dir(legacy)
print(dir_torchtext)

>>> ['__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', 'data', 'datasets', 'git_version', 'nn', 'utils', 'version', 'vocab']
```