### PR TITLE
[fbsync] Fix SST2Dataset test iterator

### DIFF
--- a/test/experimental/test_datasets.py
+++ b/test/experimental/test_datasets.py
@@ -10,7 +10,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 class TestDataset(TorchtextTestCase):
     @skipIfNoModule("torchdata")
-    def test_sst2__dataset(self):
+    def test_sst2_dataset(self):
 
         split = ("train", "dev", "test")
         train_dataset, dev_dataset, test_dataset = sst2.SST2(

--- a/torchtext/experimental/datasets/sst2.py
+++ b/torchtext/experimental/datasets/sst2.py
@@ -43,7 +43,7 @@ _EXTRACTED_FILES_MD5 = {
 _FIRST_LINE_MD5 = {
     "train": "2552b8cecd57b2e022ef23411c688fa8",
     "dev": "1b0ffd6aa5f2bf0fd9840a5f6f1a9f07",
-    "test": "f838c81fe40bfcd7e42e9ffc4dd004f7",
+    "test": "3e7ff69ab3fc6d026e3c96cadd8b0b53",
 }
 
 DATASET_NAME = "SST2"
@@ -97,6 +97,13 @@ class SST2Dataset(IterableDataset):
         )
 
         # Parse CSV file and yield data samples
-        return extracted_files.parse_csv(skip_lines=1, delimiter="\t").map(
-            lambda x: (x[0], x[1])
-        )
+        if split == "test":
+            parsed_data = extracted_files.parse_csv(skip_lines=1, delimiter="\t").map(
+                lambda x: (x[1],)
+            )
+        else:
+            parsed_data = extracted_files.parse_csv(skip_lines=1, delimiter="\t").map(
+                lambda x: (x[0], x[1])
+            )
+
+        return parsed_data


### PR DESCRIPTION
Summary:
## Summary
- Modified SST2 dataset implementation to only return text for test split (since label_ids are not available)
- Updated doc classification datamodule to temporarily use `val_dataset` instead of `test_dataset`
- Updated first line md5 hash for SST2 test split

## Followup Items
- Update doc classification module to work with test splits with and without labels

Reviewed By: parmeet

Differential Revision: D32661112

fbshipit-source-id: ef86aea0ce587c5d5282f2caa943b4b0cdf6f54a