### PR TITLE
replace git+git with git+https in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests
 nltk
 spacy
 sacremoses
-git+git://github.com/jekbradbury/revtok.git
+git+https://github.com/jekbradbury/revtok.git
 
 # Documentation
 Sphinx


### PR DESCRIPTION
Installing the requirements breaks starting today due to: https://github.blog/2021-09-01-improving-git-protocol-security-github/
with:
```
pip install --no-cache-dir -r requirements.txt
Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
Collecting git+git://github.com/jekbradbury/revtok.git (from -r requirements.txt (line 11))
  Cloning git://github.com/jekbradbury/revtok.git to /tmp/pip-req-build-inn0fxa2
  Running command git clone -q git://github.com/jekbradbury/revtok.git /tmp/pip-req-build-inn0fxa2
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
This PR should fix this build issue.

CC @malfet @atalman 