### PR TITLE
adding support for special symbols in Vocab factory functions

### DIFF
--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -225,8 +225,19 @@ class TestVocab(TorchtextTestCase):
     def test_build_vocab_iterator(self):
         iterator = [['hello', 'hello', 'hello', 'freq_low', 'hello', 'world', 'world', 'world', 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T',
                      'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'freq_low', 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T']]
+        specials = ["<unk>", "<bos>", "<eos>", "pad"]
         v = build_vocab_from_iterator(iterator)
         expected_itos = ['ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world', 'freq_low']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+        self.assertEqual(v.get_itos(), expected_itos)
+        self.assertEqual(dict(v.get_stoi()), expected_stoi)
+        v = build_vocab_from_iterator(iterator, specials=specials)
+        expected_itos = specials + ['ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world', 'freq_low']
+        expected_stoi = {x: index for index, x in enumerate(expected_itos)}
+        self.assertEqual(v.get_itos(), expected_itos)
+        self.assertEqual(dict(v.get_stoi()), expected_stoi)
+        v = build_vocab_from_iterator(iterator, specials=specials, special_first=False)
+        expected_itos = ['ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T', 'hello', 'world', 'freq_low'] + specials
         expected_stoi = {x: index for index, x in enumerate(expected_itos)}
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -229,13 +229,16 @@ def vocab(ordered_dict: Dict, min_freq: int = 1) -> Vocab:
     return Vocab(VocabPybind(tokens, None))
 
 
-def build_vocab_from_iterator(iterator: Iterable, min_freq: int = 1) -> Vocab:
+def build_vocab_from_iterator(iterator: Iterable, min_freq: int = 1, specials: Optional[List[str]] = None, special_first: bool = True) -> Vocab:
     """
     Build a Vocab from an iterator.
 
     Args:
         iterator: Iterator used to build Vocab. Must yield list or iterator of tokens.
         min_freq: The minimum frequency needed to include a token in the vocabulary.
+        specials: Special symbols to add. The order of supplied tokens will be preserved.
+        special_first: Indicates whether to insert symbols at the beginning or at the end.
+
 
     Returns:
         torchtext.vocab.Vocab: A `Vocab` object
@@ -248,7 +251,7 @@ def build_vocab_from_iterator(iterator: Iterable, min_freq: int = 1) -> Vocab:
         >>>     with io.open(file_path, encoding = 'utf-8') as f:
         >>>         for line in f:
         >>>             yield line.strip().split()
-        >>> vocab = build_vocab_from_iterator(yield_tokens_batch(file_path))
+        >>> vocab = build_vocab_from_iterator(yield_tokens_batch(file_path), specials=["<unk>"])
     """
 
     counter = Counter()
@@ -256,6 +259,18 @@ def build_vocab_from_iterator(iterator: Iterable, min_freq: int = 1) -> Vocab:
         counter.update(tokens)
     sorted_by_freq_tuples = sorted(counter.items(), key=lambda x: x[1], reverse=True)
     ordered_dict = OrderedDict(sorted_by_freq_tuples)
+
+    if specials is not None:
+        for symbol in specials:
+            if symbol in ordered_dict:
+                del ordered_dict[symbol]
+
+        if special_first:
+            specials = specials[::-1]
+        for symbol in specials:
+            ordered_dict.update({symbol: min_freq})
+            ordered_dict.move_to_end(symbol, last=not special_first)
+
     word_vocab = vocab(ordered_dict, min_freq=min_freq)
     return word_vocab
 

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -185,7 +185,7 @@ class Vocab(nn.Module):
         return self
 
 
-def vocab(ordered_dict: Dict, min_freq: int = 1) -> Vocab:
+def vocab(ordered_dict: Dict, min_freq: int = 1, specials: Optional[List[str]] = None, special_first: bool = True) -> Vocab:
     r"""Factory method for creating a vocab object which maps tokens to indices.
 
     Note that the ordering in which key value pairs were inserted in the `ordered_dict` will be respected when building the vocab.
@@ -194,6 +194,8 @@ def vocab(ordered_dict: Dict, min_freq: int = 1) -> Vocab:
     Args:
         ordered_dict: Ordered Dictionary mapping tokens to their corresponding occurance frequencies.
         min_freq: The minimum frequency needed to include a token in the vocabulary.
+        specials: Special symbols to add. The order of supplied tokens will be preserved.
+        special_first: Indicates whether to insert symbols at the beginning or at the end.
 
     Returns:
         torchtext.vocab.Vocab: A `Vocab` object
@@ -204,8 +206,8 @@ def vocab(ordered_dict: Dict, min_freq: int = 1) -> Vocab:
         >>> counter = Counter(["a", "a", "b", "b", "b"])
         >>> sorted_by_freq_tuples = sorted(counter.items(), key=lambda x: x[1], reverse=True)
         >>> ordered_dict = OrderedDict(sorted_by_freq_tuples)
-        >>> v1 = vocab(ordered_dict)
-        >>> print(v1['a']) #prints 1
+        >>> v1 = vocab(ordered_dict, specials=["<unk>"])
+        >>> print(v1['a']) #prints 2
         >>> print(v1['out of vocab']) #raise RuntimeError since default index is not set
         >>> tokens = ['e', 'd', 'c', 'b', 'a']
         >>> v2 = vocab(OrderedDict([(token, 1) for token in tokens]))
@@ -220,6 +222,16 @@ def vocab(ordered_dict: Dict, min_freq: int = 1) -> Vocab:
         >>> v2.set_default_index(v2[unk_token])
         >>> v2['out of vocab'] is v2[unk_token] #prints True
     """
+    if specials is not None:
+        for symbol in specials:
+            if symbol in ordered_dict:
+                del ordered_dict[symbol]
+
+        if special_first:
+            specials = specials[::-1]
+        for symbol in specials:
+            ordered_dict.update({symbol: min_freq})
+            ordered_dict.move_to_end(symbol, last=not special_first)
 
     tokens = []
     for token, freq in ordered_dict.items():
@@ -259,19 +271,7 @@ def build_vocab_from_iterator(iterator: Iterable, min_freq: int = 1, specials: O
         counter.update(tokens)
     sorted_by_freq_tuples = sorted(counter.items(), key=lambda x: x[1], reverse=True)
     ordered_dict = OrderedDict(sorted_by_freq_tuples)
-
-    if specials is not None:
-        for symbol in specials:
-            if symbol in ordered_dict:
-                del ordered_dict[symbol]
-
-        if special_first:
-            specials = specials[::-1]
-        for symbol in specials:
-            ordered_dict.update({symbol: min_freq})
-            ordered_dict.move_to_end(symbol, last=not special_first)
-
-    word_vocab = vocab(ordered_dict, min_freq=min_freq)
+    word_vocab = vocab(ordered_dict, min_freq=min_freq, specials=specials, special_first=special_first)
     return word_vocab
 
 


### PR DESCRIPTION
We have ongoing discussions here  #1016 and here #1305 

Although it is not yet clear what is the ideal API for factory functions, we think that providing optional arguments for adding specials at the start or end of Vocabulary can help improve user experience compared to when user is not provided with any options. In this PR we add option to provide special symbols through factory API with the constrain that they can either be added at the end or at the beginning. The order of provided special symbols will be preserved. 