### PR TITLE
Fix examples in get_vecs_by_tokens documentation.

### DIFF
--- a/torchtext/vocab/vectors.py
+++ b/torchtext/vocab/vectors.py
@@ -187,7 +187,7 @@ class Vectors(object):
         Examples:
             >>> examples = ['chip', 'baby', 'Beautiful']
             >>> vec = text.vocab.GloVe(name='6B', dim=50)
-            >>> ret = vec.get_vecs_by_tokens(tokens, lower_case_backup=True)
+            >>> ret = vec.get_vecs_by_tokens(examples, lower_case_backup=True)
         """
         to_reduce = False
 


### PR DESCRIPTION
Fix examples in `get_vecs_by_tokens` documentation.