### PR TITLE
run tests in parallel with pytest-xdist.

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -11,6 +11,7 @@ dependencies:
     - revtok
     - pytest
     - pytest-cov
+    - pytest-xdist
     - pytest-pythonpath
     - sacremoses
     - spacy

--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -6,4 +6,4 @@ eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
 python -m torch.utils.collect_env
-pytest --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 test
+pytest --tx "3*popen//python=python" --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 test

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -11,6 +11,7 @@ dependencies:
     - revtok
     - pytest
     - pytest-cov
+    - pytest-xdist
     - pytest-pythonpath
     - sacremoses
     - spacy

--- a/.circleci/unittest/windows/scripts/run_test.sh
+++ b/.circleci/unittest/windows/scripts/run_test.sh
@@ -6,4 +6,4 @@ eval "$(./conda/Scripts/conda.exe 'shell.bash' 'hook')"
 conda activate ./env
 
 python -m torch.utils.collect_env
-pytest --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 test
+pytest --tx "3*popen//python=python" --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 test


### PR DESCRIPTION
This is an improvement for status-quo test speed performance. Eventually we'll want to rework the caching situation, but we can get decent perf by running in parallel.