### PR TITLE
Added yaml.safe_load instead of yaml.load

### DIFF
--- a/.circleci/utils/test_sort_yaml.py
+++ b/.circleci/utils/test_sort_yaml.py
@@ -11,4 +11,4 @@ To compare new version with previous:
 import sys
 import yaml
 
-sys.stdout.write(yaml.dump(yaml.load(sys.stdin, Loader=yaml.FullLoader), sort_keys=True))
+sys.stdout.write(yaml.dump(yaml.safe_load(sys.stdin, Loader=yaml.FullLoader), sort_keys=True))


### PR DESCRIPTION
This PR fixes an issue pointed out by Bandit w.r.t. using `yaml.load`, where it'd allow for unsafe loading of arbitrary objects, by using `yaml.safe_load` instead.

Bandit output:
```
>> Issue: [B506:yaml_load] Use of unsafe yaml load. Allows instantiation of arbitrary objects. Consider yaml.safe_load().
   Severity: Medium   Confidence: High
   Location: ./.circleci/utils/test_sort_yaml.py:14
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html
13	
14	sys.stdout.write(yaml.dump(yaml.load(sys.stdin, Loader=yaml.FullLoader), sort_keys=True))
```