### PR TITLE
up the priority of numpy array comparisons in self.assertEqual (#59067)

### DIFF
--- a/test/legacy/test_vocab.py
+++ b/test/legacy/test_vocab.py
@@ -88,7 +88,7 @@ class TestVocab(TorchtextTestCase):
         expected_vectors = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0],
                                      [0.0, 0.0], [0.1, 0.2], [0.5, 0.6],
                                      [0.3, 0.4]])
-        self.assertEqual(v.vectors, expected_vectors)
+        self.assertEqual(v.vectors, expected_vectors, exact_dtype=False)
 
     def test_errors(self):
         c = Counter({'hello': 4, 'world': 3, 'ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T': 5, 'freq_too_low': 2})


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/58988.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/59067

Reviewed By: jbschlosser

Differential Revision: D28986642

Pulled By: heitorschueroff

