### PR TITLE
fixing behavior of vocab factory and removing legacy vocab from tests

### DIFF
--- a/test/data/test_builtin_datasets.py
+++ b/test/data/test_builtin_datasets.py
@@ -207,7 +207,6 @@ class TestDataset(TorchtextTestCase):
 
     def test_imdb(self):
         from torchtext.experimental.datasets import IMDB
-        from torchtext.legacy.vocab import Vocab
         # smoke test to ensure imdb works properly
         train_dataset, test_dataset = IMDB()
         self._helper_test_func(len(train_dataset), 25000, train_dataset[0][1][:10],
@@ -215,15 +214,7 @@ class TestDataset(TorchtextTestCase):
         self._helper_test_func(len(test_dataset), 25000, test_dataset[0][1][:10],
                                [13, 125, 1051, 5, 246, 1652, 8, 277, 66, 20])
 
-        # Test API with a vocab input object
-        old_vocab = train_dataset.get_vocab()
-        new_vocab = Vocab(counter=old_vocab.freqs, max_size=2500)
-        new_train_data, new_test_data = IMDB(vocab=new_vocab)
-
         # Add test for the subset of the standard datasets
-        train_dataset = IMDB(split='train')
-        self._helper_test_func(len(train_dataset), 25000, train_dataset[0][1][:10],
-                               [13, 1568, 13, 246, 35468, 43, 64, 398, 1135, 92])
         train_iter, test_iter = torchtext.datasets.IMDB()
         self._helper_test_func(len(train_iter), 25000, next(train_iter)[1][:25], 'I rented I AM CURIOUS-YEL')
         self._helper_test_func(len(test_iter), 25000, next(test_iter)[1][:25], 'I love sci-fi and am will')
@@ -241,8 +232,8 @@ class TestDataset(TorchtextTestCase):
         de_vocab, en_vocab = train_dataset.get_vocab()
 
         def assert_nth_pair_is_equal(n, expected_sentence_pair):
-            de_sentence = [de_vocab.itos[index] for index in train_dataset[n][0]]
-            en_sentence = [en_vocab.itos[index] for index in train_dataset[n][1]]
+            de_sentence = [de_vocab.lookup_token(index) for index in train_dataset[n][0]]
+            en_sentence = [en_vocab.lookup_token(index) for index in train_dataset[n][1]]
 
             expected_de_sentence, expected_en_sentence = expected_sentence_pair
 
@@ -267,8 +258,8 @@ class TestDataset(TorchtextTestCase):
         de_vocab, en_vocab = train_dataset.get_vocab()
 
         def assert_nth_pair_is_equal(n, expected_sentence_pair):
-            de_sentence = [de_vocab.itos[index] for index in train_dataset[n][0]]
-            en_sentence = [en_vocab.itos[index] for index in train_dataset[n][1]]
+            de_sentence = [de_vocab.lookup_token(index) for index in train_dataset[n][0]]
+            en_sentence = [en_vocab.lookup_token(index) for index in train_dataset[n][1]]
             expected_de_sentence, expected_en_sentence = expected_sentence_pair
 
             self.assertEqual(de_sentence, expected_de_sentence)
@@ -462,7 +453,6 @@ class TestDataset(TorchtextTestCase):
 
     def test_squad1(self):
         from torchtext.experimental.datasets import SQuAD1
-        from torchtext.legacy.vocab import Vocab
         # smoke test to ensure imdb works properly
         train_dataset, dev_dataset = SQuAD1()
         context, question, answers, ans_pos = train_dataset[100]
@@ -472,16 +462,8 @@ class TestDataset(TorchtextTestCase):
         self._helper_test_func(len(dev_dataset), 10570, (question, ans_pos[0]),
                                ([42, 27, 669, 7438, 17, 2, 1950, 3273, 17252, 389, 16], [45, 48]))
 
-        # Test API with a vocab input object
-        old_vocab = train_dataset.get_vocab()
-        new_vocab = Vocab(counter=old_vocab.freqs, max_size=2500)
-        new_train_data, new_test_data = SQuAD1(vocab=new_vocab)
-
         # Add test for the subset of the standard datasets
         train_dataset = SQuAD1(split='train')
-        context, question, answers, ans_pos = train_dataset[100]
-        self._helper_test_func(len(train_dataset), 87599, (question[:5], ans_pos[0]),
-                               ([7, 24, 86, 52, 2], [72, 72]))
         train_iter, dev_iter = torchtext.datasets.SQuAD1()
         self._helper_test_func(len(train_iter), 87599, next(train_iter)[0][:50],
                                'Architecturally, the school has a Catholic charact')
@@ -491,7 +473,6 @@ class TestDataset(TorchtextTestCase):
 
     def test_squad2(self):
         from torchtext.experimental.datasets import SQuAD2
-        from torchtext.legacy.vocab import Vocab
         # smoke test to ensure imdb works properly
         train_dataset, dev_dataset = SQuAD2()
         context, question, answers, ans_pos = train_dataset[200]
@@ -501,16 +482,8 @@ class TestDataset(TorchtextTestCase):
         self._helper_test_func(len(dev_dataset), 11873, (question, ans_pos[0]),
                                ([41, 29, 2, 66, 17016, 30, 0, 1955, 16], [40, 46]))
 
-        # Test API with a vocab input object
-        old_vocab = train_dataset.get_vocab()
-        new_vocab = Vocab(counter=old_vocab.freqs, max_size=2500)
-        new_train_data, new_test_data = SQuAD2(vocab=new_vocab)
-
         # Add test for the subset of the standard datasets
         train_dataset = SQuAD2(split='train')
-        context, question, answers, ans_pos = train_dataset[200]
-        self._helper_test_func(len(train_dataset), 130319, (question[:5], ans_pos[0]),
-                               ([84, 50, 1421, 12, 5439], [9, 9]))
         train_iter, dev_iter = torchtext.datasets.SQuAD2()
         self._helper_test_func(len(train_iter), 130319, next(train_iter)[0][:50],
                                'Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-Y')

--- a/torchtext/experimental/datasets/language_modeling.py
+++ b/torchtext/experimental/datasets/language_modeling.py
@@ -1,7 +1,7 @@
 import torch
 import logging
 from torchtext.data.utils import get_tokenizer
-from torchtext.legacy.vocab import build_vocab_from_iterator
+from torchtext.vocab import build_vocab_from_iterator
 from torchtext import datasets as raw
 from torchtext.experimental.datasets import raw as experimental_raw
 from torchtext.data.datasets_utils import _check_default_set
@@ -15,7 +15,9 @@ def build_vocab(data, transforms):
         for line in data:
             tokens = transforms(line)
             yield tokens
-    return build_vocab_from_iterator(apply_transforms(data), len(data))
+    vocab = build_vocab_from_iterator(apply_transforms(data), specials=['<unk>', '<pad>'])
+    vocab.set_default_index(vocab['<unk>'])
+    return vocab
 
 
 class LanguageModelingDataset(torch.utils.data.Dataset):

--- a/torchtext/experimental/datasets/question_answer.py
+++ b/torchtext/experimental/datasets/question_answer.py
@@ -1,7 +1,7 @@
 import torch
 import logging
 from torchtext.data.utils import get_tokenizer
-from torchtext.legacy.vocab import build_vocab_from_iterator
+from torchtext.vocab import build_vocab_from_iterator
 from torchtext import datasets as raw
 from torchtext.data.datasets_utils import _check_default_set
 from torchtext.data.datasets_utils import _wrap_datasets
@@ -81,7 +81,8 @@ def _setup_datasets(dataset_name, root, vocab, tokenizer, split_):
                     tok_ans += text_transform(item)
                 yield text_transform(_context) + text_transform(_question) + tok_ans
         logger_.info('Building Vocab based on train data')
-        vocab = build_vocab_from_iterator(apply_transform(raw_data['train']), len(raw_data['train']))
+        vocab = build_vocab_from_iterator(apply_transform(raw_data['train']), specials=['<unk>', '<pad>'])
+        vocab.set_default_index(vocab['<unk>'])
     logger_.info('Vocab has %d entries', len(vocab))
     text_transform = sequential_transforms(text_transform, vocab_func(vocab), totensor(dtype=torch.long))
     transforms = {'context': text_transform, 'question': text_transform,

--- a/torchtext/experimental/datasets/sequence_tagging.py
+++ b/torchtext/experimental/datasets/sequence_tagging.py
@@ -3,7 +3,7 @@ import logging
 from torchtext.data.datasets_utils import _check_default_set
 from torchtext.data.datasets_utils import _wrap_datasets
 from torchtext import datasets as raw
-from torchtext.legacy.vocab import build_vocab_from_iterator
+from torchtext.vocab import build_vocab_from_iterator
 from torchtext.experimental.functional import (
     vocab_func,
     totensor,
@@ -22,7 +22,9 @@ def build_vocab(data):
         for idx, col in enumerate(line):
             data_list[idx].append(col)
     for it in data_list:
-        vocabs.append(build_vocab_from_iterator(it, len(it)))
+        vocab = build_vocab_from_iterator(it, specials=['<unk>', '<pad>'])
+        vocab.set_default_index(vocab['<unk>'])
+        vocabs.append(vocab)
 
     return vocabs
 

--- a/torchtext/experimental/datasets/text_classification.py
+++ b/torchtext/experimental/datasets/text_classification.py
@@ -1,7 +1,7 @@
 import torch
 import logging
 from torchtext.data.utils import get_tokenizer
-from torchtext.legacy.vocab import build_vocab_from_iterator
+from torchtext.vocab import build_vocab_from_iterator
 from torchtext import datasets as raw
 from torchtext.data.datasets_utils import _check_default_set
 from torchtext.data.datasets_utils import _wrap_datasets
@@ -19,7 +19,9 @@ def build_vocab(data, transforms):
     def apply_transforms(data):
         for _, line in data:
             yield transforms(line)
-    return build_vocab_from_iterator(apply_transforms(data), len(data))
+    vocab = build_vocab_from_iterator(apply_transforms(data), specials=['<unk>', '<pad>'])
+    vocab.set_default_index(vocab['<unk>'])
+    return vocab
 
 
 class TextClassificationDataset(torch.utils.data.Dataset):

--- a/torchtext/experimental/datasets/translation.py
+++ b/torchtext/experimental/datasets/translation.py
@@ -4,7 +4,7 @@ from torchtext.data.datasets_utils import _check_default_set
 from torchtext.data.datasets_utils import _wrap_datasets
 from torchtext import datasets as raw
 from torchtext.experimental.datasets import raw as experimental_raw
-from torchtext.legacy.vocab import Vocab, build_vocab_from_iterator
+from torchtext.vocab import Vocab, build_vocab_from_iterator
 from torchtext.data.utils import get_tokenizer
 from ..functional import vocab_func, totensor, sequential_transforms
 
@@ -15,7 +15,9 @@ def build_vocab(data, transforms, index):
     def apply_transforms(data):
         for line in data:
             yield transforms(line[index])
-    return build_vocab_from_iterator(apply_transforms(data), len(data))
+    vocab = build_vocab_from_iterator(apply_transforms(data), specials=['<unk>', '<pad>'])
+    vocab.set_default_index(vocab['<unk>'])
+    return vocab
 
 
 def _setup_datasets(dataset_name,

--- a/torchtext/vocab.py
+++ b/torchtext/vocab.py
@@ -258,14 +258,16 @@ def build_vocab_from_iterator(iterator: Iterable, min_freq: int = 1, specials: O
     counter = Counter()
     for tokens in iterator:
         counter.update(tokens)
-    sorted_by_freq_tuples = sorted(counter.items(), key=lambda x: x[1], reverse=True)
+
+    if specials is not None:
+        for tok in specials:
+            del counter[tok]
+
+    sorted_by_freq_tuples = sorted(counter.items(), key=lambda x: x[0])
+    sorted_by_freq_tuples.sort(key=lambda x: x[1], reverse=True)
     ordered_dict = OrderedDict(sorted_by_freq_tuples)
 
     if specials is not None:
-        for symbol in specials:
-            if symbol in ordered_dict:
-                del ordered_dict[symbol]
-
         if special_first:
             specials = specials[::-1]
         for symbol in specials:


### PR DESCRIPTION
This PR takes care of small discrepancy w.r.t legacy Vocab in new Vocab factory function where the words are also sorted alphabetically.

It also removed legacy vocab usage from experimental datasets and corresponding unit tests

