### PR TITLE
Update annotation types of transforms and functionals

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -37,3 +37,10 @@ LabelToIndex
 .. autoclass:: LabelToIndex
 
    .. automethod:: forward
+
+Truncate
+------------
+
+.. autoclass:: Truncate
+
+   .. automethod:: forward

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -37,10 +37,3 @@ LabelToIndex
 .. autoclass:: LabelToIndex
 
    .. automethod:: forward
-
-Truncate
-------------
-
-.. autoclass:: Truncate
-
-   .. automethod:: forward

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -21,18 +21,20 @@ class TestFunctional(TorchtextTestCase):
         torch.testing.assert_close(actual, expected)
 
     def test_to_tensor(self):
+        """test tensorization on both single sequence and batch of sequence"""
         self._to_tensor(test_scripting=False)
 
     def test_to_tensor_jit(self):
+        """test tensorization with scripting on both single sequence and batch of sequence"""
         self._to_tensor(test_scripting=True)
 
     def _truncate(self, test_scripting):
-        input = [[1, 2], [1, 2, 3]]
         max_seq_len = 2
-
         func = functional.truncate
         if test_scripting:
             func = torch.jit.script(func)
+
+        input = [[1, 2], [1, 2, 3]]
         actual = func(input, max_seq_len=max_seq_len)
         expected = [[1, 2], [1, 2]]
         self.assertEqual(actual, expected)
@@ -42,13 +44,26 @@ class TestFunctional(TorchtextTestCase):
         expected = [1, 2]
         self.assertEqual(actual, expected)
 
+        input = [["a", "b"], ["a", "b", "c"]]
+        actual = func(input, max_seq_len=max_seq_len)
+        expected = [["a", "b"], ["a", "b"]]
+        self.assertEqual(actual, expected)
+
+        input = ["a", "b", "c"]
+        actual = func(input, max_seq_len=max_seq_len)
+        expected = ["a", "b"]
+        self.assertEqual(actual, expected)
+
     def test_truncate(self):
+        """test truncation on both sequence and batch of sequence with both str and int types"""
         self._truncate(test_scripting=False)
 
     def test_truncate_jit(self):
+        """test truncation with scripting on both sequence and batch of sequence with both str and int types"""
         self._truncate(test_scripting=True)
 
     def _add_token(self, test_scripting):
+
         func = functional.add_token
         if test_scripting:
             func = torch.jit.script(func)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -14,6 +14,7 @@ class TestTransforms(TorchtextTestCase):
         transform = transforms.SentencePieceTokenizer(asset_path)
         if test_scripting:
             transform = torch.jit.script(transform)
+
         actual = transform(["Hello World!, how are you?"])
         expected = [['▁Hello', '▁World', '!', ',', '▁how', '▁are', '▁you', '?']]
         self.assertEqual(actual, expected)
@@ -23,10 +24,11 @@ class TestTransforms(TorchtextTestCase):
         self.assertEqual(actual, expected)
 
     def test_spmtokenizer(self):
-
+        """test tokenization on single sentence input as well as batch on sentences"""
         self._spmtokenizer(test_scripting=False)
 
     def test_spmtokenizer_jit(self):
+        """test tokenization with scripting on single sentence input as well as batch on sentences"""
         self._spmtokenizer(test_scripting=True)
 
     def _vocab_transform(self, test_scripting):
@@ -43,9 +45,11 @@ class TestTransforms(TorchtextTestCase):
         self.assertEqual(actual, expected)
 
     def test_vocab_transform(self):
+        """test token to indices on both sequence of input tokens as well as batch of sequence"""
         self._vocab_transform(test_scripting=False)
 
     def test_vocab_transform_jit(self):
+        """test token to indices with scripting on both sequence of input tokens as well as batch of sequence"""
         self._vocab_transform(test_scripting=True)
 
     def _totensor(self, test_scripting):
@@ -65,9 +69,11 @@ class TestTransforms(TorchtextTestCase):
         torch.testing.assert_close(actual, expected)
 
     def test_totensor(self):
+        """test tensorization on both single sequence and batch of sequence"""
         self._totensor(test_scripting=False)
 
     def test_totensor_jit(self):
+        """test tensorization with scripting on both single sequence and batch of sequence"""
         self._totensor(test_scripting=True)
 
     def _labeltoindex(self, test_scripting):
@@ -100,7 +106,9 @@ class TestTransforms(TorchtextTestCase):
         self.assertEqual(actual, expected)
 
     def test_labeltoindex(self):
+        """test labe to ids on single label input as well as batch of labels"""
         self._labeltoindex(test_scripting=False)
 
     def test_labeltoindex_jit(self):
+        """test labe to ids with scripting on single label input as well as batch of labels"""
         self._labeltoindex(test_scripting=True)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,6 +1,5 @@
 import torch
 from torchtext import transforms
-from torchtext.functional import truncate
 from torchtext.vocab import vocab
 from collections import OrderedDict
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,5 +1,6 @@
 import torch
 from torchtext import transforms
+from torchtext.functional import truncate
 from torchtext.vocab import vocab
 from collections import OrderedDict
 
@@ -120,4 +121,32 @@ class TestTransforms(TorchtextTestCase):
 
         actual = transform_jit("test")
         expected = 0
+        self.assertEqual(actual, expected)
+
+    def test_truncate(self):
+        input = [[1, 2], [1, 2, 3]]
+        max_seq_len = 2
+
+        transform = transforms.Truncate(max_seq_len)
+        actual = transform(input)
+        expected = [[1, 2], [1, 2]]
+        self.assertEqual(actual, expected)
+
+        input = [1, 2, 3]
+        actual = transform(input)
+        expected = [1, 2]
+        self.assertEqual(actual, expected)
+
+    def test_truncate_jit(self):
+        input = [[1, 2], [1, 2, 3]]
+        max_seq_len = 2
+        transform = transforms.Truncate(max_seq_len)
+        transform_jit = torch.jit.script(transform)
+        actual = transform_jit(input)
+        expected = [[1, 2], [1, 2]]
+        self.assertEqual(actual, expected)
+
+        input = [1, 2, 3]
+        actual = transform_jit(input)
+        expected = [1, 2]
         self.assertEqual(actual, expected)

--- a/torchtext/functional.py
+++ b/torchtext/functional.py
@@ -11,6 +11,16 @@ __all__ = [
 
 
 def to_tensor(input: Any, padding_value: Optional[int] = None, dtype: Optional[torch.dtype] = torch.long) -> Tensor:
+    r"""Convert input to torch tensor
+
+    :param padding_value: Pad value to make each input in the batch of length equal to the longest sequence in the batch.
+    :type padding_value: Optional[int]
+    :param dtype: :class:`torch.dtype` of output tensor
+    :type dtype: :class:`torch.dtype`
+    :param input: Sequence or batch of token ids
+    :type input: Union[List[int], List[List[int]]]
+    :rtype: Tensor
+    """
     if torch.jit.isinstance(input, List[int]):
         return torch.tensor(input, dtype=torch.long)
     elif torch.jit.isinstance(input, List[List[int]]):
@@ -29,6 +39,15 @@ def to_tensor(input: Any, padding_value: Optional[int] = None, dtype: Optional[t
 
 
 def truncate(input: Any, max_seq_len: int) -> Any:
+    """ Truncate input sequence or batch
+
+    :param input: Input sequence or batch to be truncated
+    :type input: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    :param max_seq_len: Maximum length beyond which input is discarded
+    :type max_seq_len: int
+    :return: Truncated sequence
+    :rtype: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    """
     if torch.jit.isinstance(input, List[int]):
         return input[:max_seq_len]
     elif torch.jit.isinstance(input, List[str]):
@@ -47,15 +66,41 @@ def truncate(input: Any, max_seq_len: int) -> Any:
         raise TypeError("Input type not supported")
 
 
-def add_token(input: Any, token_id: int, begin: bool = True) -> Any:
-    if torch.jit.isinstance(input, List[int]):
+def add_token(input: Any, token_id: Any, begin: bool = True) -> Any:
+    """Add token to start or end of sequence
+
+    :param input: Input sequence or batch
+    :type input: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    :param token_id: token to be added
+    :type token_id: Union[str, int]
+    :param begin: Whether to insert token at start or end or sequence, defaults to True
+    :type begin: bool, optional
+    :return: sequence or batch with token_id added to begin or end or input
+    :rtype: Union[List[Union[str, int]], List[List[Union[str, int]]]]
+    """
+    if torch.jit.isinstance(input, List[int]) and torch.jit.isinstance(token_id, int):
         if begin:
             return [token_id] + input
         else:
             return input + [token_id]
-    elif torch.jit.isinstance(input, List[List[int]]):
+    elif torch.jit.isinstance(input, List[str]) and torch.jit.isinstance(token_id, str):
+        if begin:
+            return [token_id] + input
+        else:
+            return input + [token_id]
+    elif torch.jit.isinstance(input, List[List[int]]) and torch.jit.isinstance(token_id, int):
         output: List[List[int]] = []
 
+        if begin:
+            for ids in input:
+                output.append([token_id] + ids)
+        else:
+            for ids in input:
+                output.append(ids + [token_id])
+
+        return output
+    elif torch.jit.isinstance(input, List[List[str]]) and torch.jit.isinstance(token_id, str):
+        output: List[List[str]] = []
         if begin:
             for ids in input:
                 output.append([token_id] + ids)

--- a/torchtext/functional.py
+++ b/torchtext/functional.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 from torch.nn.utils.rnn import pad_sequence
-from typing import List, Optional, Union
+from typing import List, Optional, Any
 
 __all__ = [
     'to_tensor',
@@ -10,10 +10,10 @@ __all__ = [
 ]
 
 
-def to_tensor(input: Union[List[int], List[List[int]]], padding_value: Optional[int] = None, dtype: Optional[torch.dtype] = torch.long) -> Tensor:
+def to_tensor(input: Any, padding_value: Optional[int] = None, dtype: Optional[torch.dtype] = torch.long) -> Tensor:
     if torch.jit.isinstance(input, List[int]):
         return torch.tensor(input, dtype=torch.long)
-    else:
+    elif torch.jit.isinstance(input, List[List[int]]):
         if padding_value is None:
             output = torch.tensor(input, dtype=dtype)
             return output
@@ -24,12 +24,12 @@ def to_tensor(input: Union[List[int], List[List[int]]], padding_value: Optional[
                 padding_value=float(padding_value)
             )
             return output
+    else:
+        raise TypeError("Input type not supported")
 
 
-def truncate(input: Union[List[int], List[str], List[List[int]], List[List[str]]], max_seq_len: int) -> Union[List[int], List[str], List[List[int]], List[List[str]]]:
+def truncate(input: Any, max_seq_len: int) -> Any:
     if torch.jit.isinstance(input, List[int]):
-        return input[:max_seq_len]
-    elif torch.jit.isinstance(input, List[str]):
         return input[:max_seq_len]
     elif torch.jit.isinstance(input, List[str]):
         return input[:max_seq_len]
@@ -38,20 +38,22 @@ def truncate(input: Union[List[int], List[str], List[List[int]], List[List[str]]
         for ids in input:
             output.append(ids[:max_seq_len])
         return output
-    else:
+    elif torch.jit.isinstance(input, List[List[str]]):
         output: List[List[str]] = []
         for ids in input:
             output.append(ids[:max_seq_len])
         return output
+    else:
+        raise TypeError("Input type not supported")
 
 
-def add_token(input: Union[List[int], List[List[int]]], token_id: int, begin: bool = True) -> Union[List[int], List[List[int]]]:
+def add_token(input: Any, token_id: int, begin: bool = True) -> Any:
     if torch.jit.isinstance(input, List[int]):
         if begin:
             return [token_id] + input
         else:
             return input + [token_id]
-    else:
+    elif torch.jit.isinstance(input, List[List[int]]):
         output: List[List[int]] = []
 
         if begin:
@@ -62,3 +64,5 @@ def add_token(input: Union[List[int], List[List[int]]], token_id: int, begin: bo
                 output.append(ids + [token_id])
 
         return output
+    else:
+        raise TypeError("Input type not supported")

--- a/torchtext/functional.py
+++ b/torchtext/functional.py
@@ -26,15 +26,22 @@ def to_tensor(input: Union[List[int], List[List[int]]], padding_value: Optional[
             return output
 
 
-def truncate(input: Union[List[int], List[List[int]]], max_seq_len: int) -> Union[List[int], List[List[int]]]:
+def truncate(input: Union[List[int], List[str], List[List[int]], List[List[str]]], max_seq_len: int) -> Union[List[int], List[str], List[List[int]], List[List[str]]]:
     if torch.jit.isinstance(input, List[int]):
         return input[:max_seq_len]
-    else:
+    elif torch.jit.isinstance(input, List[str]):
+        return input[:max_seq_len]
+    elif torch.jit.isinstance(input, List[str]):
+        return input[:max_seq_len]
+    elif torch.jit.isinstance(input, List[List[int]]):
         output: List[List[int]] = []
-
         for ids in input:
             output.append(ids[:max_seq_len])
-
+        return output
+    else:
+        output: List[List[str]] = []
+        for ids in input:
+            output.append(ids[:max_seq_len])
         return output
 
 

--- a/torchtext/models/roberta/transforms.py
+++ b/torchtext/models/roberta/transforms.py
@@ -5,7 +5,7 @@ from torchtext._download_hooks import load_state_dict_from_url
 from torchtext import transforms
 from torchtext import functional
 
-from typing import List, Union
+from typing import Any
 
 
 class XLMRobertaModelTransform(Module):
@@ -44,10 +44,10 @@ class XLMRobertaModelTransform(Module):
         self.bos_idx = self.vocab[self.bos_token]
         self.eos_idx = self.vocab[self.eos_token]
 
-    def forward(self, input: Union[str, List[str]],
+    def forward(self, input: Any,
                 add_bos: bool = True,
                 add_eos: bool = True,
-                truncate: bool = True) -> Union[List[int], List[List[int]]]:
+                truncate: bool = True) -> Any:
 
         tokens = self.tokenizer(input)
 

--- a/torchtext/models/roberta/transforms.py
+++ b/torchtext/models/roberta/transforms.py
@@ -32,7 +32,7 @@ class XLMRobertaModelTransform(Module):
         self.sep_token = sep_token
         self.max_seq_len = max_seq_len
 
-        self.token_transform = transforms.SentencePieceTokenizer(spm_model_path)
+        self.tokenizer = transforms.SentencePieceTokenizer(spm_model_path)
 
         if os.path.exists(vocab_path):
             self.vocab = torch.load(vocab_path)
@@ -49,10 +49,12 @@ class XLMRobertaModelTransform(Module):
                 add_eos: bool = True,
                 truncate: bool = True) -> Union[List[int], List[List[int]]]:
 
-        tokens = self.vocab_transform(self.token_transform(input))
+        tokens = self.tokenizer(input)
 
         if truncate:
             tokens = functional.truncate(tokens, self.max_seq_len - 2)
+
+        tokens = self.vocab_transform((tokens))
 
         if add_bos:
             tokens = functional.add_token(tokens, self.bos_idx)

--- a/torchtext/models/roberta/transforms.py
+++ b/torchtext/models/roberta/transforms.py
@@ -5,7 +5,7 @@ from torchtext._download_hooks import load_state_dict_from_url
 from torchtext import transforms
 from torchtext import functional
 
-from typing import Any
+from typing import List, Any
 
 
 class XLMRobertaModelTransform(Module):
@@ -32,7 +32,7 @@ class XLMRobertaModelTransform(Module):
         self.sep_token = sep_token
         self.max_seq_len = max_seq_len
 
-        self.tokenizer = transforms.SentencePieceTokenizer(spm_model_path)
+        self.token_transform = transforms.SentencePieceTokenizer(spm_model_path)
 
         if os.path.exists(vocab_path):
             self.vocab = torch.load(vocab_path)
@@ -48,21 +48,34 @@ class XLMRobertaModelTransform(Module):
                 add_bos: bool = True,
                 add_eos: bool = True,
                 truncate: bool = True) -> Any:
+        if torch.jit.isinstance(input, str):
+            tokens = self.vocab_transform(self.token_transform(input))
 
-        tokens = self.tokenizer(input)
+            if truncate:
+                tokens = functional.truncate(tokens, self.max_seq_len - 2)
 
-        if truncate:
-            tokens = functional.truncate(tokens, self.max_seq_len - 2)
+            if add_bos:
+                tokens = functional.add_token(tokens, self.bos_idx)
 
-        tokens = self.vocab_transform((tokens))
+            if add_eos:
+                tokens = functional.add_token(tokens, self.eos_idx, begin=False)
 
-        if add_bos:
-            tokens = functional.add_token(tokens, self.bos_idx)
+            return tokens
+        elif torch.jit.isinstance(input, List[str]):
+            tokens = self.vocab_transform(self.token_transform(input))
 
-        if add_eos:
-            tokens = functional.add_token(tokens, self.eos_idx, begin=False)
+            if truncate:
+                tokens = functional.truncate(tokens, self.max_seq_len - 2)
 
-        return tokens
+            if add_bos:
+                tokens = functional.add_token(tokens, self.bos_idx)
+
+            if add_eos:
+                tokens = functional.add_token(tokens, self.eos_idx, begin=False)
+
+            return tokens
+        else:
+            raise TypeError("Input type not supported")
 
 
 def get_xlmr_transform(vocab_path, spm_model_path, **kwargs) -> XLMRobertaModelTransform:

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -157,4 +157,8 @@ class Truncate(Module):
         self.max_seq_len = max_seq_len
 
     def forward(self, input: Union[List[int], List[str], List[List[int]], List[List[str]]]) -> Union[List[int], List[str], List[List[int]], List[List[str]]]:
+        """
+        Args:
+            input: Input sequence to truncate. The input can either be a ``List`` or ``List[List]`` for batched operation
+        """
         return F.truncate(input, self.max_seq_len)

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -15,15 +15,19 @@ __all__ = [
     'VocabTransform',
     'ToTensor',
     'LabelToIndex',
-    'Truncate',
 ]
 
 
 class SentencePieceTokenizer(Module):
     """
-    Transform for Sentence Piece tokenizer from pre-trained SentencePiece model
+    Transform for Sentence Piece tokenizer from pre-trained sentencepiece model
 
-    Examples:
+    Additiona details: https://github.com/google/sentencepiece
+
+    :param sp_model_path: Path to pre-trained sentencepiece model
+    :type sp_model_path: str
+
+    Example
         >>> from torchtext.transforms import SpmTokenizerTransform
         >>> transform = SentencePieceTokenizer("spm_model")
         >>> transform(["hello world", "attention is all you need!"])
@@ -38,6 +42,12 @@ class SentencePieceTokenizer(Module):
         self.sp_model = load_sp_model(local_path)
 
     def forward(self, input: Any) -> Any:
+        """
+        :param input: Input sentence or list of sentences on which to apply tokenizer.
+        :type input: Union[str, List[str]]
+        :return: tokenized text
+        :rtype: Union[List[str], List[List(str)]]
+        """
         if torch.jit.isinstance(input, List[str]):
             tokens: List[List[str]] = []
             for text in input:
@@ -50,10 +60,9 @@ class SentencePieceTokenizer(Module):
 
 
 class VocabTransform(Module):
-    r"""Vocab transform
+    r"""Vocab transform to convert input batch of tokens into corresponding token ids
 
-    Args:
-        vocab: an instance of torchtext.vocab.Vocab class.
+    :param vocab: an instance of :class:`torchtext.vocab.Vocab` class.
 
     Example:
         >>> import torch
@@ -72,10 +81,11 @@ class VocabTransform(Module):
         self.vocab = vocab
 
     def forward(self, input: Any) -> Any:
-        r"""
-
-        Args:
-            input: list of list tokens
+        """
+        :param input: Input batch of token to convert to correspnding token ids
+        :type input: Union[List[str], List[List[str]]]
+        :return: Converted input into corresponding token ids
+        :rtype: Union[List[int], List[List[int]]]
         """
 
         if torch.jit.isinstance(input, List[str]):
@@ -93,8 +103,10 @@ class VocabTransform(Module):
 class ToTensor(Module):
     r"""Convert input to torch tensor
 
-    Args:
-        padding_value (int, optional): Pad value to make each input in the batch of length equal to the longest sequence in the batch.
+    :param padding_value: Pad value to make each input in the batch of length equal to the longest sequence in the batch.
+    :type padding_value: Optional[int]
+    :param dtype: :class:`torch.dtype` of output tensor
+    :type dtype: :class:`torch.dtype`
     """
 
     def __init__(self, padding_value: Optional[int] = None, dtype: Optional[torch.dtype] = torch.long) -> None:
@@ -103,9 +115,10 @@ class ToTensor(Module):
         self.dtype = dtype
 
     def forward(self, input: Any) -> Tensor:
-        r"""
-        Args:
-
+        """
+        :param input: Sequence or batch of token ids
+        :type input: Union[List[int], List[List[int]]]
+        :rtype: Tensor
         """
         return F.to_tensor(input, padding_value=self.padding_value, dtype=self.dtype)
 
@@ -114,15 +127,16 @@ class LabelToIndex(Module):
     r"""
     Transform labels from string names to ids.
 
-    Args:
-        label_names (List[str], Optional): a list of unique label names
-        label_path (str, Optional): a path to file containing unique label names containing 1 label per line.
+    :param label_names: a list of unique label names
+    :type label_names: Optional[List[str]]
+    :param label_path: a path to file containing unique label names containing 1 label per line. Note that either label_names or label_path should be supplied
+                       but not both.
+    :type label_path: Optional[str]
     """
 
     def __init__(
         self, label_names: Optional[List[str]] = None, label_path: Optional[str] = None, sort_names=False,
     ):
-
         assert label_names or label_path, "label_names or label_path is required"
         assert not (label_names and label_path), "label_names and label_path are mutually exclusive"
         super().__init__()
@@ -139,6 +153,11 @@ class LabelToIndex(Module):
         self._label_names = self._label_vocab.get_itos()
 
     def forward(self, input: Any) -> Any:
+        """
+        :param input: Input labels to convert to corresponding ids
+        :type input: Union[str, List[str]]
+        :rtype: Union[int, List[int]]
+        """
         if torch.jit.isinstance(input, List[str]):
             return self._label_vocab.lookup_indices(input)
         elif torch.jit.isinstance(input, str):
@@ -149,22 +168,3 @@ class LabelToIndex(Module):
     @property
     def label_names(self) -> List[str]:
         return self._label_names
-
-
-class Truncate(Module):
-    r"""Truncate input sequence
-
-    Args:
-        max_seq_len (int): The maximum allowable length for input sequence
-    """
-
-    def __init__(self, max_seq_len: int) -> None:
-        super().__init__()
-        self.max_seq_len = max_seq_len
-
-    def forward(self, input: Any) -> Any:
-        """
-        Args:
-            input: Input sequence to truncate. The input can either be a ``List`` or ``List[List]`` for batched operation
-        """
-        return F.truncate(input, self.max_seq_len)

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -142,3 +142,12 @@ class LabelToIndex(Module):
     @property
     def label_names(self) -> List[str]:
         return self._label_names
+
+
+class Truncate(Module):
+    def __init__(self, max_seq_len) -> None:
+        super().__init__()
+        self.max_seq_len = max_seq_len
+
+    def forward(self, input: Union[List[int], List[List[int]]]) -> Union[List[int], List[List[int]]]:
+        return F.truncate(input, self.max_seq_len)

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -15,6 +15,7 @@ __all__ = [
     'VocabTransform',
     'ToTensor',
     'LabelToIndex',
+    'Truncate',
 ]
 
 
@@ -145,9 +146,15 @@ class LabelToIndex(Module):
 
 
 class Truncate(Module):
-    def __init__(self, max_seq_len) -> None:
+    r"""Truncate input sequence
+
+    Args:
+        max_seq_len (int): The maximum allowable length for input sequence
+    """
+
+    def __init__(self, max_seq_len: int) -> None:
         super().__init__()
         self.max_seq_len = max_seq_len
 
-    def forward(self, input: Union[List[int], List[List[int]]]) -> Union[List[int], List[List[int]]]:
+    def forward(self, input: Union[List[int], List[str], List[List[int]], List[List[str]]]) -> Union[List[int], List[str], List[List[int]], List[List[str]]]:
         return F.truncate(input, self.max_seq_len)


### PR DESCRIPTION
## Summary:
* This PR updates the annotation types of transforms to `Any`
* Add `Truncate` transform
 
## Problem when transforms input and outputs are type annotated
The transforms and functionals support multiple styles of inputs (both batched and non-batched are supported) as well as sometimes they may support multiple types (refer to Truncate transform added in this PR that can work with both `int` and `str` primitive types). Composability of these transforms and support for torch scriptability may not go hand-in-hand. Below code snippets shows couple of these issues.
 
 ```python
import torch
from typing import List, Union

#primitive transform
def foo(input: Union[int, List[int]])->Union[int, List[int]]:
    if torch.jit.isinstance(input, List[int]):
        return input
    elif torch.jit.isinstance(input, int):
       return input
    else:
        raise TypeError

#primitive transform
def bar(input: List[int])-> List[int]:
    if torch.jit.isinstance(input, List[int]):    
        return input
    else:
        raise TypeError

#composite transform
def goo(input: List[int]):
    x = bar(foo(input))
    return x

goo_jit = torch.jit.script(goo)

# gives following error:
RuntimeError: 

bar(int[] input) -> (int[]):
Expected a value of type 'int' for argument '<varargs>' but instead found type 'Union[List[int], int]'.
:
  File "<ipython-input-17-9a79ce8ea4b4>", line 13
def goo(input: List[int]):
    x = bar(foo(input))
        ~~~ <--- HERE
    return x


def foofoo(input: List[int], use_foo:bool = True):
    output = bar(input)
    if use_foo:
        output = foo(output)
 
    return output

foofoo_jit = torch.jit.script(foofoo)

#gives following error:
RuntimeError: 
Variable 'output' previously had type List[int] but is now being assigned to a value of type Union[List[int], int]
:
  File "<ipython-input-18-10b17e1c770a>", line 4
    output = bar(input)
    if use_foo:
        output = foo(output)
        ~~~~~~ <--- HERE
 
    return output
```
 
## Solution
By changing the input and output type to `Any` and using [type refinement (using torch.jit.instance)](https://pytorch.org/docs/stable/generated/torch.jit.isinstance.html) in primitive transforms, the above problem can be alleviated. As a nice side-benefit, this would force the developer to always check the input types while implementing primitive transforms. 

```python
import torch
from typing import Any, List

#primitive transform
def foo(input: Any)->Any:
    if torch.jit.isinstance(input, List[int]):
        return input
    elif torch.jit.isinstance(input, int):
       return input
    else:
        raise TypeError

#primitive transform
def bar(input: Any)->Any:
    if torch.jit.isinstance(input, List[int]):    
        return input
    else:
        raise TypeError

#composite transform
def goo(input: List[int]):
    x = bar(foo(input))
    return x

goo_jit = torch.jit.script(goo)

#composite transform
def foofoo(input: List[int], use_foo:bool = True):
    output = bar(input)
    if use_foo:
        output = foo(output)
 
    return output

foofoo_jit = torch.jit.script(foofoo)
```
 
## Other concerns
* As we remove the type annotations, we would add the doc-strings to ensure that the user is aware of supported input types.

 



