### PR TITLE
fix typo in torchtext/vocab/vocab_factory.py

### DIFF
--- a/torchtext/vocab/vocab_factory.py
+++ b/torchtext/vocab/vocab_factory.py
@@ -85,7 +85,7 @@ def build_vocab_from_iterator(iterator: Iterable, min_freq: int = 1, specials: O
         >>>     with io.open(file_path, encoding = 'utf-8') as f:
         >>>         for line in f:
         >>>             yield line.strip().split()
-        >>> vocab = build_vocab_from_iterator(yield_tokens_batch(file_path), specials=["<unk>"])
+        >>> vocab = build_vocab_from_iterator(yield_tokens(file_path), specials=["<unk>"])
     """
 
     counter = Counter()


### PR DESCRIPTION
Fix typo in doc of build_vocab_from_iterator.