### PR TITLE
[fbsync] Fix issue in label Transform

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -95,6 +95,9 @@ class TestTransforms(TorchtextTestCase):
         expected = [0, 1, 2]
         self.assertEqual(actual, expected)
 
+        with self.assertRaises(RuntimeError):
+            transform(['OOV'])
+
         transform = transforms.LabelToIndex(label_names=label_names, sort_names=True)
         actual = transform(label_names)
         expected = [2, 1, 0]

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -130,7 +130,7 @@ class LabelToIndex(Module):
 
         if sort_names:
             label_names = sorted(label_names)
-        self._label_vocab = Vocab(torch.classes.torchtext.Vocab(label_names, 0))
+        self._label_vocab = Vocab(torch.classes.torchtext.Vocab(label_names, None))
         self._label_names = self._label_vocab.get_itos()
 
     def forward(self, labels: Union[str, List[str]]) -> Union[int, List[int]]:


### PR DESCRIPTION
Summary: In the construction of Vocab within label transform, the default index is set to 0. This index is returned when OOV token is given. For this transform, the default index should never be set. Otherwise, it will return default index (which is 0) for unknown labels that might get passed (Ideally it should throw error in this case because we do not know what to do when wrong label is passed for query)

Reviewed By: hudeven

Differential Revision: D32610834

fbshipit-source-id: e49385fb313929627c41fc515b6d900a6bfc3591