### PR TITLE
Removing unused TEST_MODELS_PARAMETERIZED_ARGS constant from model test

### DIFF
--- a/test/integration_tests/test_models.py
+++ b/test/integration_tests/test_models.py
@@ -10,21 +10,6 @@ from ..common.assets import get_asset_path
 from ..common.parameterized_utils import nested_params
 from ..common.torchtext_test_case import TorchtextTestCase
 
-TEST_MODELS_PARAMETERIZED_ARGS = [
-    ("xlmr.base.output.pt", "XLMR base Model Comparison", XLMR_BASE_ENCODER),
-    ("xlmr.large.output.pt", "XLMR base Model Comparison", XLMR_LARGE_ENCODER),
-    (
-        "roberta.base.output.pt",
-        "Roberta base Model Comparison",
-        ROBERTA_BASE_ENCODER,
-    ),
-    (
-        "roberta.large.output.pt",
-        "Roberta base Model Comparison",
-        ROBERTA_LARGE_ENCODER,
-    ),
-]
-
 
 class TestModels(TorchtextTestCase):
     @nested_params(


### PR DESCRIPTION
- Removing unused TEST_MODELS_PARAMETERIZED_ARGS constant from model test (this was missed in #1502)