### PR TITLE
Helper function for Vocab object

### DIFF
--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -103,6 +103,12 @@ class Vocab(object):
     def _default_unk_index(self):
         return self.unk_index
 
+    def get_token(self, index):
+        result = self.itos[index]
+        if result is None:
+            return Vocab.UNK
+        return result
+
     def __getitem__(self, token):
         return self.stoi.get(token, self.stoi.get(Vocab.UNK))
 


### PR DESCRIPTION
I found it hard to understand how to preform a "full loop" of Token -> index -> Token, I think the intended manner is to just access the itos variable of the vocab. This feels to me to be inconsistent with how the API is setup to get a index for a token, which uses the __getitem__ overload. While this is not a perfect solution, I do think it will help other new users to have a guiding hand about how to get at this information. 
