### PR TITLE
fix max sequence length for xlmr transform

### DIFF
--- a/torchtext/models/roberta/bundler.py
+++ b/torchtext/models/roberta/bundler.py
@@ -158,7 +158,7 @@ XLMR_BASE_ENCODER = RobertaModelBundle(
     transform=lambda: T.Sequential(
         T.SentencePieceTokenizer(urljoin(_TEXT_BUCKET, "xlmr.sentencepiece.bpe.model")),
         T.VocabTransform(load_state_dict_from_url(urljoin(_TEXT_BUCKET, "xlmr.vocab.pt"))),
-        T.Truncate(510),
+        T.Truncate(254),
         T.AddToken(token=0, begin=True),
         T.AddToken(token=2, begin=False),
     )


### PR DESCRIPTION
The max sequence length for base architecture is 256. This PR fixes it.