### PR TITLE
Remove Python 3.6 support as it has reached EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,9 +614,6 @@ workflows:
     jobs:
       - circleci_consistency
       - binary_linux_wheel:
-          name: binary_linux_wheel_py3.6
-          python_version: '3.6'
-      - binary_linux_wheel:
           name: binary_linux_wheel_py3.7
           python_version: '3.7'
       - binary_linux_wheel:
@@ -631,9 +628,6 @@ workflows:
           name: binary_linux_wheel_py3.9
           python_version: '3.9'
       - binary_macos_wheel:
-          name: binary_macos_wheel_py3.6
-          python_version: '3.6'
-      - binary_macos_wheel:
           name: binary_macos_wheel_py3.7
           python_version: '3.7'
       - binary_macos_wheel:
@@ -642,9 +636,6 @@ workflows:
       - binary_macos_wheel:
           name: binary_macos_wheel_py3.9
           python_version: '3.9'
-      - binary_windows_wheel:
-          name: binary_windows_wheel_py3.6
-          python_version: '3.6'
       - binary_windows_wheel:
           name: binary_windows_wheel_py3.7
           python_version: '3.7'
@@ -655,9 +646,6 @@ workflows:
           name: binary_windows_wheel_py3.9
           python_version: '3.9'
       - binary_linux_conda:
-          name: binary_linux_conda_py3.6
-          python_version: '3.6'
-      - binary_linux_conda:
           name: binary_linux_conda_py3.7
           python_version: '3.7'
       - binary_linux_conda:
@@ -667,9 +655,6 @@ workflows:
           name: binary_linux_conda_py3.9
           python_version: '3.9'
       - binary_macos_conda:
-          name: binary_macos_conda_py3.6
-          python_version: '3.6'
-      - binary_macos_conda:
           name: binary_macos_conda_py3.7
           python_version: '3.7'
       - binary_macos_conda:
@@ -678,9 +663,6 @@ workflows:
       - binary_macos_conda:
           name: binary_macos_conda_py3.9
           python_version: '3.9'
-      - binary_windows_conda:
-          name: binary_windows_conda_py3.6
-          python_version: '3.6'
       - binary_windows_conda:
           name: binary_windows_conda_py3.7
           python_version: '3.7'
@@ -720,15 +702,10 @@ workflows:
     jobs:
       - cachesetup_linux:
           name: cachesetup_linux_py_any
-          python_version: '3.6'
-      - unittest_linux:
-          name: unittest_linux_py3.6
-          python_version: '3.6'
-          requires:
-          - cachesetup_linux_py_any
+          python_version: '3.7'
       - stylecheck:
-          name: stylecheck_py3.6
-          python_version: '3.6'
+          name: stylecheck_py_any
+          python_version: '3.7'
       - unittest_linux:
           name: unittest_linux_py3.7
           python_version: '3.7'
@@ -746,12 +723,7 @@ workflows:
           - cachesetup_linux_py_any
       - cachesetup_windows:
           name: cachesetup_windows_py_any
-          python_version: '3.6'
-      - unittest_windows:
-          name: unittest_windows_py3.6
-          python_version: '3.6'
-          requires:
-          - cachesetup_windows_py_any
+          python_version: '3.7'
       - unittest_windows:
           name: unittest_windows_py3.7
           python_version: '3.7'
@@ -773,34 +745,6 @@ workflows:
           filters:
             branches:
               only: nightly
-      - binary_linux_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6
-          python_version: '3.6'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.6
-      - smoke_test_linux_pip:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_wheel_py3.6_upload
       - binary_linux_wheel:
           filters:
             branches:
@@ -891,24 +835,6 @@ workflows:
               only: nightly
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.6
-          python_version: '3.6'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.6_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.6
-      - binary_macos_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: nightly_binary_macos_wheel_py3.7
           python_version: '3.7'
       - binary_wheel_upload:
@@ -957,34 +883,6 @@ workflows:
           name: nightly_binary_macos_wheel_py3.9_upload
           requires:
           - nightly_binary_macos_wheel_py3.9
-      - binary_windows_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6
-          python_version: '3.6'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_upload
-          requires:
-          - nightly_binary_windows_wheel_py3.6
-      - smoke_test_windows_pip:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_wheel_py3.6_upload
       - binary_windows_wheel:
           filters:
             branches:
@@ -1075,34 +973,6 @@ workflows:
               only: nightly
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6
-          python_version: '3.6'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_upload
-          requires:
-          - nightly_binary_linux_conda_py3.6
-      - smoke_test_linux_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_conda_py3.6_upload
-      - binary_linux_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: nightly_binary_linux_conda_py3.7
           python_version: '3.7'
       - binary_conda_upload:
@@ -1187,24 +1057,6 @@ workflows:
               only: nightly
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.6
-          python_version: '3.6'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.6_upload
-          requires:
-          - nightly_binary_macos_conda_py3.6
-      - binary_macos_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: nightly_binary_macos_conda_py3.7
           python_version: '3.7'
       - binary_conda_upload:
@@ -1253,34 +1105,6 @@ workflows:
           name: nightly_binary_macos_conda_py3.9_upload
           requires:
           - nightly_binary_macos_conda_py3.9
-      - binary_windows_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6
-          python_version: '3.6'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_upload
-          requires:
-          - nightly_binary_windows_conda_py3.6
-      - smoke_test_windows_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_conda_py3.6_upload
       - binary_windows_conda:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -703,14 +703,14 @@ workflows:
       - cachesetup_linux:
           name: cachesetup_linux_py_any
           python_version: '3.7'
-      - stylecheck:
-          name: stylecheck_py_any
-          python_version: '3.7'
       - unittest_linux:
           name: unittest_linux_py3.7
           python_version: '3.7'
           requires:
           - cachesetup_linux_py_any
+      - stylecheck:
+          name: stylecheck_py3.7
+          python_version: '3.7'
       - unittest_linux:
           name: unittest_linux_py3.8
           python_version: '3.8'

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -20,7 +20,7 @@ import yaml
 import os.path
 
 
-PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
+PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
 
 DOC_VERSION = ('linux', '3.8')
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ We recommend Anaconda as a Python package management system. Please refer to `py
    :header: "PyTorch version", "torchtext version", "Supported Python version"
    :widths: 10, 10, 10
 
-   nightly build, main, ">=3.6, <=3.9"
+   nightly build, main, ">=3.7, <=3.9"
    1.10.0, 0.11.0, ">=3.6, <=3.9" 
    1.9.1, 0.10.1, ">=3.6, <=3.9" 
    1.9, 0.10, ">=3.6, <=3.9"

--- a/setup.py
+++ b/setup.py
@@ -92,12 +92,9 @@ setup_info = dict(
     ],
     python_requires='>=3.5',
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.9',
     ],
     # Package info
     packages=find_packages(exclude=('test*', 'build_tools*')),


### PR DESCRIPTION
Python 3.6 reached [EOL](https://endoflife.date/python) last month. PyTorch core is going to do the same in pytorch/pytorch#69005. Other libraries doing the same are:
- Torchvision pytorch/vision#5152
- Torchdata pytorch/data#156
- Torchaudio pytorch/audio#2051

This should also fix the CircleCI failures in 3_6 conda builds