### PR TITLE
fixes platform-dependent expectation for Multi30k mocked test.

### DIFF
--- a/test/datasets/test_multi30k.py
+++ b/test/datasets/test_multi30k.py
@@ -29,9 +29,8 @@ def _get_mock_dataset(root_dir):
                 rand_string = " ".join(
                     random.choice(string.ascii_letters) for i in range(seed)
                 )
-                content = f"{rand_string}\n"
-                f.write(content)
-                mocked_data[file_name].append(content)
+                f.write(rand_string + "\n")
+                mocked_data[file_name].append(rand_string)
                 seed += 1
 
     archive = {}

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -77,7 +77,7 @@ def Multi30k(root: str, split: Union[Tuple[str], str], language_pair: Tuple[str]
         lambda x: f"{_PREFIX[split]}.{language_pair[1]}" in x[0])
     tgt_cache_decompressed_dp = tgt_cache_decompressed_dp.end_caching(mode="wb", same_filepath_fn=True)
 
-    src_data_dp = FileOpener(src_cache_decompressed_dp, mode="b").readlines(decode=True, return_path=False, strip_newline=False)
-    tgt_data_dp = FileOpener(tgt_cache_decompressed_dp, mode="b").readlines(decode=True, return_path=False, strip_newline=False)
+    src_data_dp = FileOpener(src_cache_decompressed_dp, mode="b").readlines(decode=True, return_path=False, strip_newline=True)
+    tgt_data_dp = FileOpener(tgt_cache_decompressed_dp, mode="b").readlines(decode=True, return_path=False, strip_newline=True)
 
     return src_data_dp.zip(tgt_data_dp)


### PR DESCRIPTION
Tests currently fail on Windows because multi30k doesn't strip newlines and therefore the file is read with carriage returns: `"ABCD\r\n" != "ABC\n"`. This fixes the bug by stripping newlines from Multi30k to be consistent with other datasets.

Technically this is a BC and users can revert it in userland code by appending `os.linesep` to each line as needed.