### PR TITLE
Store artifacts of rendered docs so that rendered docs can be checked on each PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,6 +559,9 @@ jobs:
           root: ./
           paths:
             - "*"
+      - store_artifacts:
+          path: ./docs/build/html
+          destination: docs
 
   upload_docs:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -559,6 +559,9 @@ jobs:
           root: ./
           paths:
             - "*"
+      - store_artifacts:
+          path: ./docs/build/html
+          destination: docs
 
   upload_docs:
     <<: *binary_common


### PR DESCRIPTION
The `build_docs` CI run builds the doc on every PR but the artifacts aren't saved, so we can't access the rendered html files.

This PR saves the artifacts so that the built docs can be browsed on each PR by going in the "Artifacts" tab of the `build_docs` CI run.