### PR TITLE
Fix for windows builds with python 3.10 , getting rid of ssize_t

### DIFF
--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -120,14 +120,14 @@ PYBIND11_MODULE(_torchtext, m) {
       .def(
           "__contains__",
           [](c10::intrusive_ptr<Vocab>& self, const py::str& item) -> bool {
-            ssize_t length;
+            Py_ssize_t length;
             const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
             return self->__contains__(c10::string_view{buffer, (size_t)length});
           })
       .def(
           "__getitem__",
           [](c10::intrusive_ptr<Vocab>& self, const py::str& item) -> int64_t {
-            ssize_t length;
+            Py_ssize_t length;
             const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
             return self->__getitem__(c10::string_view{buffer, (size_t)length});
           })
@@ -144,7 +144,7 @@ PYBIND11_MODULE(_torchtext, m) {
             std::vector<int64_t> indices(items.size());
             int64_t counter = 0;
             for (const auto& item : items) {
-              ssize_t length;
+              Py_ssize_t length;
               const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
               indices[counter++] =
                   self->__getitem__(c10::string_view{buffer, (size_t)length});


### PR DESCRIPTION
Fix for windows builds with python 3.10 , getting rid of ssize_t

This is to fix error when building with Python 3.10 on windows:
Ref: https://app.circleci.com/pipelines/github/pytorch/text/4984/workflows/5df0236c-4758-412d-8a08-e50aa120be39/jobs/166014

Error details:

```
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(123): error C2065: 'ssize_t': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(123): error C2146: syntax error: missing ';' before identifier 'length'
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(123): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(124): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(125): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(130): error C2065: 'ssize_t': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(130): error C2146: syntax error: missing ';' before identifier 'length'
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(130): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(131): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(132): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(147): error C2065: 'ssize_t': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(147): error C2146: syntax error: missing ';' before identifier 'length'
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(147): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(148): error C2065: 'length': undeclared identifier
C:\Users\circleci\project\torchtext\csrc\register_pybindings.cpp(150): error C2065: 'length': undeclared identifier
ninja: build stopped: subcommand failed.
Traceback (most recent call last):
  File "C:\Users\circleci\project\env\lib\site-packages\torch\utils\cpp_extension.py", line 1726, in _run_ninja_build
    subprocess.run(
  File "C:\Users\circleci\project\env\lib\subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.
```

Similar PR for pytorch core [here](https://github.com/pytorch/pytorch/commit/efd274bbcbede795f22c12318e618ce2cf4f435d) and [here](https://github.com/pytorch/pytorch/pull/71250)


Summary for usage guidelines:
Use `Py_ssize_t` when calling Python API
Use `c10::irange` to automatically infer loop type
Use `size_t` or `unsigned` for unsigned type

Reference issue: [here](https://github.com/pytorch/pytorch/issues/69948)