### PR TITLE
Install torchdata from nightly release in CI

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -13,8 +13,8 @@ conda activate ./env
 printf "* Installing PyTorch\n"
 conda install -y -c "pytorch-${UPLOAD_CHANNEL}" ${CONDA_CHANNEL_FLAGS} pytorch cpuonly
 
-printf "Installing torchdata from source\n"
-pip install git+https://github.com/pytorch/data.git
+printf "Installing torchdata nightly\n"
+pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 printf "* Installing torchtext\n"
 git submodule update --init --recursive

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -18,8 +18,8 @@ conda activate ./env
 printf "* Installing PyTorch\n"
 conda install -y -c "pytorch-${UPLOAD_CHANNEL}" ${CONDA_CHANNEL_FLAGS} pytorch cpuonly
 
-printf "Installing torchdata from source\n"
-pip install git+https://github.com/pytorch/data.git
+printf "Installing torchdata nightly\n"
+pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 printf "* Installing torchtext\n"
 git submodule update --init --recursive


### PR DESCRIPTION
Now that torchdata nightly releases are available, this PR will install that version instead from source. This should reduce the amount of noise coming from accidental torchdata failures.

In addition, some "ci/circleci: unittests" seem to be [failing](https://app.circleci.com/pipelines/github/pytorch/text/5139/workflows/601f2b62-ce43-4f8f-975a-631be15c16f8/jobs/172078) because it cannot find the module `torch` during the installation of `torchdata`. This also fixes that.
