### PR TITLE
add attention mask to transformer encoder modules

### DIFF
--- a/test/models/test_models.py
+++ b/test/models/test_models.py
@@ -5,6 +5,35 @@ from ..common.torchtext_test_case import TorchtextTestCase
 from ..common.assets import get_asset_path
 
 
+class TestModules(TorchtextTestCase):
+    def test_self_attn_mask(self):
+        from torchtext.models.roberta.modules import MultiheadSelfAttention
+        embed_dim, batch_size, num_heads, source_len = 4, 1, 2, 2
+        mha = MultiheadSelfAttention(embed_dim=embed_dim, num_heads=num_heads)
+        query = torch.ones((source_len, batch_size, embed_dim))
+        query[0, ...] = 0
+        key_padding_mask = torch.zeros((batch_size, source_len))
+        attn_mask = torch.zeros((source_len, source_len))
+        attn_mask[0][1] = -1e8
+        with torch.no_grad():
+            mha.input_projection.weight.fill_(1. / embed_dim)
+            mha.input_projection.bias.fill_(0.)
+            mha.output_projection.weight.fill_(1. / embed_dim)
+            mha.output_projection.bias.fill_(0.)
+
+            # with attention mask
+            actual = mha(query, key_padding_mask, attn_mask)
+            expected = torch.tensor([[[0.0000, 0.0000, 0.0000, 0.0000]],
+                                     [[0.8938, 0.8938, 0.8938, 0.8938]]])
+            torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+            # without attention mask
+            actual = mha(query, key_padding_mask)
+            expected = torch.tensor([[[0.5556, 0.5556, 0.5556, 0.5556]],
+                                     [[0.8938, 0.8938, 0.8938, 0.8938]]])
+            torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+
 class TestModels(TorchtextTestCase):
     def test_xlmr_base_output(self):
         asset_name = "xlmr.base.output.pt"

--- a/torchtext/models/roberta/modules.py
+++ b/torchtext/models/roberta/modules.py
@@ -224,13 +224,13 @@ class TransformerEncoderLayer(Module):
 
         if self.normalize_before:
             x = self.attention_layer_norm(input)
-            attention = self.attention(x, key_padding_mask)
+            attention = self.attention(x, key_padding_mask, attn_mask)
             attention = self.dropout(attention)
             biased_input = input + attention
             x = self.final_layer_norm(biased_input)
             return self.residual_mlp(x) + biased_input
         else:
-            attention = self.attention(input, key_padding_mask)
+            attention = self.attention(input, key_padding_mask, attn_mask)
             attention = self.dropout(attention)
             biased_input = input + attention
             biased_input = self.attention_layer_norm(biased_input)

--- a/torchtext/models/roberta/modules.py
+++ b/torchtext/models/roberta/modules.py
@@ -125,6 +125,7 @@ class MultiheadSelfAttention(Module):
 
         attn_weights = torch.bmm(q, k.transpose(1, 2))
         if attn_mask is not None:
+            torch._assert(attn_mask.dim() == 2, "Expected attn_mask of dim 2 but got {}".format(attn_mask.dim()))
             attn_mask = attn_mask.unsqueeze(0)
             attn_weights += attn_mask
 
@@ -214,6 +215,8 @@ class TransformerEncoderLayer(Module):
 
     def forward(self, input: torch.Tensor, key_padding_mask: torch.Tensor, attn_mask: Optional[torch.Tensor] = None):
         if attn_mask is not None:
+            torch._assert(attn_mask.dtype == torch.bool, "Expected attn_mask dtype as `torch.bool` but got {}".format(attn_mask.dtype))
+            torch._assert(attn_mask.dim() == 2, "Expected attn_mask of dim 2 but got {}".format(attn_mask.dim()))
             attn_mask = attn_mask.masked_fill(
                 attn_mask.to(torch.bool),
                 -1e8 if input.dtype == torch.float32 else -1e4
@@ -278,6 +281,10 @@ class TransformerEncoder(Module):
         self.return_all_layers = return_all_layers
 
     def forward(self, tokens: torch.Tensor, attn_mask: Optional[torch.Tensor] = None) -> Union[torch.Tensor, List[torch.Tensor]]:
+        if attn_mask is not None:
+            torch._assert(attn_mask.dtype == torch.bool, "Expected attn_mask dtype as `torch.bool` but got {}".format(attn_mask.dtype))
+            torch._assert(attn_mask.dim() == 2, "Expected attn_mask of dim 2 but got {}".format(attn_mask.dim()))
+
         padding_mask = tokens.eq(self.padding_idx)
 
         token_embeddings = self.token_embedding(tokens)

--- a/torchtext/models/roberta/modules.py
+++ b/torchtext/models/roberta/modules.py
@@ -310,7 +310,7 @@ class TransformerEncoder(Module):
             return states
         else:
             for layer in self.layers:
-                encoded = layer(encoded, padding_mask)
+                encoded = layer(encoded, padding_mask, attn_mask)
 
             if self.normalize_before:
                 encoded = self.embedding_layer_norm(encoded)

--- a/torchtext/models/roberta/modules.py
+++ b/torchtext/models/roberta/modules.py
@@ -126,6 +126,8 @@ class MultiheadSelfAttention(Module):
         attn_weights = torch.bmm(q, k.transpose(1, 2))
         if attn_mask is not None:
             torch._assert(attn_mask.dim() == 2, "Expected attn_mask of dim 2 but got {}".format(attn_mask.dim()))
+            torch._assert(attn_mask.size(0) == target_length, "attn_mask shape didn't match for target length {}".format(target_length))
+            torch._assert(attn_mask.size(1) == source_length, "attn_mask shape didn't match for source length {}".format(source_length))
             attn_mask = attn_mask.unsqueeze(0)
             attn_weights += attn_mask
 
@@ -215,7 +217,6 @@ class TransformerEncoderLayer(Module):
 
     def forward(self, input: torch.Tensor, key_padding_mask: torch.Tensor, attn_mask: Optional[torch.Tensor] = None):
         if attn_mask is not None:
-            torch._assert(attn_mask.dtype == torch.bool, "Expected attn_mask dtype as `torch.bool` but got {}".format(attn_mask.dtype))
             torch._assert(attn_mask.dim() == 2, "Expected attn_mask of dim 2 but got {}".format(attn_mask.dim()))
             attn_mask = attn_mask.masked_fill(
                 attn_mask.to(torch.bool),


### PR DESCRIPTION
Add Attention mask to transform encoder modules. The implementation is based on [Encoder layer from fairseq](https://github.com/pytorch/fairseq/blob/0b21875e45f332bedbcc0617dcf9379d3c03855f/fairseq/modules/transformer_layer.py#L20) 

Follow-up:

- [ ] Add Documentation
- [x] Add unit-test