### PR TITLE
Fix IMDB: all samples are positive

### DIFF
--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -4,6 +4,7 @@ from torchtext.data.datasets_utils import _wrap_split_argument
 from torchtext.data.datasets_utils import _add_docstring_header
 from torchtext.data.datasets_utils import _create_dataset_directory
 import io
+from pathlib import Path
 
 URL = 'http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz'
 
@@ -25,11 +26,10 @@ DATASET_NAME = "IMDB"
 def IMDB(root, split):
     def generate_imdb_data(key, extracted_files):
         for fname in extracted_files:
-            if 'urls' in fname:
-                continue
-            elif key in fname and ('pos' in fname or 'neg' in fname):
+            *_, split, label, file = Path(fname).parts
+
+            if key == split and (label in ['pos', 'neg']):
                 with io.open(fname, encoding="utf8") as f:
-                    label = 'pos' if 'pos' in fname else 'neg'
                     yield label, f.read()
     dataset_tar = download_from_url(URL, root=root,
                                     hash_value=MD5, hash_type='md5')


### PR DESCRIPTION
Currently, if the path of the working space as a 'pos' in its name, e.g. '/Users/user/Documents/re**pos**itories/<something> since repositories contains 'pos' all samples will be positive and some files that are not samples will be considered as samples .e.g 'labeledBow.feat'

By using this approach this will no longer be an issue.