### PR TITLE
remove install instructions from tutorial

### DIFF
--- a/examples/tutorials/sst2_classification_non_distributed.py
+++ b/examples/tutorials/sst2_classification_non_distributed.py
@@ -18,14 +18,6 @@ SST-2 Binary text classification with XLM-RoBERTa model
 # 3. instantiate classification model using pre-trained XLM-R encoder
 #
 #
-# To run this tutorial, please install torchtext nightly and TorchData (following commands will do in google Colab)
-#
-# ::
-#
-#   !pip3 install --pre --upgrade torchtext -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-#   !pip install --user "git+https://github.com/pytorch/data.git"
-#
-
 
 ######################################################################
 # Common imports


### PR DESCRIPTION
The installation instructions corresponds to nightly release. As we are getting close to release, we can remove them as users would be able to run this using the released binaries.