### PR TITLE
removing reassignment API from Vocab

### DIFF
--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -36,28 +36,6 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v['a'], 1)
         self.assertEqual(v['b'], 2)
 
-    def test_reassign_token(self):
-        token_to_freq = {'<unk>': 1, 'a': 2, 'b': 2}
-        sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
-        c = OrderedDict(sorted_by_freq_tuples)
-        v = vocab(c, min_freq=1)
-
-        self.assertEqual(v['<unk>'], 2)
-        self.assertEqual(v['a'], 0)
-        self.assertEqual(v['b'], 1)
-        v.reassign_token('<unk>', 0)
-        self.assertEqual(v['<unk>'], 0)
-        self.assertEqual(v['a'], 1)
-        self.assertEqual(v['b'], 2)
-
-        self.assertEqual(v.get_itos(), ['<unk>', 'a', 'b'])
-
-        with self.assertRaises(RuntimeError):
-            v.reassign_token('not in vocab', 0)
-
-        with self.assertRaises(RuntimeError):
-            v.reassign_token('<unk>', 3)
-
     def test_default_index(self):
         token_to_freq = {'<unk>': 2, 'a': 2, 'b': 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)

--- a/torchtext/csrc/register_bindings.cpp
+++ b/torchtext/csrc/register_bindings.cpp
@@ -118,7 +118,6 @@ PYBIND11_MODULE(_torchtext, m) {
              const char *buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
              return self->__getitem__(c10::string_view{buffer, (size_t)length});
            })
-      .def("reassign_token", &Vocab::reassign_token)
       .def("insert_token", &Vocab::insert_token)
       .def("set_default_index", &Vocab::set_default_index)
       .def("get_default_index", &Vocab::get_default_index)
@@ -244,7 +243,6 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
       .def("__getitem__",
            [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
                -> int64_t { return self->__getitem__(c10::string_view{item}); })
-      .def("reassign_token", &Vocab::reassign_token)
       .def("insert_token", &Vocab::insert_token)
       .def("__len__", &Vocab::__len__)
       .def("set_default_index", &Vocab::set_default_index)

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -46,7 +46,9 @@ int64_t Vocab::__getitem__(const c10::string_view &token) const {
   return default_index_.value();
 }
 
-void Vocab::set_default_index(c10::optional<int64_t> index) { default_index_ = index; }
+void Vocab::set_default_index(c10::optional<int64_t> index) {
+  default_index_ = index;
+}
 
 c10::optional<int64_t> Vocab::get_default_index() const {
   return default_index_;
@@ -60,20 +62,6 @@ void Vocab::append_token(const std::string &token) {
                                    std::to_string(stoi_[id]));
 
   _add(token);
-}
-
-void Vocab::reassign_token(const std::string &token, const int64_t &index) {
-  // throw error if index is not valid
-  TORCH_CHECK(index >= 0 && index < __len__(),
-              "Specified index " + std::to_string(index) +
-                  " is out of bounds for vocab of size " +
-                  std::to_string(__len__()));
-
-  // throw error if token not found
-  TORCH_CHECK(__contains__(token), "Token " + token + " not found in Vocab");
-
-  _remove(token);
-  insert_token(token, index);
 }
 
 void Vocab::insert_token(const std::string &token, const int64_t &index) {

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -29,7 +29,6 @@ struct Vocab : torch::CustomClassHolder {
   bool __contains__(const c10::string_view &token) const;
   void set_default_index(c10::optional<int64_t> index);
   c10::optional<int64_t> get_default_index() const;
-  void reassign_token(const std::string &token, const int64_t &index);
   void insert_token(const std::string &token, const int64_t &index);
   void append_token(const std::string &token);
   std::string lookup_token(const int64_t &index);
@@ -63,14 +62,6 @@ protected:
     if (stoi_[h] == -1) {
       itos_.push_back(w);
       stoi_[h] = itos_.size() - 1;
-    }
-  }
-
-  void _remove(const std::string &w) {
-    uint32_t h = _find(c10::string_view{w.data(), w.size()});
-    if (stoi_[h] != -1) {
-      stoi_[h] = -1;
-      itos_.erase(std::find(itos_.begin(), itos_.end(), w));
     }
   }
 };

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -100,17 +100,6 @@ class Vocab(nn.Module):
         return self.vocab.get_default_index()
 
     @torch.jit.export
-    def reassign_token(self, token: str, index: int) -> None:
-        r"""
-        Args:
-            token: the token used to lookup the corresponding index.
-            index: the index corresponding to the associated token.
-        Raises:
-            RuntimeError: If `index` is not in range [0,Vocab.size()) or if `token` is not present in Vocab
-        """
-        self.vocab.reassign_token(token, index)
-
-    @torch.jit.export
     def insert_token(self, token: str, index: int) -> None:
         r"""
         Args:


### PR DESCRIPTION
We remove the API for reassignment from Vocab as the usage is not so clear and it may confusing functionality to use in practice.