### PR TITLE
Remove redundant get asset functions from parameterized_utils file

### DIFF
--- a/test/common/parameterized_utils.py
+++ b/test/common/parameterized_utils.py
@@ -1,17 +1,10 @@
 import json
+
 from parameterized import param
-import os.path
 
-
-_TEST_DIR_PATH = os.path.realpath(
-    os.path.join(os.path.dirname(__file__), '..'))
-
-
-def get_asset_path(*paths):
-    """Return full path of a test asset"""
-    return os.path.join(_TEST_DIR_PATH, 'asset', *paths)
+from .assets import get_asset_path
 
 
 def load_params(*paths):
-    with open(get_asset_path(*paths), 'r') as file:
+    with open(get_asset_path(*paths), "r") as file:
         return [param(json.loads(line)) for line in file]


### PR DESCRIPTION
## Summary
- Both `test/common/assets.py` and `test/common/parameterized_utils.py` files have a constant for the path to the assets directory and a `get_asset_path` method
- We remove these redundant constants/methods from `test/common/parameterized_utils.py` and instead use the implementation from `test/common/assets.py`

## Test
- `pytest test/data/test_builtin_datasets.py`
   - Note: the above tests only run on circleci and fail when run locally since the datasets are not cached

## Followup

- [ ] Update `common/__init__.py` file with `__all__` variable to list the public objects within the `test/common` module