### PR TITLE
add support for not loading weights

### DIFF
--- a/torchtext/models/roberta/bundler.py
+++ b/torchtext/models/roberta/bundler.py
@@ -56,10 +56,10 @@ class RobertaModelBundle:
     _head: Optional[Module] = None
     transform: Optional[Callable] = None
 
-    def get_model(self, load_weights=True, head: Optional[Module] = None, *, dl_kwargs=None) -> RobertaModel:
+    def get_model(self, head: Optional[Module] = None, load_weights=True, *, dl_kwargs=None) -> RobertaModel:
 
         if load_weights:
-            assert self._path is not None, "load_weights cannot be True when _path is not set"
+            assert self._path is not None, "load_weights cannot be True. The pre-trained model weights are not available for the current object"
 
         if head is not None:
             input_head = head


### PR DESCRIPTION
Follow-up on #1406 

We would like to add support for not loading weights from pre-trained models, such that user can still instantiate standard model architectures but without initializing them to support training from scratch.

Example usage:
```python
import torchtext
xlmr_base = torchtext.models.XLMR_BASE_ENCODER
model_uninitialized = xlmr_base.get_model(load_weights=False)
```