### PR TITLE
Another raw-RPC pipeline implementation with multi-GPU-linear layer

### DIFF
--- a/examples/BERT/pipeline.py
+++ b/examples/BERT/pipeline.py
@@ -87,4 +87,143 @@ class RPCPipeline(nn.Module):
         for shard in self.shards:
             remote_params.extend(shard.remote().parameter_rrefs().to_here())
         return remote_params
-    
+
+# =======================================================================================================================================
+
+class MyPipelineLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.underlying_moved_to_device = False
+
+    def move_underlying_to_device():
+        pass
+
+
+class MyPipelineLocalMultiGPULayer(MyPipelineLayer):
+    def __init__(self, layer, in_features, out_features, devices=None, result_device=None, *args, **kwargs):
+        super().__init__()
+        self.devices = devices
+        self.result_device = result_device
+
+        if self.devices is None:
+            self.devices = ['cpu']
+        if self.result_device is None:
+            self.result_device = self.devices[-1]
+
+        n_devices = len(self.devices)
+        if out_features < n_devices:
+            self.shard_out_features = [1] * out_features
+            self.devices = self.devices[:out_features]
+        elif out_features % n_devices == 0:
+            self.shard_out_features = [out_features // n_devices] * n_devices
+        else:
+            size = (out_features + n_devices - 1) // n_devices
+            self.shard_out_features = [size] * (n_devices - 1) + [out_features - size * (n_devices - 1)]
+        self.linears = nn.Sequential(*[layer(in_features, shard_out_feature, *args, **kwargs) for shard_out_feature in self.shard_out_features])
+
+    def move_underlying_to_device(self):
+        for device, linear in zip(self.devices, self.linears):
+            linear.to(device)
+
+    def forward(self, input):
+        return torch.cat([linear(input.to(device)).to(self.result_device) for device, linear in zip(self.devices, self.linears)], dim=-1)
+
+
+class MyPipelineWrapper(MyPipelineLayer):
+    def __init__(self, underlying, device):
+        super().__init__()
+        self.underlying = underlying
+        self.device = device
+
+    def move_underlying_to_device(self):
+        self.underlying.to(self.device)
+        self.underlying_moved_to_device = True
+
+    def _move_input_to_device(self, *args, **kwargs):
+        new_args = tuple(arg.to(self.device) if isinstance(arg, torch.Tensor) else arg for arg in args)
+        new_kwargs = {key: value.to(device) if isinstance(value, torch.Tensor) else  value for key, value in kwargs}
+        return new_args, new_kwargs
+
+    def forward(self, *args, **kwargs):
+        args, kwargs = self._move_input_to_device(*args, **kwargs)
+        return self.underlying(*args, **kwargs)
+
+
+class MyPipeline(nn.Sequential):
+    def __init__(self, *layers):
+        super().__init__(*layers)
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            concurrent.futures.wait([executor.submit(lambda l: l.move_underlying_to_device(), layer) for layer in self])
+
+# =======================================================================================================================================
+
+class MyRPCPipelineWrapper(nn.Module):
+    def __init__(self, underlying, remote_device):
+        super().__init__()
+        self.underlying = underlying
+        self.worker, self.device = remote_device.split(":")
+        self.device = int(self.device)
+        self.shard = None
+
+    def move_underlying_to_device(self):
+        self.shard = rpc.remote(self.worker, RemoteBaseCPURPC, args=(self.underlying, self.device))
+        self.underlying_moved_to_device = True
+
+    def forward(self, *args, **kwargs):
+        return self.shard.remote().forward(*args, **kwargs)
+
+    def parameter_rrefs(self):
+        return self.shard.remote().parameter_rrefs()
+
+
+class MyRPCPipelineDistMultiGPULayer(nn.Module):
+    def __init__(self, layer, in_features, out_features, remote_devices=None, result_remote_device=None, *args, **kwargs):
+        super().__init__()
+        self.workers = [remote_device.split(":")[0] for remote_device in remote_devices]
+        self.devices = [int(remote_device.split(":")[1]) for remote_device in remote_devices]
+        if result_remote_device is None:
+            result_remote_device = remote_devices[-1]
+        self.result_worker, self.result_device = result_remote_device.split(":")
+        self.result_device = int(self.result_device)
+
+        n_devices = len(remote_devices)
+        if out_features < n_devices:
+            self.shard_out_features = [1] * out_features
+            self.workers = self.workers[:out_features]
+            self.devices = self.devices[:out_features]
+        elif out_features % n_devices == 0:
+            self.shard_out_features = [out_features // n_devices] * n_devices
+        else:
+            size = (out_features + n_devices - 1) // n_devices
+            self.shard_out_features = [size] * (n_devices - 1) + [out_features - size * (n_devices - 1)]
+        self.in_features = in_features
+        # TODO: move to move_underlying_to_device
+        self.linears = [rpc.remote(worker, RemoteBaseCPURPC, args=(layer(self.in_features, shard_out_feature, *args, **kwargs), device)) for worker, shard_out_feature, device in zip(self.workers, self.shard_out_features, self.devices)]
+
+    def move_underlying_to_device(self):
+        pass
+
+    def forward(self, input):
+        return RRef(torch.cat([linear.remote().forward(input).to_here() for linear in self.linears], dim=-1))
+
+    def parameter_rrefs(self):
+        remote_params = []
+        for layer in self.linears:
+            remote_params.extend(layer.remote().parameter_rrefs().to_here())
+        return RRef(remote_params)
+
+
+class MyRPCPipeline(nn.Sequential):
+    def __init__(self, *layers):
+        super().__init__(*layers)
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            concurrent.futures.wait([executor.submit(lambda l: l.move_underlying_to_device(), layer) for layer in self])
+
+    def forward(self, x):
+        return super().forward(RRef(x)).to_here()
+
+    def parameter_rrefs(self):
+        remote_params = []
+        for layer in self:
+            remote_params.extend(layer.parameter_rrefs().to_here())
+        return remote_params


### PR DESCRIPTION
```
python cross_lingual_mlm_task.py --cc100_path ~/local/cc100/ --num_lines 3000 --gpus=8 --pipeline_mode=cpu \
--nlayers=20 --emsize=5120 --nhid=20480 --nhead=32
Allocating memory
total = 6387M
Memory allocated
| epoch   1 |    10/43500 batches | lr 0.00100 | ms/batch 3930.30 | loss 14.72 | ppl 2479920.71
| epoch   1 |    20/43500 batches | lr 0.00100 | ms/batch 3675.10 | loss 12.70 | ppl 326508.81
| epoch   1 |    30/43500 batches | lr 0.00100 | ms/batch 2565.92 | loss 12.40 | ppl 241973.65
| epoch   1 |    40/43500 batches | lr 0.00100 | ms/batch 3857.97 | loss 11.52 | ppl 100745.66
| epoch   1 |    50/43500 batches | lr 0.00100 | ms/batch 2845.25 | loss 10.96 | ppl 57632.00
| epoch   1 |    60/43500 batches | lr 0.00100 | ms/batch 4021.83 | loss 11.37 | ppl 86627.78
| epoch   1 |    70/43500 batches | lr 0.00100 | ms/batch 4703.93 | loss 10.46 | ppl 34985.80
| epoch   1 |    80/43500 batches | lr 0.00100 | ms/batch 3515.36 | loss  9.93 | ppl 20540.25
| epoch   1 |    90/43500 batches | lr 0.00100 | ms/batch 3806.06 | loss 10.18 | ppl 26449.71
| epoch   1 |   100/43500 batches | lr 0.00100 | ms/batch 4120.39 | loss  8.88 | ppl  7161.26

+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID   Type   Process name                             Usage      |
|=============================================================================|
|    0   3028267      C   .../local/anaconda3/envs/pt-dev/bin/python 15685MiB |
|    1   3028268      C   .../local/anaconda3/envs/pt-dev/bin/python 15685MiB |
|    2   3028269      C   .../local/anaconda3/envs/pt-dev/bin/python 16155MiB |
|    3   3028270      C   .../local/anaconda3/envs/pt-dev/bin/python 16157MiB |
|    4   3028271      C   .../local/anaconda3/envs/pt-dev/bin/python 16157MiB |
|    5   3028272      C   .../local/anaconda3/envs/pt-dev/bin/python 16157MiB |
|    6   3028273      C   .../local/anaconda3/envs/pt-dev/bin/python 16089MiB |
|    7   3028274      C   .../local/anaconda3/envs/pt-dev/bin/python 15641MiB |
+-----------------------------------------------------------------------------+
```