### PR TITLE
Added defusedxml to parse untrusted XML data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ pytest-pythonpath
 # Coverage statistics
 pytest-cov
 codecov
+
+# To parse untrusted XML data
+defusedxml

--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -11,7 +11,10 @@ from torchtext.utils import (
     unicode_csv_reader,
 )
 import codecs
-import xml.etree.ElementTree as ET
+try:
+    import defusedxml.ElementTree as ET
+except ImportError:
+    import xml.etree.ElementTree as ET
 """
 These functions and classes are meant solely for use in torchtext.datasets and not
 for public consumption yet.

--- a/torchtext/legacy/datasets/translation.py
+++ b/torchtext/legacy/datasets/translation.py
@@ -1,5 +1,8 @@
 import os
-import xml.etree.ElementTree as ET
+try:
+    import defusedxml.ElementTree as ET
+except ImportError:
+    import xml.etree.ElementTree as ET
 import glob
 import io
 import codecs


### PR DESCRIPTION
This PR fixes an issue pointed out by [Bandit ](https://bandit.readthedocs.io/en/latest/)w.r.t. using the `xml` library to parse untrusted data, by using `defusedxml` instead.

Bandit output:
```
>> Issue: [B314:blacklist] Using xml.etree.ElementTree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace xml.etree.ElementTree.parse with its defusedxml equivalent function or make sure defusedxml.defuse_stdlib() is called
   Severity: Medium   Confidence: High
   Location: ./torchtext/data/datasets_utils.py:24
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b313-b320-xml-bad-elementtree
23	    with codecs.open(f_txt, mode='w', encoding='utf-8') as fd_txt:
24	        root = ET.parse(f_xml).getroot()[0]
25	        for doc in root.findall('doc'):

>> Issue: [B314:blacklist] Using xml.etree.ElementTree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace xml.etree.ElementTree.parse with its defusedxml equivalent function or make sure defusedxml.defuse_stdlib() is called
   Severity: Medium   Confidence: High
   Location: ./torchtext/legacy/datasets/translation.py:169
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b313-b320-xml-bad-elementtree
168	            with codecs.open(f_txt, mode='w', encoding='utf-8') as fd_txt:
169	                root = ET.parse(f_xml).getroot()[0]
170	                for doc in root.findall('doc'):
```