### PR TITLE
replace string typing with pkg_resources.parse_version

### DIFF
--- a/test/data/test_utils.py
+++ b/test/data/test_utils.py
@@ -1,5 +1,6 @@
 import io
 from torchtext.data import get_tokenizer
+from torchtext.data.utils import get_torch_version
 from torchtext.utils import unicode_csv_reader
 from ..common.torchtext_test_case import TorchtextTestCase
 from ..common.assets import get_asset_path
@@ -48,3 +49,12 @@ class TestUtils(TorchtextTestCase):
                 ref_lines.append(line)
 
         self.assertEqual(ref_lines, test_lines)
+
+    def test_version_parsing(self):
+        import torch
+        # Assign a torch version arbitrarily
+        version = (1, 10, 1)
+        major, minor, patch = version
+        torch.__version__ = ".".join(map(str, version))
+        parsed_major, parsed_minor = get_torch_version()
+        self.assertEqual((parsed_major, parsed_minor), (major, minor))

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -196,10 +196,9 @@ def interleave_keys(a, b):
 
 def get_torch_version():
     import torch
-    v = torch.__version__
-    version_substrings = v.split('.')
-    major, minor = version_substrings[0], version_substrings[1]
-    return int(major), int(minor)
+    from pkg_resources import parse_version
+    version = parse_version(torch.__version__)
+    return version.major, version.minor
 
 
 def dtype_to_attr(dtype):


### PR DESCRIPTION
Instead of using string methods to parse version information, we can use tested and standard tools in the standard library.