### PR TITLE
Added PCRE library to torchtext

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,9 @@
 	path = third_party/double-conversion
 	url = https://github.com/google/double-conversion
 	ignore = dirty
+[submodule "third_party/pcre"]
+	path = third_party/pcre
+	url = https://github.com/vmg/pcre
+	ignore = dirty
+
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	ignore = dirty
 [submodule "third_party/pcre"]
 	path = third_party/pcre
-	url = https://github.com/vmg/pcre
+	url = https://github.com/vmg/pcre.git
 	ignore = dirty
 
 

--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -103,11 +103,13 @@ def _build_third_party(debug):
     if platform.system() == 'Windows':
         extra_args = [
             '-GNinja',
+            '-DCMAKE_C_FLAGS=-fPIC'
         ]
         build_env.setdefault('CC', 'cl')
         build_env.setdefault('CXX', 'cl')
     else:
-        extra_args = ['-DCMAKE_CXX_FLAGS=-fPIC ' + _get_cxx11_abi(), "-DCMAKE_C_FLAGS=-fPIC"]
+        extra_args = ['-DCMAKE_CXX_FLAGS=-fPIC ' + _get_cxx11_abi(),
+                      '-DCMAKE_C_FLAGS=-fPIC']
     subprocess.run(
         args=[
             'cmake',

--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -79,8 +79,9 @@ def _get_libraries():
     return [
         'sentencepiece_train',
         'sentencepiece',
-        're2',
+        'pcrecpp',
         'pcre',
+        're2',
         'double-conversion',
     ]
 
@@ -106,7 +107,7 @@ def _build_third_party(debug):
         build_env.setdefault('CC', 'cl')
         build_env.setdefault('CXX', 'cl')
     else:
-        extra_args = ['-DCMAKE_CXX_FLAGS=-fPIC ' + _get_cxx11_abi()]
+        extra_args = ['-DCMAKE_CXX_FLAGS=-fPIC ' + _get_cxx11_abi(), "-DCMAKE_C_FLAGS=-fPIC"]
     subprocess.run(
         args=[
             'cmake',

--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -81,6 +81,7 @@ def _get_libraries():
         'sentencepiece',
         're2',
         'double-conversion'
+        'pcre'
     ]
 
 

--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -80,8 +80,8 @@ def _get_libraries():
         'sentencepiece_train',
         'sentencepiece',
         're2',
-        'double-conversion'
-        'pcre'
+        'pcre',
+        'double-conversion',
     ]
 
 

--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -103,7 +103,7 @@ def _build_third_party(debug):
     if platform.system() == 'Windows':
         extra_args = [
             '-GNinja',
-            '-DCMAKE_C_FLAGS=-fPIC'
+            '-DCMAKE_C_FLAGS=-DPCRE_STATIC'
         ]
         build_env.setdefault('CC', 'cl')
         build_env.setdefault('CXX', 'cl')

--- a/test/experimental/test_functional.py
+++ b/test/experimental/test_functional.py
@@ -130,27 +130,27 @@ class TestFunctional(TorchtextTestCase):
             results = loaded_tokenizer(test_sample)
             self.assertEqual(results, ref_results)
 
-    # def test_regex_find_all(self):
-    #     # Use in TorchScript
-    #     @torch.jit.script
-    #     def tokenize(text: str):
-    #         pattern = "(*UCP)(\\'s|\\'t|\\'re|\\'ve|\\'m|\\'ll|\\'d| ?\\pL+|" \
-    #                   " ?\\pN+| ?[^\\s\\pL\\pN]+|\\s+(?!\\S)|\\s+)"
-    #         regex_op = torch.classes.torchtext.Regex(pattern)
-    #         return regex_op.find_all(text)
+    def test_regex_find_all(self):
+        # Use in TorchScript
+        @torch.jit.script
+        def tokenize(text: str):
+            pattern = "(*UCP)(\\'s|\\'t|\\'re|\\'ve|\\'m|\\'ll|\\'d| ?\\pL+|" \
+                      " ?\\pN+| ?[^\\s\\pL\\pN]+|\\s+(?!\\S)|\\s+)"
+            regex_op = torch.classes.torchtext.Regex(pattern)
+            return regex_op.find_all(text)
 
-    #     def py_tokenize(text):
-    #         pat = regex.compile(
-    #             r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"""
-    #         )
-    #         return regex.findall(pat, text)
+        def py_tokenize(text):
+            pat = regex.compile(
+                r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"""
+            )
+            return regex.findall(pat, text)
 
-    #     input_path = (
-    #         "pytorch/text/fb/transforms/tests/data/"
-    #         "test_gpt2_bpe_tokenizer_input.txt"
-    #     )
-    #     with open(input_path, "r") as f:
-    #         for line in f:
-    #             pcre_tokens = tokenize(line[:-1])
-    #             py_tokens = py_tokenize(line[:-1])
-    #             self.assertEqual(pcre_tokens, py_tokens)
+        input_path = (
+            "pytorch/text/fb/transforms/tests/data/"
+            "test_gpt2_bpe_tokenizer_input.txt"
+        )
+        with open(input_path, "r") as f:
+            for line in f:
+                pcre_tokens = tokenize(line[:-1])
+                py_tokens = py_tokenize(line[:-1])
+                self.assertEqual(pcre_tokens, py_tokens)

--- a/test/experimental/test_functional.py
+++ b/test/experimental/test_functional.py
@@ -145,12 +145,12 @@ class TestFunctional(TorchtextTestCase):
             )
             return regex.findall(pat, text)
 
-        input_path = (
-            "pytorch/text/fb/transforms/tests/data/"
-            "test_gpt2_bpe_tokenizer_input.txt"
-        )
-        with open(input_path, "r") as f:
-            for line in f:
-                pcre_tokens = tokenize(line[:-1])
-                py_tokens = py_tokenize(line[:-1])
-                self.assertEqual(pcre_tokens, py_tokens)
+        # test_sample = '\'".<br />,()!?;:   Find all regex matches for a Line of Text   \'".<br />,()!?;:'
+        test_sample = 'We proclaimed sincerely to the public John to be a hero.'
+
+        pcre_tokens = tokenize(test_sample)
+        py_tokens = py_tokenize(test_sample)
+
+        print(pcre_tokens)
+        print(py_tokens)
+        self.assertEqual(pcre_tokens, py_tokens)

--- a/test/experimental/test_functional.py
+++ b/test/experimental/test_functional.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import regex
 import unittest
 
 import torch
@@ -128,3 +129,28 @@ class TestFunctional(TorchtextTestCase):
             loaded_tokenizer = torch.load(save_path)
             results = loaded_tokenizer(test_sample)
             self.assertEqual(results, ref_results)
+
+    # def test_regex_find_all(self):
+    #     # Use in TorchScript
+    #     @torch.jit.script
+    #     def tokenize(text: str):
+    #         pattern = "(*UCP)(\\'s|\\'t|\\'re|\\'ve|\\'m|\\'ll|\\'d| ?\\pL+|" \
+    #                   " ?\\pN+| ?[^\\s\\pL\\pN]+|\\s+(?!\\S)|\\s+)"
+    #         regex_op = torch.classes.torchtext.Regex(pattern)
+    #         return regex_op.find_all(text)
+
+    #     def py_tokenize(text):
+    #         pat = regex.compile(
+    #             r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"""
+    #         )
+    #         return regex.findall(pat, text)
+
+    #     input_path = (
+    #         "pytorch/text/fb/transforms/tests/data/"
+    #         "test_gpt2_bpe_tokenizer_input.txt"
+    #     )
+    #     with open(input_path, "r") as f:
+    #         for line in f:
+    #             pcre_tokens = tokenize(line[:-1])
+    #             py_tokens = py_tokenize(line[:-1])
+    #             self.assertEqual(pcre_tokens, py_tokens)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,6 +8,6 @@ endif()
 project(thirdparty CXX)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+add_subdirectory(pcre)
 add_subdirectory(re2)
 add_subdirectory(double-conversion)
-add_subdirectory(pcre)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -10,3 +10,4 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 add_subdirectory(re2)
 add_subdirectory(double-conversion)
+add_subdirectory(pcre)

--- a/torchtext/csrc/regex.cpp
+++ b/torchtext/csrc/regex.cpp
@@ -2,11 +2,11 @@
 
 namespace torchtext {
 
-Regex::Regex(const std::string& re_str) : re_str_(re_str) {
+Regex::Regex(const std::string &re_str) : re_str_(re_str) {
   compiled_pattern_ = new pcrecpp::RE(re_str_, pcrecpp::UTF8());
 }
 
-std::string Regex::Sub(std::string str, const std::string& repl) const {
+std::string Regex::Sub(std::string str, const std::string &repl) const {
   (*compiled_pattern_).GlobalReplace(repl, &str);
   return str;
 }
@@ -23,11 +23,11 @@ std::vector<std::string> Regex::find_all(std::string input) {
   return tokens;
 }
 
-std::string _serialize_regex(const c10::intrusive_ptr<Regex>& self) {
+std::string _serialize_regex(const c10::intrusive_ptr<Regex> &self) {
   return self->re_str_;
 }
 
-c10::intrusive_ptr<Regex> _deserialize_regex(std::string&& state) {
+c10::intrusive_ptr<Regex> _deserialize_regex(std::string &&state) {
   return c10::make_intrusive<Regex>(std::move(state));
 }
 

--- a/torchtext/csrc/regex.cpp
+++ b/torchtext/csrc/regex.cpp
@@ -3,6 +3,7 @@
 namespace torchtext {
 
 Regex::Regex(const std::string &re_str) : re_str_(re_str) {
+  std::cout << "[re_str] " << re_str << std::endl;
   compiled_pattern_ = new pcrecpp::RE(re_str_, pcrecpp::UTF8());
 }
 
@@ -16,7 +17,9 @@ std::vector<std::string> Regex::find_all(std::string input) {
   std::string token;
   std::vector<std::string> tokens;
 
+  std::cout << "[line] " << line << std::endl;
   while ((*compiled_pattern_).FindAndConsume(&line, &token)) {
+    std::cout << "[token] " << token << std::endl;
     tokens.push_back(token);
   }
 

--- a/torchtext/csrc/regex.h
+++ b/torchtext/csrc/regex.h
@@ -1,3 +1,5 @@
+#define PCRE_STATIC
+
 #include <pcrecpp.h>
 #include <string>
 #include <torch/script.h>

--- a/torchtext/csrc/regex.h
+++ b/torchtext/csrc/regex.h
@@ -1,4 +1,4 @@
-#define PCRE_STATIC
+// #define PCRE_STATIC
 
 #include <pcrecpp.h>
 #include <string>

--- a/torchtext/csrc/regex.h
+++ b/torchtext/csrc/regex.h
@@ -1,17 +1,18 @@
-#include <re2/re2.h>
+#include <pcrecpp.h>
 #include <string>
 #include <torch/script.h>
 
 namespace torchtext {
 struct Regex : torch::CustomClassHolder {
 private:
-  RE2 *compiled_pattern_;
+  pcrecpp::RE *compiled_pattern_;
 
 public:
   std::string re_str_;
 
   Regex(const std::string &re_str);
   std::string Sub(std::string str, const std::string &repl) const;
+  std::vector<std::string> find_all(std::string input);
 };
 
 std::string _serialize_regex(const c10::intrusive_ptr<Regex> &self);

--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -30,6 +30,7 @@ PYBIND11_MODULE(_torchtext, m) {
   py::class_<Regex, c10::intrusive_ptr<Regex>>(m, "Regex")
       .def(py::init<std::string>())
       .def("Sub", &Regex::Sub)
+      .def("find_all", &Regex::find_all)
       .def(py::pickle(
           // __getstate__
           [](const c10::intrusive_ptr<Regex> &self) -> std::string {

--- a/torchtext/csrc/register_torchbindings.cpp
+++ b/torchtext/csrc/register_torchbindings.cpp
@@ -11,6 +11,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
   m.class_<Regex>("Regex")
       .def(torch::init<std::string>())
       .def("Sub", &Regex::Sub)
+      .def("find_all", &Regex::find_all)
       .def_pickle(
           // __getstate__
           [](const c10::intrusive_ptr<Regex> &self) -> std::string {


### PR DESCRIPTION
## Description
- Replacing [`RE2`](https://github.com/google/re2) with [`PCRE`](https://github.com/vmg/pcre) library in `regex.cpp` to support negative look aheads in regex expressions
- Added new `find_all()` function similar to Python's `re.findall()`
- Added unit tests for new function

## Followup
- Followup discussion needed around [regex library performance](https://rust-leipzig.github.io/regex/2017/03/28/comparison-of-regex-engines/#timings) (PCRE vs re2)