### PR TITLE
DOC: remove git tag from page title

### DIFF
--- a/0.10.0/_modules/index.html
+++ b/0.10.0/_modules/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Overview: module code &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>Overview: module code &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/data/functional.html
+++ b/0.10.0/_modules/torchtext/data/functional.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.data.functional &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.data.functional &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/data/metrics.html
+++ b/0.10.0/_modules/torchtext/data/metrics.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.data.metrics &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.data.metrics &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/data/utils.html
+++ b/0.10.0/_modules/torchtext/data/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.data.utils &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.data.utils &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/ag_news.html
+++ b/0.10.0/_modules/torchtext/datasets/ag_news.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.ag_news &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.ag_news &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/amazonreviewfull.html
+++ b/0.10.0/_modules/torchtext/datasets/amazonreviewfull.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.amazonreviewfull &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.amazonreviewfull &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/amazonreviewpolarity.html
+++ b/0.10.0/_modules/torchtext/datasets/amazonreviewpolarity.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.amazonreviewpolarity &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.amazonreviewpolarity &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/conll2000chunking.html
+++ b/0.10.0/_modules/torchtext/datasets/conll2000chunking.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.conll2000chunking &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.conll2000chunking &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/dbpedia.html
+++ b/0.10.0/_modules/torchtext/datasets/dbpedia.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.dbpedia &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.dbpedia &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/enwik9.html
+++ b/0.10.0/_modules/torchtext/datasets/enwik9.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.enwik9 &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.enwik9 &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/imdb.html
+++ b/0.10.0/_modules/torchtext/datasets/imdb.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.imdb &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.imdb &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/iwslt2016.html
+++ b/0.10.0/_modules/torchtext/datasets/iwslt2016.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.iwslt2016 &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.iwslt2016 &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/iwslt2017.html
+++ b/0.10.0/_modules/torchtext/datasets/iwslt2017.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.iwslt2017 &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.iwslt2017 &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/multi30k.html
+++ b/0.10.0/_modules/torchtext/datasets/multi30k.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.multi30k &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.multi30k &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/penntreebank.html
+++ b/0.10.0/_modules/torchtext/datasets/penntreebank.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.penntreebank &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.penntreebank &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/sogounews.html
+++ b/0.10.0/_modules/torchtext/datasets/sogounews.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.sogounews &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.sogounews &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/squad1.html
+++ b/0.10.0/_modules/torchtext/datasets/squad1.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.squad1 &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.squad1 &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/squad2.html
+++ b/0.10.0/_modules/torchtext/datasets/squad2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.squad2 &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.squad2 &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/udpos.html
+++ b/0.10.0/_modules/torchtext/datasets/udpos.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.udpos &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.udpos &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/wikitext103.html
+++ b/0.10.0/_modules/torchtext/datasets/wikitext103.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.wikitext103 &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.wikitext103 &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/wikitext2.html
+++ b/0.10.0/_modules/torchtext/datasets/wikitext2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.wikitext2 &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.wikitext2 &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/yahooanswers.html
+++ b/0.10.0/_modules/torchtext/datasets/yahooanswers.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.yahooanswers &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.yahooanswers &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/yelpreviewfull.html
+++ b/0.10.0/_modules/torchtext/datasets/yelpreviewfull.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.yelpreviewfull &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.yelpreviewfull &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/datasets/yelpreviewpolarity.html
+++ b/0.10.0/_modules/torchtext/datasets/yelpreviewpolarity.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets.yelpreviewpolarity &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets.yelpreviewpolarity &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/nn/modules/multiheadattention.html
+++ b/0.10.0/_modules/torchtext/nn/modules/multiheadattention.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.nn.modules.multiheadattention &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.nn.modules.multiheadattention &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/utils.html
+++ b/0.10.0/_modules/torchtext/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.utils &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.utils &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/_modules/torchtext/vocab.html
+++ b/0.10.0/_modules/torchtext/vocab.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.vocab &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.vocab &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/data_functional.html
+++ b/0.10.0/data_functional.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.data.functional &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.data.functional &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/data_metrics.html
+++ b/0.10.0/data_metrics.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.data.metrics &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.data.metrics &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/data_utils.html
+++ b/0.10.0/data_utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.data.utils &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.data.utils &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/datasets.html
+++ b/0.10.0/datasets.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.datasets &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.datasets &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/genindex.html
+++ b/0.10.0/genindex.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Index &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>Index &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/index.html
+++ b/0.10.0/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/nn_modules.html
+++ b/0.10.0/nn_modules.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.nn &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.nn &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/py-modindex.html
+++ b/0.10.0/py-modindex.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Python Module Index &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>Python Module Index &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/search.html
+++ b/0.10.0/search.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Search &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>Search &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/utils.html
+++ b/0.10.0/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.utils &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.utils &mdash; torchtext 0.10.0 documentation</title>
   
 
   

--- a/0.10.0/vocab.html
+++ b/0.10.0/vocab.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchtext.vocab &mdash; torchtext 0.11.0a0+e8bb3fc documentation</title>
+  <title>torchtext.vocab &mdash; torchtext 0.10.0 documentation</title>
   
 
   


### PR DESCRIPTION
The page titles (what you see when you hover over the page's tab in the browser) still had the git tag.

for f in $(find . -name "*.html"); do sed -i -e"s/0\.11\.0a0+e8bb3fc/0.10.0/" $f; done