### PR TITLE
fix test by adding missing asset label_names.txt

### DIFF
--- a/test/asset/label_names.txt
+++ b/test/asset/label_names.txt
@@ -1,0 +1,3 @@
+test
+label
+indices


### PR DESCRIPTION
Adding missing asset file "label_names.txt" from the repo that lead to failure in "test_labeltoindex" unit test. 