### PR TITLE
Update RobertaModel to directly take in configuration

### DIFF
--- a/torchtext/models/roberta/__init__.py
+++ b/torchtext/models/roberta/__init__.py
@@ -1,6 +1,7 @@
 from .model import (
-    RobertaEncoderParams,
+    RobertaEncoderConf,
     RobertaClassificationHead,
+    RobertaModel,
 )
 
 from .bundler import (
@@ -10,8 +11,9 @@ from .bundler import (
 )
 
 __all__ = [
-    "RobertaEncoderParams",
+    "RobertaEncoderConf",
     "RobertaClassificationHead",
+    "RobertaModel",
     "RobertaModelBundle",
     "XLMR_BASE_ENCODER",
     "XLMR_LARGE_ENCODER",

--- a/torchtext/models/roberta/bundler.py
+++ b/torchtext/models/roberta/bundler.py
@@ -55,12 +55,12 @@ class RobertaModelBundle:
         >>> from torchtext.models import RobertaEncoderConf, RobertaModelBundle, RobertaClassificationHead
         >>> model_weights_path = "https://download.pytorch.org/models/text/xlmr.base.encoder.pt"
         >>> roberta_encoder_conf = RobertaEncoderConf(vocab_size=250002)
-        >>> roberta_bundle = RobertaModelBundle(_params=roberta_encoder_conf, _path=model_weights_path)
+        >>> roberta_bundle = RobertaModelBundle(_encoder_conf=roberta_encoder_conf, _path=model_weights_path)
         >>> encoder = roberta_bundle.get_model()
         >>> classifier_head = RobertaClassificationHead(num_classes=2, input_dim=768)
         >>> classifier = roberta_bundle.get_model(head=classifier_head)
     """
-    _params: RobertaEncoderConf
+    _encoder_conf: RobertaEncoderConf
     _path: Optional[str] = None
     _head: Optional[Module] = None
     transform: Optional[Callable] = None
@@ -81,7 +81,7 @@ class RobertaModelBundle:
         else:
             input_head = self._head
 
-        model = _get_model(self._params, input_head, freeze_encoder)
+        model = _get_model(self._encoder_conf, input_head, freeze_encoder)
 
         if not load_weights:
             return model
@@ -95,13 +95,13 @@ class RobertaModelBundle:
         return model
 
     @property
-    def params(self) -> RobertaEncoderConf:
-        return self._params
+    def encoderConf(self) -> RobertaEncoderConf:
+        return self._encoder_conf
 
 
 XLMR_BASE_ENCODER = RobertaModelBundle(
     _path=os.path.join(_TEXT_BUCKET, "xlmr.base.encoder.pt"),
-    _params=RobertaEncoderConf(vocab_size=250002),
+    _encoder_conf=RobertaEncoderConf(vocab_size=250002),
     transform=partial(get_xlmr_transform,
                       vocab_path=os.path.join(_TEXT_BUCKET, "xlmr.vocab.pt"),
                       spm_model_path=os.path.join(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),
@@ -110,7 +110,7 @@ XLMR_BASE_ENCODER = RobertaModelBundle(
 
 XLMR_LARGE_ENCODER = RobertaModelBundle(
     _path=os.path.join(_TEXT_BUCKET, "xlmr.large.encoder.pt"),
-    _params=RobertaEncoderConf(vocab_size=250002, embedding_dim=1024, ffn_dimension=4096, num_attention_heads=16, num_encoder_layers=24),
+    _encoder_conf=RobertaEncoderConf(vocab_size=250002, embedding_dim=1024, ffn_dimension=4096, num_attention_heads=16, num_encoder_layers=24),
     transform=partial(get_xlmr_transform,
                       vocab_path=os.path.join(_TEXT_BUCKET, "xlmr.vocab.pt"),
                       spm_model_path=os.path.join(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),

--- a/torchtext/models/roberta/bundler.py
+++ b/torchtext/models/roberta/bundler.py
@@ -52,7 +52,7 @@ class RobertaModelBundle:
         torch.Size([1, 2])
 
     Example - User-specified configuration and checkpoint
-        >>> from torchtext.models import RobertaEncoderConf, RobertaModelBundle, RobertaClassificationHead 
+        >>> from torchtext.models import RobertaEncoderConf, RobertaModelBundle, RobertaClassificationHead
         >>> model_weights_path = "https://download.pytorch.org/models/text/xlmr.base.encoder.pt"
         >>> roberta_encoder_conf = RobertaEncoderConf(vocab_size=250002)
         >>> roberta_bundle = RobertaModelBundle(_params=roberta_encoder_conf, _path=model_weights_path)

--- a/torchtext/models/roberta/bundler.py
+++ b/torchtext/models/roberta/bundler.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from .model import (
-    RobertaEncoderParams,
+    RobertaEncoderConf,
     RobertaModel,
     _get_model,
 )
@@ -50,8 +50,17 @@ class RobertaModelBundle:
         >>> output = classification_model(model_input)
         >>> output.shape
         torch.Size([1, 2])
+
+    Example - User-specified configuration and checkpoint
+        >>> from torchtext.models import RobertaEncoderConf, RobertaModelBundle, RobertaClassificationHead 
+        >>> model_weights_path = "https://download.pytorch.org/models/text/xlmr.base.encoder.pt"
+        >>> roberta_encoder_conf = RobertaEncoderConf(vocab_size=250002)
+        >>> roberta_bundle = RobertaModelBundle(_params=roberta_encoder_conf, _path=model_weights_path)
+        >>> encoder = roberta_bundle.get_model()
+        >>> classifier_head = RobertaClassificationHead(num_classes=2, input_dim=768)
+        >>> classifier = roberta_bundle.get_model(head=classifier_head)
     """
-    _params: RobertaEncoderParams
+    _params: RobertaEncoderConf
     _path: Optional[str] = None
     _head: Optional[Module] = None
     transform: Optional[Callable] = None
@@ -86,13 +95,13 @@ class RobertaModelBundle:
         return model
 
     @property
-    def params(self) -> RobertaEncoderParams:
+    def params(self) -> RobertaEncoderConf:
         return self._params
 
 
 XLMR_BASE_ENCODER = RobertaModelBundle(
     _path=os.path.join(_TEXT_BUCKET, "xlmr.base.encoder.pt"),
-    _params=RobertaEncoderParams(vocab_size=250002),
+    _params=RobertaEncoderConf(vocab_size=250002),
     transform=partial(get_xlmr_transform,
                       vocab_path=os.path.join(_TEXT_BUCKET, "xlmr.vocab.pt"),
                       spm_model_path=os.path.join(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),
@@ -101,7 +110,7 @@ XLMR_BASE_ENCODER = RobertaModelBundle(
 
 XLMR_LARGE_ENCODER = RobertaModelBundle(
     _path=os.path.join(_TEXT_BUCKET, "xlmr.large.encoder.pt"),
-    _params=RobertaEncoderParams(vocab_size=250002, embedding_dim=1024, ffn_dimension=4096, num_attention_heads=16, num_encoder_layers=24),
+    _params=RobertaEncoderConf(vocab_size=250002, embedding_dim=1024, ffn_dimension=4096, num_attention_heads=16, num_encoder_layers=24),
     transform=partial(get_xlmr_transform,
                       vocab_path=os.path.join(_TEXT_BUCKET, "xlmr.vocab.pt"),
                       spm_model_path=os.path.join(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),

--- a/torchtext/models/roberta/model.py
+++ b/torchtext/models/roberta/model.py
@@ -98,6 +98,15 @@ class RobertaClassificationHead(nn.Module):
 
 
 class RobertaModel(Module):
+    """
+
+    Example - Instantiate model with user-specified configuration
+        >>> from torchtext.models import RobertaEncoderConf, RobertaModel, RobertaClassificationHead
+        >>> roberta_encoder_conf = RobertaEncoderConf(vocab_size=250002)
+        >>> encoder = RobertaModel(config=roberta_encoder_conf)
+        >>> classifier_head = RobertaClassificationHead(num_classes=2, input_dim=768)
+        >>> classifier = RobertaModel(config=roberta_encoder_conf, head=classifier_head)
+    """
     def __init__(self, config: RobertaEncoderConf, head: Optional[Module] = None, freeze_encoder: bool = False):
         super().__init__()
         self.encoder = RobertaEncoder.from_config(config)

--- a/torchtext/models/roberta/model.py
+++ b/torchtext/models/roberta/model.py
@@ -107,8 +107,11 @@ class RobertaModel(Module):
         >>> classifier_head = RobertaClassificationHead(num_classes=2, input_dim=768)
         >>> classifier = RobertaModel(config=roberta_encoder_conf, head=classifier_head)
     """
+
     def __init__(self, config: RobertaEncoderConf, head: Optional[Module] = None, freeze_encoder: bool = False):
         super().__init__()
+        assert isinstance(config, RobertaEncoderConf)
+
         self.encoder = RobertaEncoder.from_config(config)
         if freeze_encoder:
             for param in self.encoder.parameters():


### PR DESCRIPTION
Follow-up item from #1406 : Extend API to support user-specified configuration and checkpoint

Modifying RobertaModel to directly accept configuration. Users can use this class to create uninitialized model as follows:

```python
from torchtext.models import RobertaEncoderConf, RobertaModel, RobertaClassificationHead
roberta_encoder_conf = RobertaEncoderConf(vocab_size=250002)
encoder = RobertaModel(config=roberta_encoder_conf)
classifier_head = RobertaClassificationHead(num_classes=2, input_dim=768)
classifier = RobertaModel(config=roberta_encoder_conf, head=classifier_head)
```

Users can also use the Bundler API to instantiate model with user-specified checkpoint as follows:
```python
from torchtext.models import RobertaEncoderConf, RobertaModelBundle, RobertaClassificationHead
model_weights_path = "https://download.pytorch.org/models/text/xlmr.base.encoder.pt"
roberta_encoder_conf = RobertaEncoderConf(vocab_size=250002)
roberta_bundle = RobertaModelBundle(_encoder_conf=roberta_encoder_conf, _path=model_weights_path)
encoder = roberta_bundle.get_model()
classifier_head = RobertaClassificationHead(num_classes=2, input_dim=768)
classifier = roberta_bundle.get_model(head=classifier_head)
```

