### PR TITLE
functional to convert iterables into map-style dataset

### DIFF
--- a/docs/source/data_functional.rst
+++ b/docs/source/data_functional.rst
@@ -47,3 +47,8 @@ torchtext.data.functional
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: filter_wikipedia_xml
+
+:hidden:`to_map_style_dataset`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: to_map_style_dataset

--- a/torchtext/data/__init__.py
+++ b/torchtext/data/__init__.py
@@ -9,6 +9,7 @@ from .functional import (
     simple_space_split,
     numericalize_tokens_from_iterator,
     filter_wikipedia_xml,
+    to_map_style_dataset,
 )
 
 from ..legacy.data import Batch
@@ -20,5 +21,6 @@ __all__ = ["bleu_score",
            "custom_replace", "simple_space_split",
            "numericalize_tokens_from_iterator",
            "filter_wikipedia_xml",
+           "to_map_style_dataset",
            "Batch"  # tmp compatibility hack for old lightning
            ]

--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -7,6 +7,7 @@ __all__ = [
     "sentencepiece_numericalizer", "sentencepiece_tokenizer",
     "numericalize_tokens_from_iterator",
     "filter_wikipedia_xml",
+    "to_map_style_dataset",
 ]
 
 
@@ -249,3 +250,35 @@ def filter_wikipedia_xml(text_iterator):
         line = list(norm_transform([line]))[0].strip()
         if line:
             yield line
+
+
+def to_map_style_dataset(iter_data):
+    r"""Convert iterable-style dataset to map-style dataset.
+
+    args:
+        iter_data: An iterator type object. Examples include Iterable datasets, string list, text io, generators etc.
+
+
+    Examples:
+        >>> from torchtext.datasets import IMDB
+        >>> from torchtext.data import to_map_style_dataset
+        >>> train_iter = IMDB(split='train')
+        >>> train_dataset = to_map_style_dataset(train_iter)
+        >>> file_name = '.data/EnWik9/enwik9'
+        >>> data_iter = to_map_style_dataset(open(file_name,'r'))
+    """
+
+    # Inner class to convert iterable-style to map-style dataset
+    class map_style_dataset(torch.utils.data.Dataset):
+
+        def __init__(self, iter_data):
+            # TODO Avoid list issue #1296
+            self._data = list(iter_data)
+
+        def __len__(self):
+            return len(self._data)
+
+        def __getitem__(self, idx):
+            return self._data[idx]
+
+    return map_style_dataset(iter_data)

--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -269,7 +269,7 @@ def to_map_style_dataset(iter_data):
     """
 
     # Inner class to convert iterable-style to map-style dataset
-    class map_style_dataset(torch.utils.data.Dataset):
+    class _MapStyleDataset(torch.utils.data.Dataset):
 
         def __init__(self, iter_data):
             # TODO Avoid list issue #1296
@@ -281,4 +281,4 @@ def to_map_style_dataset(iter_data):
         def __getitem__(self, idx):
             return self._data[idx]
 
-    return map_style_dataset(iter_data)
+    return _MapStyleDataset(iter_data)


### PR DESCRIPTION
With reference to issue #1296, this is a naive implementation to convert to map-style datasets.

Follow-up:
- [ ] Move away from lists and implement specialized containers. Reference: #1296