### PR TITLE
Some simple c++ refactoring

### DIFF
--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -100,7 +100,7 @@ PYBIND11_MODULE(_torchtext, m) {
           },
           // __setstate__
           [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
-            return _deserialize_vectors(std::move(states));
+            return _deserialize_vectors(states);
           }));
 
   py::class_<Vocab, c10::intrusive_ptr<Vocab>>(m, "Vocab")
@@ -149,7 +149,7 @@ PYBIND11_MODULE(_torchtext, m) {
           },
           // __setstate__
           [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
-            return _deserialize_vocab(std::move(states));
+            return _deserialize_vocab(states);
           }));
 
   // Functions
@@ -159,127 +159,6 @@ PYBIND11_MODULE(_torchtext, m) {
   m.def("_build_vocab_from_text_file", &build_vocab_from_text_file);
   m.def("_build_vocab_from_text_file_using_python_tokenizer",
         &_build_vocab_from_text_file_using_python_tokenizer);
-  m.def("_build_vocab_from_text_file_using_python_tokenizer", &_build_vocab_from_text_file_using_python_tokenizer);
-}
-
-TORCH_LIBRARY_FRAGMENT(torchtext, m) {
-  m.class_<Regex>("Regex")
-      .def(torch::init<std::string>())
-      .def("Sub", &Regex::Sub)
-      .def_pickle(
-          // __getstate__
-          [](const c10::intrusive_ptr<Regex> &self) -> std::string {
-            return _serialize_regex(self);
-          },
-          // __setstate__
-          [](std::string state) -> c10::intrusive_ptr<Regex> {
-            return _deserialize_regex(std::move(state));
-          });
-
-  m.class_<RegexTokenizer>("RegexTokenizer")
-      .def(torch::init<std::vector<std::string>, std::vector<std::string>,
-                       bool>())
-      .def("forward", &RegexTokenizer::forward)
-      .def_pickle(
-          // __getstate__
-          [](const c10::intrusive_ptr<RegexTokenizer> &self)
-              -> RegexTokenizerStates {
-            return _serialize_regex_tokenizer(self);
-          },
-          // __setstate__
-          [](RegexTokenizerStates states)
-              -> c10::intrusive_ptr<RegexTokenizer> {
-            return _deserialize_regex_tokenizer(std::move(states));
-          });
-
-  m.class_<SentencePiece>("SentencePiece")
-      .def(torch::init<std::string>())
-      .def("Encode", &SentencePiece::Encode)
-      .def("EncodeAsIds", &SentencePiece::EncodeAsIds)
-      .def("DecodeIds", &SentencePiece::DecodeIds)
-      .def("EncodeAsPieces", &SentencePiece::EncodeAsPieces)
-      .def("DecodePieces", &SentencePiece::DecodePieces)
-      .def("GetPieceSize", &SentencePiece::GetPieceSize)
-      .def("unk_id", &SentencePiece::unk_id)
-      .def("PieceToId", &SentencePiece::PieceToId)
-      .def("IdToPiece", &SentencePiece::IdToPiece)
-      .def_pickle(
-          // The underlying content of SentencePiece contains byte string,
-          // and returing it as std::string cause UTF8 decoding error.
-          // Since TorchScript does not support byte string, we use byte Tensor
-          // to pass around the data.
-          // __getstate__
-          [](const c10::intrusive_ptr<SentencePiece> &self) -> torch::Tensor {
-            auto *data =
-                static_cast<void *>(const_cast<char *>(self->content_.data()));
-            auto numel = static_cast<int64_t>(self->content_.size());
-            return torch::from_blob(data, {numel}, {torch::kUInt8}).clone();
-          },
-          // __setstate__
-          [](torch::Tensor state) -> c10::intrusive_ptr<SentencePiece> {
-            auto *data = static_cast<char *>(state.data_ptr());
-            auto numel = state.size(0);
-            return c10::make_intrusive<SentencePiece>(std::string(data, numel));
-          });
-
-  m.class_<Vectors>("Vectors")
-      .def(torch::init<std::vector<std::string>, std::vector<std::int64_t>,
-                       torch::Tensor, torch::Tensor>())
-      .def("__getitem__", &Vectors::__getitem__)
-      .def("lookup_vectors", &Vectors::lookup_vectors)
-      .def("__setitem__", &Vectors::__setitem__)
-      .def("__len__", &Vectors::__len__)
-      .def_pickle(
-          // __getstate__
-          [](const c10::intrusive_ptr<Vectors> &self) -> VectorsStates {
-            return _serialize_vectors(self);
-          },
-          // __setstate__
-          [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
-            return _deserialize_vectors(std::move(states));
-          });
-
-  m.class_<Vocab>("Vocab")
-      .def(torch::init<StringList, c10::optional<int64_t>>())
-      .def("__contains__",
-           [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
-               -> bool { return self->__contains__(c10::string_view{item}); })
-      .def("__getitem__",
-           [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
-               -> int64_t { return self->__getitem__(c10::string_view{item}); })
-      .def("insert_token", &Vocab::insert_token)
-      .def("__len__", &Vocab::__len__)
-      .def("set_default_index", &Vocab::set_default_index)
-      .def("get_default_index", &Vocab::get_default_index)
-      .def("append_token", &Vocab::append_token)
-      .def("lookup_token", &Vocab::lookup_token)
-      .def("lookup_tokens", &Vocab::lookup_tokens)
-      .def("lookup_indices",
-           [](const c10::intrusive_ptr<Vocab> &self,
-              const std::vector<std::string> &items) {
-             std::vector<int64_t> indices(items.size());
-             int64_t counter = 0;
-             for (const auto &item : items) {
-               indices[counter++] = self->__getitem__(c10::string_view{item});
-             }
-             return indices;
-           })
-      .def("get_stoi", &Vocab::get_stoi)
-      .def("get_itos", &Vocab::get_itos)
-      .def_pickle(
-          // __getstate__
-          [](const c10::intrusive_ptr<Vocab> &self) -> VocabStates {
-            return _serialize_vocab(self);
-          },
-          // __setstate__
-          [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
-            return _deserialize_vocab(std::move(states));
-          });
-
-  m.def("torchtext::generate_sp_model", &generate_sp_model);
-  m.def("torchtext::load_sp_model", &load_sp_model);
-  m.def("torchtext::load_sp_model_string", &load_sp_model_string);
->>>>>>> 1c8cd01e (more std::move):torchtext/csrc/register_bindings.cpp
 }
 
 } // namespace torchtext

--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -100,7 +100,7 @@ PYBIND11_MODULE(_torchtext, m) {
           },
           // __setstate__
           [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
-            return _deserialize_vectors(states);
+            return _deserialize_vectors(std::move(states));
           }));
 
   py::class_<Vocab, c10::intrusive_ptr<Vocab>>(m, "Vocab")
@@ -149,7 +149,7 @@ PYBIND11_MODULE(_torchtext, m) {
           },
           // __setstate__
           [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
-            return _deserialize_vocab(states);
+            return _deserialize_vocab(std::move(states));
           }));
 
   // Functions
@@ -159,6 +159,127 @@ PYBIND11_MODULE(_torchtext, m) {
   m.def("_build_vocab_from_text_file", &build_vocab_from_text_file);
   m.def("_build_vocab_from_text_file_using_python_tokenizer",
         &_build_vocab_from_text_file_using_python_tokenizer);
+  m.def("_build_vocab_from_text_file_using_python_tokenizer", &_build_vocab_from_text_file_using_python_tokenizer);
+}
+
+TORCH_LIBRARY_FRAGMENT(torchtext, m) {
+  m.class_<Regex>("Regex")
+      .def(torch::init<std::string>())
+      .def("Sub", &Regex::Sub)
+      .def_pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<Regex> &self) -> std::string {
+            return _serialize_regex(self);
+          },
+          // __setstate__
+          [](std::string state) -> c10::intrusive_ptr<Regex> {
+            return _deserialize_regex(std::move(state));
+          });
+
+  m.class_<RegexTokenizer>("RegexTokenizer")
+      .def(torch::init<std::vector<std::string>, std::vector<std::string>,
+                       bool>())
+      .def("forward", &RegexTokenizer::forward)
+      .def_pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<RegexTokenizer> &self)
+              -> RegexTokenizerStates {
+            return _serialize_regex_tokenizer(self);
+          },
+          // __setstate__
+          [](RegexTokenizerStates states)
+              -> c10::intrusive_ptr<RegexTokenizer> {
+            return _deserialize_regex_tokenizer(std::move(states));
+          });
+
+  m.class_<SentencePiece>("SentencePiece")
+      .def(torch::init<std::string>())
+      .def("Encode", &SentencePiece::Encode)
+      .def("EncodeAsIds", &SentencePiece::EncodeAsIds)
+      .def("DecodeIds", &SentencePiece::DecodeIds)
+      .def("EncodeAsPieces", &SentencePiece::EncodeAsPieces)
+      .def("DecodePieces", &SentencePiece::DecodePieces)
+      .def("GetPieceSize", &SentencePiece::GetPieceSize)
+      .def("unk_id", &SentencePiece::unk_id)
+      .def("PieceToId", &SentencePiece::PieceToId)
+      .def("IdToPiece", &SentencePiece::IdToPiece)
+      .def_pickle(
+          // The underlying content of SentencePiece contains byte string,
+          // and returing it as std::string cause UTF8 decoding error.
+          // Since TorchScript does not support byte string, we use byte Tensor
+          // to pass around the data.
+          // __getstate__
+          [](const c10::intrusive_ptr<SentencePiece> &self) -> torch::Tensor {
+            auto *data =
+                static_cast<void *>(const_cast<char *>(self->content_.data()));
+            auto numel = static_cast<int64_t>(self->content_.size());
+            return torch::from_blob(data, {numel}, {torch::kUInt8}).clone();
+          },
+          // __setstate__
+          [](torch::Tensor state) -> c10::intrusive_ptr<SentencePiece> {
+            auto *data = static_cast<char *>(state.data_ptr());
+            auto numel = state.size(0);
+            return c10::make_intrusive<SentencePiece>(std::string(data, numel));
+          });
+
+  m.class_<Vectors>("Vectors")
+      .def(torch::init<std::vector<std::string>, std::vector<std::int64_t>,
+                       torch::Tensor, torch::Tensor>())
+      .def("__getitem__", &Vectors::__getitem__)
+      .def("lookup_vectors", &Vectors::lookup_vectors)
+      .def("__setitem__", &Vectors::__setitem__)
+      .def("__len__", &Vectors::__len__)
+      .def_pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<Vectors> &self) -> VectorsStates {
+            return _serialize_vectors(self);
+          },
+          // __setstate__
+          [](VectorsStates states) -> c10::intrusive_ptr<Vectors> {
+            return _deserialize_vectors(std::move(states));
+          });
+
+  m.class_<Vocab>("Vocab")
+      .def(torch::init<StringList, c10::optional<int64_t>>())
+      .def("__contains__",
+           [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
+               -> bool { return self->__contains__(c10::string_view{item}); })
+      .def("__getitem__",
+           [](const c10::intrusive_ptr<Vocab> &self, const std::string &item)
+               -> int64_t { return self->__getitem__(c10::string_view{item}); })
+      .def("insert_token", &Vocab::insert_token)
+      .def("__len__", &Vocab::__len__)
+      .def("set_default_index", &Vocab::set_default_index)
+      .def("get_default_index", &Vocab::get_default_index)
+      .def("append_token", &Vocab::append_token)
+      .def("lookup_token", &Vocab::lookup_token)
+      .def("lookup_tokens", &Vocab::lookup_tokens)
+      .def("lookup_indices",
+           [](const c10::intrusive_ptr<Vocab> &self,
+              const std::vector<std::string> &items) {
+             std::vector<int64_t> indices(items.size());
+             int64_t counter = 0;
+             for (const auto &item : items) {
+               indices[counter++] = self->__getitem__(c10::string_view{item});
+             }
+             return indices;
+           })
+      .def("get_stoi", &Vocab::get_stoi)
+      .def("get_itos", &Vocab::get_itos)
+      .def_pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<Vocab> &self) -> VocabStates {
+            return _serialize_vocab(self);
+          },
+          // __setstate__
+          [](VocabStates states) -> c10::intrusive_ptr<Vocab> {
+            return _deserialize_vocab(std::move(states));
+          });
+
+  m.def("torchtext::generate_sp_model", &generate_sp_model);
+  m.def("torchtext::load_sp_model", &load_sp_model);
+  m.def("torchtext::load_sp_model_string", &load_sp_model_string);
+>>>>>>> 1c8cd01e (more std::move):torchtext/csrc/register_bindings.cpp
 }
 
 } // namespace torchtext

--- a/torchtext/csrc/sentencepiece.cpp
+++ b/torchtext/csrc/sentencepiece.cpp
@@ -75,7 +75,7 @@ c10::intrusive_ptr<SentencePiece> load_sp_model(const std::string &path) {
 }
 
 c10::intrusive_ptr<SentencePiece>
-load_sp_model_string(const std::string &content) {
+load_sp_model_string(std::string content) {
   return c10::make_intrusive<SentencePiece>(std::move(content));
 }
 

--- a/torchtext/csrc/sentencepiece.h
+++ b/torchtext/csrc/sentencepiece.h
@@ -33,6 +33,6 @@ void generate_sp_model(const std::string &filename, const int64_t &vocab_size,
                        const std::string &model_prefix);
 c10::intrusive_ptr<SentencePiece> load_sp_model(const std::string &path);
 c10::intrusive_ptr<SentencePiece>
-load_sp_model_string(const std::string &content);
+load_sp_model_string(std::string content);
 
 } // namespace torchtext

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -206,7 +206,7 @@ _concat_vectors(std::vector<std::shared_ptr<StringList>> chunk_tokens,
 
 constexpr int64_t GRAIN_SIZE = 131072;
 std::tuple<Vectors, std::vector<std::string>> _load_token_and_vectors_from_file(
-    const std::string &file_path, const std::string delimiter_str,
+    const std::string &file_path, const std::string &delimiter_str,
     int64_t num_cpus, c10::optional<torch::Tensor> opt_unk_tensor) {
 
   TORCH_CHECK(delimiter_str.size() == 1,

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -15,13 +15,13 @@
 
 namespace torchtext {
 
-Vectors::Vectors(const IndexMap &stoi, const torch::Tensor &vectors,
-                 const torch::Tensor &unk_tensor)
-    : stoi_(stoi), vectors_(vectors), unk_tensor_(unk_tensor) {}
+Vectors::Vectors(const IndexMap &stoi, torch::Tensor vectors,
+                 torch::Tensor unk_tensor)
+    : stoi_(stoi), vectors_(std::move(vectors)), unk_tensor_(std::move(unk_tensor)) {}
 
 Vectors::Vectors(const std::vector<std::string> &tokens,
                  const std::vector<std::int64_t> &indices,
-                 const torch::Tensor &vectors, const torch::Tensor &unk_tensor)
+                 torch::Tensor vectors, torch::Tensor unk_tensor)
     : vectors_(std::move(vectors)), unk_tensor_(std::move(unk_tensor)) {
   // guarding against size mismatch of tokens and indices
   if (static_cast<int>(tokens.size()) != indices.size()) {

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -24,7 +24,7 @@ Vectors::Vectors(const std::vector<std::string> &tokens,
                  torch::Tensor vectors, torch::Tensor unk_tensor)
     : vectors_(std::move(vectors)), unk_tensor_(std::move(unk_tensor)) {
   // guarding against size mismatch of tokens and indices
-  if (static_cast<int>(tokens.size()) != indices.size()) {
+  if (tokens.size() != indices.size()) {
 #ifdef _MSC_VER
     std::cerr << "[RuntimeError] Mismatching sizes for tokens and indices. "
                  "Size of tokens: "

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -15,7 +15,7 @@
 
 namespace torchtext {
 
-Vectors::Vectors(const IndexMap &stoi, const torch::Tensor vectors,
+Vectors::Vectors(const IndexMap &stoi, const torch::Tensor &vectors,
                  const torch::Tensor &unk_tensor)
     : stoi_(stoi), vectors_(vectors), unk_tensor_(unk_tensor) {}
 

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -265,7 +265,7 @@ std::tuple<Vectors, std::vector<std::string>> _load_token_and_vectors_from_file(
 
   torch::Tensor unk_tensor;
   if (opt_unk_tensor) {
-    unk_tensor = *opt_unk_tensor;
+    unk_tensor = std::move(*opt_unk_tensor);
   } else {
     unk_tensor = torch::zeros({vector_dim}, torch::kFloat32);
   }

--- a/torchtext/csrc/vectors.cpp
+++ b/torchtext/csrc/vectors.cpp
@@ -72,7 +72,7 @@ torch::Tensor Vectors::__getitem__(const std::string &token) {
 torch::Tensor Vectors::lookup_vectors(const std::vector<std::string> &tokens) {
   std::vector<torch::Tensor> vectors;
   for (const std::string &token : tokens) {
-    vectors.push_back(__getitem__(token));
+    vectors.emplace_back(__getitem__(token));
   }
   return torch::stack(vectors, 0);
 }

--- a/torchtext/csrc/vectors.h
+++ b/torchtext/csrc/vectors.h
@@ -19,7 +19,7 @@ public:
   torch::Tensor vectors_;
   torch::Tensor unk_tensor_;
 
-  explicit Vectors(const IndexMap &stoi, const torch::Tensor vectors,
+  explicit Vectors(const IndexMap &stoi, const torch::Tensor &vectors,
                    const torch::Tensor &unk_tensor);
   explicit Vectors(const std::vector<std::string> &tokens,
                    const std::vector<std::int64_t> &indices,

--- a/torchtext/csrc/vectors.h
+++ b/torchtext/csrc/vectors.h
@@ -19,12 +19,12 @@ public:
   torch::Tensor vectors_;
   torch::Tensor unk_tensor_;
 
-  explicit Vectors(const IndexMap &stoi, const torch::Tensor &vectors,
-                   const torch::Tensor &unk_tensor);
+  explicit Vectors(const IndexMap &stoi, torch::Tensor vectors,
+                   torch::Tensor unk_tensor);
   explicit Vectors(const std::vector<std::string> &tokens,
                    const std::vector<std::int64_t> &indices,
-                   const torch::Tensor &vectors,
-                   const torch::Tensor &unk_tensor);
+                   torch::Tensor vectors,
+                   torch::Tensor unk_tensor);
   std::unordered_map<std::string, int64_t> get_stoi();
   torch::Tensor __getitem__(const std::string &token);
   torch::Tensor lookup_vectors(const std::vector<std::string> &tokens);

--- a/torchtext/csrc/vectors.h
+++ b/torchtext/csrc/vectors.h
@@ -36,7 +36,7 @@ VectorsStates _serialize_vectors(const c10::intrusive_ptr<Vectors> &self);
 c10::intrusive_ptr<Vectors> _deserialize_vectors(VectorsStates states);
 
 std::tuple<Vectors, std::vector<std::string>> _load_token_and_vectors_from_file(
-    const std::string &file_path, const std::string delimiter_str,
+    const std::string &file_path, const std::string &delimiter_str,
     const int64_t num_cpus, c10::optional<torch::Tensor> opt_unk_tensor);
 
 } // namespace torchtext

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -144,7 +144,7 @@ int64_t _infer_lines(const std::string &file_path) {
 
 void parse_vocab_file_chunk(const std::string &file_path, size_t offset,
                             const int64_t start_line, const int64_t end_line,
-                            std::shared_ptr<IndexDict> counter) {
+                            const std::shared_ptr<IndexDict> &counter) {
   std::ifstream fin(file_path, std::ios::in);
   TORCH_CHECK(fin.is_open(), "Cannot open input file " + file_path);
 
@@ -165,7 +165,7 @@ void parse_vocab_file_chunk(const std::string &file_path, size_t offset,
 
 void parse_raw_text_file_chunk(const std::string &file_path, size_t offset,
                                const int64_t start_line, const int64_t end_line,
-                               std::shared_ptr<IndexDict> counter,
+                               const std::shared_ptr<IndexDict> &counter,
                                torch::jit::script::Module &module) {
   std::ifstream fin(file_path, std::ios::in);
   TORCH_CHECK(fin.is_open(), "Cannot open input file " + file_path);

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -335,6 +335,54 @@ Vocab _build_vocab_from_text_file(const std::string &file_path,
   return Vocab(std::move(tokens));
 }
 
+Vocab _build_vocab_from_text_file_using_python_tokenizer(
+    const std::string &file_path, const int64_t min_freq,
+    py::object tokenizer) {
+  // find number of lines
+  int64_t num_lines = _infer_lines(file_path);
+  // Read text from file and add tokens
+  std::ifstream fin(file_path, std::ios::in);
+  TORCH_CHECK(fin.is_open(), "Cannot open input file " + file_path);
+
+  IndexDict counter;
+  std::string line;
+  for (int64_t i = 0; i < num_lines; i++) {
+    std::getline(fin, line);
+    std::vector<std::string> token_list =
+        tokenizer(line).cast<std::vector<std::string>>();
+
+    for (size_t i = 0; i < token_list.size(); i++) {
+      std::string token = token_list[i];
+
+      if (counter.find(token) == counter.end()) {
+        counter[token] = 1;
+      } else {
+        counter[token] += 1;
+      }
+    }
+  }
+
+  // create tokens-frequency pairs
+  std::vector<std::pair<std::string, int64_t>> token_freq_pairs;
+  for (const auto &item : counter) {
+    if (item.second >= min_freq) {
+      token_freq_pairs.push_back(item);
+    }
+  }
+
+  // sort tokens by frequency
+  CompareTokens compare_tokens;
+  std::sort(token_freq_pairs.begin(), token_freq_pairs.end(), compare_tokens);
+
+  // Create final list of tokens
+  StringList tokens;
+  for (auto &token_freq_pair : token_freq_pairs) {
+    tokens.emplace_back(std::move(token_freq_pair.first));
+  }
+
+  return Vocab(std::move(tokens));
+}
+
 VocabStates _serialize_vocab(const c10::intrusive_ptr<Vocab> &self) {
   std::vector<int64_t> integers;
   StringList strings = self->itos_;

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -225,9 +225,11 @@ _concat_tokens(std::vector<std::shared_ptr<IndexDict>> chunk_counters,
   // create token freq pairs
   std::vector<std::pair<std::string, int64_t>> token_freq_pairs;
 
-  for (std::string token : unique_tokens) {
-    token_freq_pairs.push_back(std::make_pair(token, tokens_freq[token]));
+  for (std::string &token : unique_tokens) {
+    auto token_freq = tokens_freq[token];
+    token_freq_pairs.emplace_back(std::move(token), token_freq);
   }
+  unique_tokens.clear();
 
   // sort tokens by freq
   if (sort_tokens) {
@@ -236,9 +238,8 @@ _concat_tokens(std::vector<std::shared_ptr<IndexDict>> chunk_counters,
   }
 
   // update unique tokens with correct order
-  unique_tokens.clear();
-  for (const auto &token_freq_pair : token_freq_pairs) {
-    unique_tokens.push_back(token_freq_pair.first);
+  for (auto &token_freq_pair : token_freq_pairs) {
+    unique_tokens.emplace_back(std::move(token_freq_pair.first));
   }
 
   return unique_tokens;

--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -335,48 +335,6 @@ Vocab _build_vocab_from_text_file(const std::string &file_path,
   return Vocab(std::move(tokens));
 }
 
-Vocab _build_vocab_from_text_file_using_python_tokenizer(
-    const std::string &file_path, const int64_t min_freq,
-    py::object tokenizer) {
-  // find number of lines
-  int64_t num_lines = _infer_lines(file_path);
-  // Read text from file and add tokens
-  std::ifstream fin(file_path, std::ios::in);
-  TORCH_CHECK(fin.is_open(), "Cannot open input file " + file_path);
-
-  IndexDict counter;
-  std::string line;
-  for (int64_t i = 0; i < num_lines; i++) {
-    std::getline(fin, line);
-    std::vector<std::string> token_list =
-        tokenizer(line).cast<std::vector<std::string>>();
-
-    for (auto &token : token_list) {
-      counter[std::move(token)] += 1;
-    }
-  }
-
-  // create tokens-frequency pairs
-  std::vector<std::pair<std::string, int64_t>> token_freq_pairs;
-  for (const auto &item : counter) {
-    if (item.second >= min_freq) {
-      token_freq_pairs.push_back(item);
-    }
-  }
-
-  // sort tokens by frequency
-  CompareTokens compare_tokens;
-  std::sort(token_freq_pairs.begin(), token_freq_pairs.end(), compare_tokens);
-
-  // Create final list of tokens
-  StringList tokens;
-  for (auto &token_freq_pair : token_freq_pairs) {
-    tokens.emplace_back(std::move(token_freq_pair.first));
-  }
-
-  return Vocab(std::move(tokens));
-}
-
 VocabStates _serialize_vocab(const c10::intrusive_ptr<Vocab> &self) {
   std::vector<int64_t> integers;
   StringList strings = self->itos_;

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -36,16 +36,16 @@ struct Vocab : torch::CustomClassHolder {
   // TODO: [can we remove this?] we need to keep this constructor, otherwise
   // torch binding gets compilation error: no matching constructor for
   // initialization of 'torchtext::Vocab'
-  explicit Vocab(const StringList &tokens);
-  explicit Vocab(const StringList &tokens,
+  explicit Vocab(StringList tokens);
+  explicit Vocab(StringList tokens,
                  const c10::optional<int64_t> &default_index);
   int64_t __len__() const;
   int64_t __getitem__(const c10::string_view &token) const;
   bool __contains__(const c10::string_view &token) const;
   void set_default_index(c10::optional<int64_t> index);
   c10::optional<int64_t> get_default_index() const;
-  void insert_token(const std::string &token, const int64_t &index);
-  void append_token(const std::string &token);
+  void insert_token(std::string token, const int64_t &index);
+  void append_token(std::string token);
   std::string lookup_token(const int64_t &index);
   std::vector<std::string> lookup_tokens(const std::vector<int64_t> &indices);
   std::vector<int64_t>
@@ -72,10 +72,10 @@ protected:
     return id;
   }
 
-  void _add(const std::string &w) {
+  void _add(std::string w) {
     uint32_t h = _find(c10::string_view{w.data(), w.size()});
     if (stoi_[h] == -1) {
-      itos_.push_back(w);
+      itos_.emplace_back(std::move(w));
       stoi_[h] = itos_.size() - 1;
     }
   }

--- a/torchtext/csrc/vocab.h
+++ b/torchtext/csrc/vocab.h
@@ -27,7 +27,7 @@ int64_t _infer_lines(const std::string &file_path);
 
 struct Vocab : torch::CustomClassHolder {
   static const int32_t MAX_VOCAB_SIZE = 30000000;
-  int64_t unk_index_;
+  int64_t unk_index_{};
   std::vector<int32_t> stoi_;
   const std::string version_str_ = "0.0.2";
   StringList itos_;


### PR DESCRIPTION
Fix some warnings from clang-tidy due to the lack of parameter reference and using emplace_back to improve performance.