### PR TITLE
remove experimental import in release branch

### DIFF
--- a/packaging/torchtext/meta.yaml
+++ b/packaging/torchtext/meta.yaml
@@ -42,7 +42,6 @@ test:
     - torchtext
     - torchtext.datasets
     - torchtext.data
-    - torchtext.experimental
 
   source_files:
     - test


### PR DESCRIPTION
Experimental features are not available in release branch. Remove it from conda packaging test.