### PR TITLE
Added APIs for default index and removed unk token

### DIFF
--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
 import os
-import platform
 import torch
-import unittest
 from test.common.torchtext_test_case import TorchtextTestCase
 from torchtext.experimental.vocab import (
     vocab,

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -62,9 +62,11 @@ class TestVocab(TorchtextTestCase):
 
         self.assertEqual(v.get_itos(), ['<unk>', 'a', 'b'])
 
+        # token must exist for rassignment
         with self.assertRaises(RuntimeError):
             v.reassign_token('not in vocab', 0)
 
+        # index should be valid for reassignment
         with self.assertRaises(RuntimeError):
             v.reassign_token('<unk>', 3)
 
@@ -112,10 +114,9 @@ class TestVocab(TorchtextTestCase):
 
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
-        with self.assertRaises(RuntimeError) as context:
+        # token must not exist to be inserted
+        with self.assertRaises(RuntimeError):
             v.insert_token('b', 0)
-
-        self.assertTrue("Token b already exists in the Vocab with index: 0" in str(context.exception))
 
     def test_vocab_append_token(self):
         c = OrderedDict({'a': 2})
@@ -128,10 +129,9 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-        with self.assertRaises(RuntimeError) as context:
+        # token must not exist to be appended
+        with self.assertRaises(RuntimeError):
             v.append_token('b')
-
-        self.assertTrue("Token b already exists in the Vocab with index: 2" in str(context.exception))
 
     def test_vocab_len(self):
         token_to_freq = {'a': 2, 'b': 2, 'c': 2}

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -55,20 +55,16 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v['<unk>'], 2)
         self.assertEqual(v['a'], 0)
         self.assertEqual(v['b'], 1)
-        v.reassign_token('<unk>', 0)
+        v['<unk>'] = 0
         self.assertEqual(v['<unk>'], 0)
         self.assertEqual(v['a'], 1)
         self.assertEqual(v['b'], 2)
 
         self.assertEqual(v.get_itos(), ['<unk>', 'a', 'b'])
 
-        # token must exist for rassignment
-        with self.assertRaises(RuntimeError):
-            v.reassign_token('not in vocab', 0)
-
         # index should be valid for reassignment
         with self.assertRaises(RuntimeError):
-            v.reassign_token('<unk>', 3)
+            v['<unk>'] = 3
 
     def test_default_index(self):
         token_to_freq = {'<unk>': 2, 'a': 2, 'b': 2}
@@ -97,7 +93,7 @@ class TestVocab(TorchtextTestCase):
 
         # add item to end
         v = vocab(c)
-        v.insert_token('b', 2)
+        v['b'] = 2
 
         expected_itos = ['<unk>', 'a', 'b']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
@@ -107,16 +103,13 @@ class TestVocab(TorchtextTestCase):
 
         # add item to middle
         v = vocab(c)
-        v.insert_token('b', 0)
+        v['b'] = 0
 
         expected_itos = ['b', '<unk>', 'a']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
 
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
-        # token must not exist to be inserted
-        with self.assertRaises(RuntimeError):
-            v.insert_token('b', 0)
 
     def test_vocab_append_token(self):
         c = OrderedDict({'a': 2})
@@ -225,7 +218,7 @@ class TestVocab(TorchtextTestCase):
         with self.assertRaises(RuntimeError):
             # Test proper error raised when setting a token out of bounds
             v = vocab(c, min_freq=3)
-            v.insert_token('new_token', 100)
+            v['new_token'] = 100
 
         with self.assertRaises(RuntimeError):
             # Test proper error raised when looking up a token out of bounds
@@ -247,6 +240,7 @@ class TestVocab(TorchtextTestCase):
 
         c = OrderedDict(sorted_by_freq_tuples)
         v = vocab(c, min_freq=3)
+        v.set_default_index(0)
 
         expected_itos = ['<unk>', 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
@@ -260,6 +254,7 @@ class TestVocab(TorchtextTestCase):
             loaded_v = torch.load(vocab_path)
             self.assertEqual(v.get_itos(), expected_itos)
             self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
+            self.assertEqual(v['not in vocab'], 0)
 
         with self.subTest('torchscript'):
             vocab_path = os.path.join(self.test_dir, 'vocab_torchscript.pt')
@@ -269,6 +264,7 @@ class TestVocab(TorchtextTestCase):
             loaded_v = torch.load(vocab_path)
             self.assertEqual(v.get_itos(), expected_itos)
             self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
+            self.assertEqual(v['not in vocab'], 0)
 
     def test_build_vocab_iterator(self):
         iterator = [['hello', 'hello', 'hello', 'freq_low', 'hello', 'world', 'world', 'world', 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T',

--- a/test/experimental/test_vocab.py
+++ b/test/experimental/test_vocab.py
@@ -76,6 +76,10 @@ class TestVocab(TorchtextTestCase):
 
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
+        with self.assertRaises(RuntimeError) as context:
+            v.insert_token('b', 0)
+
+        self.assertTrue("Token b already exists in the Vocab with index: 0" in str(context.exception))
 
     def test_vocab_append_token(self):
         c = OrderedDict({'a': 2})
@@ -87,6 +91,11 @@ class TestVocab(TorchtextTestCase):
 
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
+
+        with self.assertRaises(RuntimeError) as context:
+            v.append_token('b')
+
+        self.assertTrue("Token b already exists in the Vocab with index: 2" in str(context.exception))
 
     def test_vocab_len(self):
         token_to_freq = {'a': 2, 'b': 2, 'c': 2}

--- a/test/experimental/test_with_asset.py
+++ b/test/experimental/test_with_asset.py
@@ -178,8 +178,8 @@ class TestTransformsWithAsset(TorchtextTestCase):
     def test_vocab_from_file(self):
         asset_name = 'vocab_test.txt'
         asset_path = get_asset_path(asset_name)
-        v = load_vocab_from_file(asset_path, unk_token='<new_unk>')
-        expected_itos = ['<new_unk>', 'b', 'a', 'c']
+        v = load_vocab_from_file(asset_path)
+        expected_itos = ['b', 'a', 'c']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
@@ -189,8 +189,8 @@ class TestTransformsWithAsset(TorchtextTestCase):
         asset_path = get_asset_path(asset_name)
         tokenizer = basic_english_normalize()
         jit_tokenizer = torch.jit.script(tokenizer)
-        v = build_vocab_from_text_file(asset_path, jit_tokenizer, unk_token='<new_unk>')
-        expected_itos = ['<new_unk>', "'", 'after', 'talks', '.', 'are', 'at', 'disappointed',
+        v = build_vocab_from_text_file(asset_path, jit_tokenizer)
+        expected_itos = ["'", 'after', 'talks', '.', 'are', 'at', 'disappointed',
                          'fears', 'federal', 'firm', 'for', 'mogul', 'n', 'newall', 'parent',
                          'pension', 'representing', 'say', 'stricken', 't', 'they', 'turner',
                          'unions', 'with', 'workers']

--- a/test/experimental/test_with_asset.py
+++ b/test/experimental/test_with_asset.py
@@ -178,8 +178,8 @@ class TestTransformsWithAsset(TorchtextTestCase):
     def test_vocab_from_file(self):
         asset_name = 'vocab_test.txt'
         asset_path = get_asset_path(asset_name)
-        v = load_vocab_from_file(asset_path)
-        expected_itos = ['b', 'a', 'c']
+        v = load_vocab_from_file(asset_path, unk_token='<new_unk>')
+        expected_itos = ['<new_unk>', 'b', 'a', 'c']
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
@@ -189,8 +189,8 @@ class TestTransformsWithAsset(TorchtextTestCase):
         asset_path = get_asset_path(asset_name)
         tokenizer = basic_english_normalize()
         jit_tokenizer = torch.jit.script(tokenizer)
-        v = build_vocab_from_text_file(asset_path, jit_tokenizer)
-        expected_itos = ["'", 'after', 'talks', '.', 'are', 'at', 'disappointed',
+        v = build_vocab_from_text_file(asset_path, jit_tokenizer, unk_token='<new_unk>')
+        expected_itos = ['<new_unk>', "'", 'after', 'talks', '.', 'are', 'at', 'disappointed',
                          'fears', 'federal', 'firm', 'for', 'mogul', 'n', 'newall', 'parent',
                          'pension', 'representing', 'say', 'stricken', 't', 'they', 'turner',
                          'unions', 'with', 'workers']

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -112,13 +112,14 @@ PYBIND11_MODULE(_torchtext, m) {
             const char *buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
             return self->__contains__(c10::string_view{buffer, (size_t)length});
           })
-      .def("__setitem__", &Vocab::__setitem__)
       .def("__getitem__",
            [](c10::intrusive_ptr<Vocab> &self, const py::str &item) -> int64_t {
              ssize_t length;
              const char *buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
              return self->__getitem__(c10::string_view{buffer, (size_t)length});
            })
+      .def("reassign_token", &Vocab::reassign_token)
+      .def("insert_token", &Vocab::insert_token)
       .def("set_default_index", &Vocab::set_default_index)
       .def("get_default_index", &Vocab::get_default_index)
       .def("__len__", &Vocab::__len__)
@@ -239,10 +240,11 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
       .def("__contains__",
            [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
                -> bool { return self->__contains__(c10::string_view{item}); })
-      .def("__setitem__", &Vocab::__setitem__)
       .def("__getitem__",
            [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
                -> int64_t { return self->__getitem__(c10::string_view{item}); })
+      .def("reassign_token", &Vocab::reassign_token)
+      .def("insert_token", &Vocab::insert_token)
       .def("__len__", &Vocab::__len__)
       .def("set_default_index", &Vocab::set_default_index)
       .def("get_default_index", &Vocab::get_default_index)

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -112,6 +112,7 @@ PYBIND11_MODULE(_torchtext, m) {
             const char *buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
             return self->__contains__(c10::string_view{buffer, (size_t)length});
           })
+      .def("__setitem__", &Vocab::__setitem__)
       .def("__getitem__",
            [](c10::intrusive_ptr<Vocab> &self, const py::str &item) -> int64_t {
              ssize_t length;
@@ -120,9 +121,7 @@ PYBIND11_MODULE(_torchtext, m) {
            })
       .def("set_default_index", &Vocab::set_default_index)
       .def("get_default_index", &Vocab::get_default_index)
-      .def("reassign_token", &Vocab::reassign_token)
       .def("__len__", &Vocab::__len__)
-      .def("insert_token", &Vocab::insert_token)
       .def("append_token", &Vocab::append_token)
       .def("lookup_token", &Vocab::lookup_token)
       .def("lookup_tokens", &Vocab::lookup_tokens)
@@ -240,14 +239,13 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
       .def("__contains__",
            [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
                -> bool { return self->__contains__(c10::string_view{item}); })
+      .def("__setitem__", &Vocab::__setitem__)
       .def("__getitem__",
            [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
                -> int64_t { return self->__getitem__(c10::string_view{item}); })
       .def("__len__", &Vocab::__len__)
       .def("set_default_index", &Vocab::set_default_index)
       .def("get_default_index", &Vocab::get_default_index)
-      .def("reassign_token", &Vocab::reassign_token)
-      .def("insert_token", &Vocab::insert_token)
       .def("append_token", &Vocab::append_token)
       .def("lookup_token", &Vocab::lookup_token)
       .def("lookup_tokens", &Vocab::lookup_tokens)

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -23,7 +23,7 @@ Vocab::Vocab(const StringList &tokens) : stoi_(MAX_VOCAB_SIZE, -1) {
     _add(tokens[i]);
   }
 }
-Vocab::Vocab(const StringList &tokens, c10::optional<int64_t> default_index)
+Vocab::Vocab(const StringList &tokens,const c10::optional<int64_t> &default_index)
     : stoi_(MAX_VOCAB_SIZE, -1), default_index_{default_index} {
   for (std::size_t i = 0; i < tokens.size(); i++) {
     // tokens should not have any duplicates

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -38,7 +38,6 @@ bool Vocab::__contains__(const c10::string_view &token) const {
   return false;
 }
 
-
 int64_t Vocab::__getitem__(const c10::string_view &token) const {
   int64_t id = _find(token);
   if (stoi_[id] != -1) {
@@ -47,7 +46,22 @@ int64_t Vocab::__getitem__(const c10::string_view &token) const {
   return unk_index_;
 }
 
-void Vocab::append_token(const std::string &token) { _add(token); }
+void Vocab::append_token(const std::string &token) {
+  // if item already in stoi we throw an error
+  auto token_position = _find(c10::string_view{token.data(), token.size()});
+  if (stoi_[token_position] != -1) {
+#ifdef _MSC_VER
+    std::cerr << "[RuntimeError] Token " << token
+              << " already exists in the Vocab with index: "
+              << stoi_[token_position] << std::endl;
+#endif
+    throw std::runtime_error("Token " + token +
+                             " already exists in the Vocab with index: " +
+                             std::to_string(stoi_[token_position]) + ".");
+  }
+
+  _add(token);
+}
 
 void Vocab::insert_token(const std::string &token, const int64_t &index) {
   if (index < 0 || index > itos_.size()) {

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -44,7 +44,7 @@ protected:
   uint32_t _find(const c10::string_view &w) const {
     uint32_t stoi_size = stoi_.size();
     uint32_t id = _hash(w) % stoi_size;
-    while (stoi_[id] != -1 && itos_[stoi_[id]]!= w) {
+    while (stoi_[id] != -1 && itos_[stoi_[id]] != w) {
       id = (id + 1) % stoi_size;
     }
     return id;

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -29,7 +29,8 @@ struct Vocab : torch::CustomClassHolder {
   bool __contains__(const c10::string_view &token) const;
   void set_default_index(int64_t index);
   c10::optional<int64_t> get_default_index() const;
-  void __setitem__(const std::string &token, const int64_t &index);
+  void reassign_token(const std::string &token, const int64_t &index);
+  void insert_token(const std::string &token, const int64_t &index);
   void append_token(const std::string &token);
   std::string lookup_token(const int64_t &index);
   std::vector<std::string> lookup_tokens(const std::vector<int64_t> &indices);

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -6,8 +6,8 @@ namespace torchtext {
 typedef std::vector<std::string> StringList;
 typedef ska_ordered::order_preserving_flat_hash_map<std::string, int64_t>
     IndexDict;
-typedef std::tuple<std::string, c10::optional<int64_t>, std::vector<int64_t>,
-                   std::vector<std::string>, std::vector<torch::Tensor>>
+typedef std::tuple<std::string, std::vector<int64_t>, std::vector<std::string>,
+                   std::vector<torch::Tensor>>
     VocabStates;
 
 struct Vocab : torch::CustomClassHolder {
@@ -18,18 +18,19 @@ struct Vocab : torch::CustomClassHolder {
   StringList itos_;
   c10::optional<int64_t> default_index_ = {};
 
-  // TODO: [can we remove this?] we need to keep this constructor, otherwise torch binding gets
-  // compilation error: no matching constructor for initialization of 'torchtext::Vocab'
+  // TODO: [can we remove this?] we need to keep this constructor, otherwise
+  // torch binding gets compilation error: no matching constructor for
+  // initialization of 'torchtext::Vocab'
   explicit Vocab(const StringList &tokens);
-  explicit Vocab(const StringList &tokens,const c10::optional<int64_t> &default_index);
+  explicit Vocab(const StringList &tokens,
+                 const c10::optional<int64_t> &default_index);
   int64_t __len__() const;
   int64_t __getitem__(const c10::string_view &token) const;
   bool __contains__(const c10::string_view &token) const;
   void set_default_index(int64_t index);
   c10::optional<int64_t> get_default_index() const;
-  void reassign_token(const std::string &token,const int64_t &index);
+  void __setitem__(const std::string &token, const int64_t &index);
   void append_token(const std::string &token);
-  void insert_token(const std::string &token, const int64_t &index);
   std::string lookup_token(const int64_t &index);
   std::vector<std::string> lookup_tokens(const std::vector<int64_t> &indices);
   std::vector<int64_t>

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -21,7 +21,7 @@ struct Vocab : torch::CustomClassHolder {
   // TODO: [can we remove this?] we need to keep this constructor, otherwise torch binding gets
   // compilation error: no matching constructor for initialization of 'torchtext::Vocab'
   explicit Vocab(const StringList &tokens);
-  explicit Vocab(const StringList &tokens, c10::optional<int64_t> default_index);
+  explicit Vocab(const StringList &tokens,const c10::optional<int64_t> &default_index);
   int64_t __len__() const;
   int64_t __getitem__(const c10::string_view &token) const;
   bool __contains__(const c10::string_view &token) const;

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -45,7 +45,7 @@ def build_vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token
     """
     vocab_obj = _build_vocab_from_text_file(file_path, min_freq, num_cpus, jited_tokenizer)
     if unk_token not in vocab_obj:
-        vocab_obj[unk_token] = 0
+        vocab_obj.insert_token(unk_token, 0)
     return Vocab(vocab_obj)
 
 
@@ -76,7 +76,7 @@ def load_vocab_from_file(file_path, min_freq=1, unk_token='<unk>', num_cpus=4):
 
     vocab_obj = _load_vocab_from_file(file_path, min_freq, num_cpus)
     if unk_token not in vocab_obj:
-        vocab_obj[unk_token] = 0
+        vocab_obj.insert_token(unk_token, 0)
     return Vocab(vocab_obj)
 
 
@@ -215,16 +215,26 @@ class Vocab(nn.Module):
         return self.vocab.get_default_index()
 
     @torch.jit.export
-    def __setitem__(self, token: str, index: int) -> None:
+    def reassign_token(self, token: str, index: int) -> None:
         r"""
         Args:
             token (str): the token used to lookup the corresponding index.
             index (int): the index corresponding to the associated token.
         Raises:
-            RuntimeError: If `index` is out or range [0,Vocab.size()) in
-            case token exsist or out of range [0,Vocab.size()] in case token does not exist in Vocab.
+            RuntimeError: If `index` is not range [0,Vocab.size()) or if token is not present in Vocab
         """
-        self.vocab.__setitem__(token, index)
+        self.vocab.reassign_token(token, index)
+
+    @torch.jit.export
+    def insert_token(self, token: str, index: int) -> None:
+        r"""
+        Args:
+            token (str): the token used to lookup the corresponding index.
+            index (int): the index corresponding to the associated token.
+        Raises:
+            RuntimeError: if `index` not between [0, Vocab.size()] or if token already exists in the vocab.
+        """
+        self.vocab.insert_token(token, index)
 
     @torch.jit.export
     def append_token(self, token: str) -> None:

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -45,7 +45,7 @@ def build_vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token
     """
     vocab_obj = _build_vocab_from_text_file(file_path, min_freq, num_cpus, jited_tokenizer)
     if unk_token not in vocab_obj:
-        vocab_obj.insert_token(unk_token, 0)
+        vocab_obj[unk_token] = 0
     return Vocab(vocab_obj)
 
 
@@ -76,7 +76,7 @@ def load_vocab_from_file(file_path, min_freq=1, unk_token='<unk>', num_cpus=4):
 
     vocab_obj = _load_vocab_from_file(file_path, min_freq, num_cpus)
     if unk_token not in vocab_obj:
-        vocab_obj.insert_token(unk_token, 0)
+        vocab_obj[unk_token] = 0
     return Vocab(vocab_obj)
 
 
@@ -215,28 +215,16 @@ class Vocab(nn.Module):
         return self.vocab.get_default_index()
 
     @torch.jit.export
-    def reassign_token(self, token: str, index: int) -> None:
+    def __setitem__(self, token: str, index: int) -> None:
         r"""
         Args:
             token (str): the token used to lookup the corresponding index.
             index (int): the index corresponding to the associated token.
-
         Raises:
-            RuntimeError: If token is not present in Vocab
+            RuntimeError: If `index` is out or range [0,Vocab.size()) in
+            case token exsist or out of range [0,Vocab.size()] in case token does not exist in Vocab.
         """
-        self.vocab.reassign_token(token, index)
-
-    @torch.jit.export
-    def insert_token(self, token: str, index: int) -> None:
-        r"""
-        Args:
-            token (str): the token used to lookup the corresponding index.
-            index (int): the index corresponding to the associated token.
-
-        Raises:
-            RuntimeError: if `index` not between [0, Vocab.size()] or if token already exists in the vocab.
-        """
-        self.vocab.insert_token(token, index)
+        self.vocab.__setitem__(token, index)
 
     @torch.jit.export
     def append_token(self, token: str) -> None:

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -214,6 +214,9 @@ class Vocab(nn.Module):
         r"""
         Args:
             token (str): the token used to lookup the corresponding index.
+
+        Raises:
+            RuntimeError: if token already exists in the vocab
         """
         self.vocab.append_token(token)
 

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -19,7 +19,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def build_vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token='<unk>', num_cpus=4):
+def build_vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, num_cpus=4):
     r"""Create a `Vocab` object from a raw text file.
 
     The `file_path` can contain any raw text. This function applies a generic JITed tokenizer in
@@ -44,11 +44,11 @@ def build_vocab_from_text_file(file_path, jited_tokenizer, min_freq=1, unk_token
         >>> jit_tokenizer = torch.jit.script(tokenizer)
         >>> v = build_vocab_from_text_file('vocab.txt', jit_tokenizer)
     """
-    vocab_obj = _build_vocab_from_text_file(file_path, unk_token, min_freq, num_cpus, jited_tokenizer)
+    vocab_obj = _build_vocab_from_text_file(file_path, min_freq, num_cpus, jited_tokenizer)
     return Vocab(vocab_obj)
 
 
-def load_vocab_from_file(file_path, min_freq=1, unk_token='<unk>', num_cpus=4):
+def load_vocab_from_file(file_path, min_freq=1, num_cpus=4):
     r"""Create a `Vocab` object from a text file.
     The `file_path` should contain tokens separated by new lines.
     Format for txt file:
@@ -73,7 +73,7 @@ def load_vocab_from_file(file_path, min_freq=1, unk_token='<unk>', num_cpus=4):
         >>> v = load_vocab_from_file('vocab.txt')
     """
 
-    vocab_obj = _load_vocab_from_file(file_path, unk_token, min_freq, num_cpus)
+    vocab_obj = _load_vocab_from_file(file_path, min_freq, num_cpus)
     return Vocab(vocab_obj)
 
 

--- a/torchtext/experimental/vocab.py
+++ b/torchtext/experimental/vocab.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Dict, List, Optional
-import warnings
 from collections import Counter, OrderedDict
 import torch
 import torch.nn as nn


### PR DESCRIPTION
This PR modifies behavior of Vocab according to the discussions in #1016 and #1027

In Summary we made following changes:

1. Added APIs for setting and getting default index. This index is returns when OOV is queried
2. Added API to reassign token
3. Removed unk token from vocab construction
4. Used TORCH_CHECK Macro for error handling

Please note these changes are BC-breaking and hence we further update the version used for vocab serialization.

Furthermore, we added and modified vocab unit tests to check the added functionality.

- [ ] Re-design functionalities around `__setitem__`
- [ ] Finalize API for factory functions