### PR TITLE
Add Google Analytics support

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 sphinx==2.4.4
-sphinxcontrib-googleanalytics
 -e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,6 +111,7 @@ html_theme_options = {
     'collapse_navigation': False,
     'display_version': True,
     'logo_only': True,
+    'analytics_id': 'UA-117752657-2',
 }
 
 html_logo = '_static/img/pytorch-logo-dark.svg'


### PR DESCRIPTION
This PR adds GA support to torchtext. We just rely on the native support from the theme (pytorch/pytorch_sphinx_theme#110)