### PR TITLE
Fix CircleCI failures on Windows for XLM-R unit tests

### DIFF
--- a/torchtext/__init__.py
+++ b/torchtext/__init__.py
@@ -1,5 +1,5 @@
 import os
-_TEXT_BUCKET = 'https://download.pytorch.org/models/text'
+_TEXT_BUCKET = 'https://download.pytorch.org/models/text/'
 _CACHE_DIR = os.path.expanduser('~/.torchtext/cache')
 
 from . import data

--- a/torchtext/models/roberta/bundler.py
+++ b/torchtext/models/roberta/bundler.py
@@ -1,7 +1,7 @@
 
-import os
 from dataclasses import dataclass
 from functools import partial
+from urllib.parse import urljoin
 
 from typing import Optional, Callable
 from torchtext._download_hooks import load_state_dict_from_url
@@ -100,19 +100,19 @@ class RobertaModelBundle:
 
 
 XLMR_BASE_ENCODER = RobertaModelBundle(
-    _path=os.path.join(_TEXT_BUCKET, "xlmr.base.encoder.pt"),
+    _path=urljoin(_TEXT_BUCKET, "xlmr.base.encoder.pt"),
     _encoder_conf=RobertaEncoderConf(vocab_size=250002),
     transform=partial(get_xlmr_transform,
-                      vocab_path=os.path.join(_TEXT_BUCKET, "xlmr.vocab.pt"),
-                      spm_model_path=os.path.join(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),
+                      vocab_path=urljoin(_TEXT_BUCKET, "xlmr.vocab.pt"),
+                      spm_model_path=urljoin(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),
                       )
 )
 
 XLMR_LARGE_ENCODER = RobertaModelBundle(
-    _path=os.path.join(_TEXT_BUCKET, "xlmr.large.encoder.pt"),
+    _path=urljoin(_TEXT_BUCKET, "xlmr.large.encoder.pt"),
     _encoder_conf=RobertaEncoderConf(vocab_size=250002, embedding_dim=1024, ffn_dimension=4096, num_attention_heads=16, num_encoder_layers=24),
     transform=partial(get_xlmr_transform,
-                      vocab_path=os.path.join(_TEXT_BUCKET, "xlmr.vocab.pt"),
-                      spm_model_path=os.path.join(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),
+                      vocab_path=urljoin(_TEXT_BUCKET, "xlmr.vocab.pt"),
+                      spm_model_path=urljoin(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model"),
                       )
 )


### PR DESCRIPTION
This PR fixes the Circle CI model test failures on Windows.

## Cause
 
To generate download URLs we used `os.path.join(_TEXT_BUCKET, "xlmr.vocab.pt")`. `os.path.join` is not the right way to join URL paths and must only be used for local OS directory paths. In our case, since `_TEXT_BUCKET` has forward slashes (because it is a URL), `os` library acts smart and on Windows it produces the URL: `https://download.pytorch.org/models/text\xlmr.vocab.pt` which gives a 403 on CURL.

## Fix
Instead of `os.path.join`, we must use `urllib.parse.urljoin`
