### PR TITLE
Fix IWSLT2016 testing

### DIFF
--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -14,6 +14,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 SUPPORTED_LANGPAIRS = [(k, e) for k, v in SUPPORTED_DATASETS["language_pair"].items() for e in v]
 
+
 def _generate_uncleaned_train():
     """Generate tags files"""
     file_contents = []

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -17,6 +17,7 @@ SUPPORTED_LANGPAIRS = [(k, e) for k, v in SUPPORTED_DATASETS["language_pair"].it
 SUPPORTED_DEVTEST_SPLITS = SUPPORTED_DATASETS["valid_test"]
 DEV_TEST_SPLITS = [(dev, test) for dev, test in itertools.product(SUPPORTED_DEVTEST_SPLITS, repeat=2) if dev != test]
 
+
 def _generate_uncleaned_train():
     """Generate tags files"""
     file_contents = []
@@ -138,6 +139,7 @@ class TestIWSLT2016(TempDirMixin, TorchtextTestCase):
         if (dev_set not in SET_NOT_EXISTS[(src, tgt)] and test_set not in SET_NOT_EXISTS[(src, tgt)])
     ])
     def test_iwslt2016(self, split, src, tgt, dev_set, test_set):
+
         expected_samples = _get_mock_dataset(self.root_dir, split, src, tgt, dev_set, test_set)
 
         dataset = IWSLT2016(

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -22,10 +22,11 @@ def _generate_uncleaned_train():
         '<translator', '<title', '<speaker', '<doc', '</doc'
     ]
     for i in range(100):
-        # Write one of the XML tags randomly to make sure we clean appropriately
         rand_string = " ".join(
             random.choice(string.ascii_letters) for i in range(10)
         )
+        # With a 10% change, add one of the XML tags which is cleaned
+        # to ensure cleaning happens appropriately
         if random.random() < 0.1:
             open_tag = random.choice(xml_tags) + ">"
             close_tag = "</" + open_tag[1:] + ">"
@@ -43,7 +44,6 @@ def _generate_uncleaned_valid():
     for doc_id in range(5):
         file_contents.append(f'<doc docid="{doc_id}" genre="lectures">')
         for seg_id in range(100):
-            # Write one of the XML tags randomly to make sure we clean appropriately
             rand_string = " ".join(
                 random.choice(string.ascii_letters) for i in range(10)
             )

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -137,7 +137,7 @@ class TestIWSLT2016(TempDirMixin, TorchtextTestCase):
     def test_iwslt2016(self, split, src, tgt):
         expected_samples = _get_mock_dataset(self.root_dir, split, src, tgt)
 
-        dataset = IWSLT2016(root=self.root_dir, split=split)
+        dataset = IWSLT2016(root=self.root_dir, split=split, language_pair=(src, tgt))
 
         samples = list(dataset)
 

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -130,10 +130,10 @@ class TestIWSLT2016(TempDirMixin, TorchtextTestCase):
         super().tearDownClass()
 
     @parameterized.expand([
-        ("train", src, tgt),
-        ("valid", src, tgt),
-        ("test", src, tgt),
-    ] for src, tgt in SUPPORTED_LANGPAIRS)
+        (split, src, tgt)
+        for split in ("train", "valid", "test")
+        for src, tgt in SUPPORTED_LANGPAIRS
+    ])
     def test_iwslt2016(self, split, src, tgt):
         expected_samples = _get_mock_dataset(self.root_dir, split, src, tgt)
 

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -70,10 +70,11 @@ def _get_mock_dataset(root_dir, split, src, tgt):
     """
     root_dir: directory to the mocked dataset
     """
-    inner_temp_dataset_dir = f"{src}-{tgt}"
     outer_temp_dataset_dir = os.path.join(root_dir, f"IWSLT2016/2016-01/texts/{src}/{tgt}/")
-    os.makedirs(inner_temp_dataset_dir, exist_ok=True)
+    inner_temp_dataset_dir = os.path.join(outer_temp_dataset_dir, f"{src}-{tgt}")
+
     os.makedirs(outer_temp_dataset_dir, exist_ok=True)
+    os.makedirs(inner_temp_dataset_dir, exist_ok=True)
 
     mocked_data = defaultdict(lambda: defaultdict(list))
     valid_set = "tst2013"
@@ -126,7 +127,11 @@ class TestIWSLT2016(TempDirMixin, TorchtextTestCase):
         cls.patcher.stop()
         super().tearDownClass()
 
-    @parameterized.expand([("train", "de", "en"), ("valid", "de", "en")])
+    @parameterized.expand([
+        ("train", "de", "en"),
+        ("valid", "de", "en"),
+        ("test", "de", "en"),
+    ])
     def test_iwslt2016(self, split, src, tgt):
         expected_samples = _get_mock_dataset(self.root_dir, split, src, tgt)
 
@@ -137,7 +142,7 @@ class TestIWSLT2016(TempDirMixin, TorchtextTestCase):
         for sample, expected_sample in zip_equal(samples, expected_samples):
             self.assertEqual(sample, expected_sample)
 
-    @parameterized.expand(["train", "valid"])
+    @parameterized.expand(["train", "valid", "test"])
     def test_iwslt2016_split_argument(self, split):
         dataset1 = IWSLT2016(root=self.root_dir, split=split)
         (dataset2,) = IWSLT2016(root=self.root_dir, split=(split,))

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -70,7 +70,7 @@ def _get_mock_dataset(root_dir, split, src, tgt):
     """
     root_dir: directory to the mocked dataset
     """
-    outer_temp_dataset_dir = os.path.join(root_dir, f"IWSLT2016/2016-01/texts/{src}/{tgt}/")
+    outer_temp_dataset_dir = os.path.join(root_dir, f"IWSLT2016/temp_dataset_dir/2016-01/texts/{src}/{tgt}/")
     inner_temp_dataset_dir = os.path.join(outer_temp_dataset_dir, f"{src}-{tgt}")
 
     os.makedirs(outer_temp_dataset_dir, exist_ok=True)

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -102,12 +102,12 @@ def _get_mock_dataset(root_dir, split, src, tgt, valid_set, test_set):
         # new random strings. Otherwise generate new files and clean when read.
         if os.path.exists(expected_clean_filename):
             with open(expected_clean_filename, encoding="utf-8") as f:
-                mocked_data[(split, valid_set, test_set)][lang] = f.readlines()
+                mocked_data[split][lang] = f.readlines()
         else:
             out_file = os.path.join(inner_temp_dataset_dir, unclean_file_name)
             with open(out_file, "w") as f:
                 mocked_data_for_split, file_contents = _generate_uncleaned_contents(split)
-                mocked_data[(split, valid_set, test_set)][lang] = mocked_data_for_split
+                mocked_data[split][lang] = mocked_data_for_split
                 f.write(file_contents)
 
     inner_compressed_dataset_path = os.path.join(
@@ -124,7 +124,7 @@ def _get_mock_dataset(root_dir, split, src, tgt, valid_set, test_set):
     with tarfile.open(outer_temp_dataset_path, "w:gz") as tar:
         tar.add(outer_temp_dataset_dir, arcname="2016-01")
 
-    return list(zip(mocked_data[(split, valid_set, test_set)][src], mocked_data[(split, valid_set, test_set)][tgt]))
+    return list(zip(mocked_data[split][src], mocked_data[split][tgt]))
 
 
 class TestIWSLT2016(TempDirMixin, TorchtextTestCase):

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -83,18 +83,32 @@ def _get_mock_dataset(root_dir, split, src, tgt, valid_set, test_set):
 
     mocked_data = defaultdict(lambda: defaultdict(list))
 
-    _, uncleaned_file_names = _generate_iwslt_files_for_lang_and_split(16, src, tgt, valid_set, test_set)
-    src_file = uncleaned_file_names[src][split]
-    tgt_file = uncleaned_file_names[tgt][split]
+    cleaned_file_names, uncleaned_file_names = _generate_iwslt_files_for_lang_and_split(16, src, tgt, valid_set, test_set)
+    uncleaned_src_file = uncleaned_file_names[src][split]
+    uncleaned_tgt_file = uncleaned_file_names[tgt][split]
 
-    for file_name in (src_file, tgt_file):
-        out_file = os.path.join(inner_temp_dataset_dir, file_name)
-        with open(out_file, "w") as f:
-            # Get file extension (i.e., the language) without the . prefix (.en -> en)
-            lang = os.path.splitext(file_name)[1][1:]
-            mocked_data_for_split, file_contents = _generate_uncleaned_contents(split)
-            mocked_data[split][lang] = mocked_data_for_split
-            f.write(file_contents)
+    cleaned_src_file = cleaned_file_names[src][split]
+    cleaned_tgt_file = cleaned_file_names[tgt][split]
+
+    for (unclean_file_name, clean_file_name) in [
+        (uncleaned_src_file, cleaned_src_file),
+        (uncleaned_tgt_file, cleaned_tgt_file)
+    ]:
+        # Get file extension (i.e., the language) without the . prefix (.en -> en)
+        lang = os.path.splitext(unclean_file_name)[1][1:]
+        expected_clean_filename = os.path.join(inner_temp_dataset_dir, clean_file_name)
+
+        # If we've already written a clean file, read it, so we don't generate
+        # new random strings. Otherwise generate new files and clean when read.
+        if os.path.exists(expected_clean_filename):
+            with open(expected_clean_filename, encoding="utf-8") as f:
+                mocked_data[(split, valid_set, test_set)][lang] = f.readlines()
+        else:
+            out_file = os.path.join(inner_temp_dataset_dir, unclean_file_name)
+            with open(out_file, "w") as f:
+                mocked_data_for_split, file_contents = _generate_uncleaned_contents(split)
+                mocked_data[(split, valid_set, test_set)][lang] = mocked_data_for_split
+                f.write(file_contents)
 
     inner_compressed_dataset_path = os.path.join(
         outer_temp_dataset_dir, f"{src}-{tgt}.tgz"
@@ -105,12 +119,12 @@ def _get_mock_dataset(root_dir, split, src, tgt, valid_set, test_set):
         tar.add(inner_temp_dataset_dir, arcname=f"{src}-{tgt}")
 
     outer_temp_dataset_path = os.path.join(
-        root_dir, "2016-01.tgz"
+        root_dir, "IWSLT2016", "2016-01.tgz"
     )
     with tarfile.open(outer_temp_dataset_path, "w:gz") as tar:
         tar.add(outer_temp_dataset_dir, arcname="2016-01")
 
-    return list(zip(mocked_data[split][src], mocked_data[split][tgt]))
+    return list(zip(mocked_data[(split, valid_set, test_set)][src], mocked_data[(split, valid_set, test_set)][tgt]))
 
 
 class TestIWSLT2016(TempDirMixin, TorchtextTestCase):

--- a/test/datasets/test_iwslt2016.py
+++ b/test/datasets/test_iwslt2016.py
@@ -6,12 +6,13 @@ from collections import defaultdict
 from unittest.mock import patch
 
 from parameterized import parameterized
-from torchtext.datasets.iwslt2016 import IWSLT2016
+from torchtext.datasets.iwslt2016 import IWSLT2016, SUPPORTED_DATASETS
 from torchtext.data.datasets_utils import _generate_iwslt_files_for_lang_and_split
 
 from ..common.case_utils import TempDirMixin, zip_equal
 from ..common.torchtext_test_case import TorchtextTestCase
 
+SUPPORTED_LANGPAIRS = [(k, e) for k, v in SUPPORTED_DATASETS["language_pair"].items() for e in v]
 
 def _generate_uncleaned_train():
     """Generate tags files"""
@@ -70,7 +71,7 @@ def _get_mock_dataset(root_dir, split, src, tgt):
     """
     root_dir: directory to the mocked dataset
     """
-    outer_temp_dataset_dir = os.path.join(root_dir, f"IWSLT2016/temp_dataset_dir/2016-01/texts/{src}/{tgt}/")
+    outer_temp_dataset_dir = os.path.join(root_dir, f"IWSLT2016/2016-01/texts/{src}/{tgt}/")
     inner_temp_dataset_dir = os.path.join(outer_temp_dataset_dir, f"{src}-{tgt}")
 
     os.makedirs(outer_temp_dataset_dir, exist_ok=True)
@@ -128,10 +129,10 @@ class TestIWSLT2016(TempDirMixin, TorchtextTestCase):
         super().tearDownClass()
 
     @parameterized.expand([
-        ("train", "de", "en"),
-        ("valid", "de", "en"),
-        ("test", "de", "en"),
-    ])
+        ("train", src, tgt),
+        ("valid", src, tgt),
+        ("test", src, tgt),
+    ] for src, tgt in SUPPORTED_LANGPAIRS)
     def test_iwslt2016(self, split, src, tgt):
         expected_samples = _get_mock_dataset(self.root_dir, split, src, tgt)
 


### PR DESCRIPTION
This serves as a patch to the newly-added IWSLT2016 mock testing which addresses two issues:

1. Starting from the downloaded archive to test the extraction and cleaning pipeline more fully
2. Adds missed test split testing path

cc @parmeet 