### PR TITLE
Add benchmark for roberta prepoc pipelines

### DIFF
--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -1,0 +1,145 @@
+from argparse import ArgumentParser
+from functools import partial
+from typing import Dict, Any
+
+import torcharrow as ta
+import torcharrow.dtypes as dt
+import torcharrow.pytorch as tap
+import torchtext.functional as F
+import torchtext.transforms as T
+from benchmark.utils import Timer
+from torch.hub import load_state_dict_from_url
+from torch.nn import Module
+from torch.utils.data import DataLoader
+from torchtext.datasets import DATASETS
+
+
+class RobertaTransformDataPipe(Module):
+    def __init__(self) -> None:
+        super().__init__()
+        # Instantiate various transforms
+
+        # Tokenizer to split input text into tokens
+        encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
+        vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
+        self.tokenizer = T.GPT2BPETokenizer(encoder_json_path, vocab_bpe_path)
+
+        # vocabulary converting tokens to IDs
+        vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
+        self.vocab = T.VocabTransform(load_state_dict_from_url(vocab_path))
+
+        # Add BOS token to the beginning of sentence
+        self.add_bos = T.AddToken(token=0, begin=True)
+
+        # Add EOS token to the end of sentence
+        self.add_eos = T.AddToken(token=2, begin=False)
+
+    def forward(self, input: Dict[str, Any]) -> Dict[str, Any]:
+        tokens = self.tokenizer(input["text"])
+        tokens = F.truncate(tokens, max_seq_len=254)
+        tokens = self.vocab(tokens)
+        tokens = self.add_bos(tokens)
+        tokens = self.add_eos(tokens)
+        input["tokens"] = tokens
+        return input
+
+
+class RobertaTransformDataFrame(Module):
+    def __init__(self) -> None:
+        super().__init__()
+        # Instantiate various transforms
+
+        # Tokenizer to split input text into tokens
+        encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
+        vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
+        self.tokenizer = T.GPT2BPETokenizer(encoder_json_path, vocab_bpe_path)
+
+        # vocabulary converting tokens to IDs
+        vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
+        self.vocab = T.VocabTransform(load_state_dict_from_url(vocab_path))
+
+        # Add BOS token to the beginning of sentence
+        self.add_bos = T.AddToken(token=0, begin=True)
+
+        # Add EOS token to the end of sentence
+        self.add_eos = T.AddToken(token=2, begin=False)
+
+    def forward(self, input: ta.DataFrame) -> ta.DataFrame:
+        input["tokens"] = input["text"].map(self.tokenizer.forward, dtype=dt.List(dt.string))
+        input["tokens"] = input["tokens"].list.slice(stop=254)
+        input["tokens"] = input["tokens"].map(self.vocab, dtype=dt.List(dt.int32))
+        input["tokens"] = input["tokens"].map(self.add_bos)
+        input["tokens"] = input["tokens"].map(self.add_eos)
+        return input
+
+
+def benchmark_roberta_datapipe(args):
+    print("********Running Benchmark using DataPipes**************\n")
+    batch_size = args.batch_size
+    dataset_name = args.dataset_name
+    columns = args.columns
+
+    # Instantiate transform
+    with Timer("Initialize Roberta Transform (for datapipe)"):
+        transform = RobertaTransformDataPipe()
+
+    with Timer("Initialize datapipe"):
+        # Create SST2 datapipe and apply pre-processing
+        train_dp = DATASETS[dataset_name](split="train")
+        train_dp = train_dp.batch(batch_size).rows2columnar(columns)
+
+        # Apply text pre-processing
+        train_dp = train_dp.map(transform)
+
+        # convert to Tensor
+        train_dp = train_dp.map(partial(F.to_tensor, padding_value=1), input_col="tokens")
+        train_dp = train_dp.map(F.to_tensor, input_col="label")
+
+    # create DataLoader
+    dl = DataLoader(train_dp, batch_size=None)
+
+    with Timer("Execute datapipe"):
+        list(dl)
+
+
+def benchmark_roberta_dataframe(args):
+    print("****************Running Benchmark using TorchArrow Dataframes*********************\n")
+    batch_size = args.batch_size
+    dataset_name = args.dataset_name
+    columns = args.columns
+
+    # Instantiate transform
+    with Timer("Initialize Roberta Transform (for DataFrame)"):
+        transform = RobertaTransformDataFrame()
+
+    with Timer("Initialize datapipe"):
+        # Create SST2 datapipe and apply pre-processing
+        train_dp = DATASETS[dataset_name](split="train")
+
+        # convert to DataFrame of size batches
+        # TODO: Figure out how to create DataFrame of larger size and create batches consequently
+        train_dp = train_dp.dataframe(columns=columns, dataframe_size=batch_size)
+
+        # Apply transformation on DataFrame
+        train_dp = train_dp.map(transform)
+
+        # Remove not required columns
+        train_dp = train_dp.map(lambda x: x.drop(["text"]))
+
+        # convert DataFrame to tensor (This will yeild named tuple)
+        train_dp = train_dp.map(lambda x: x.to_tensor({"tokens": tap.PadSequence(padding_value=1)}))
+
+    # create DataLoader
+    dl = DataLoader(train_dp, batch_size=None)
+
+    with Timer("Execute datapipe"):
+        list(dl)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--batch-size", default=32, type=int)
+    parser.add_argument("--dataset-name", default="SST2", type=str)
+    parser.add_argument("--columns", default=["text", "label"], nargs="+")
+    benchmark_roberta_datapipe(parser.parse_args())
+    benchmark_roberta_dataframe(parser.parse_args())

--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -96,8 +96,9 @@ class RobertaTransformDataFrame(Module):
     def forward(self, input: ta.DataFrame) -> ta.DataFrame:
         input["tokens"] = ta_F.bpe_tokenize(self.tokenizer, input["text"])
         input["tokens"] = input["tokens"].list.slice(stop=254)
-        input["tokens"] = ta_F.lookup_indices(self.vocab, input["tokens"])
-        input["tokens"]._dtype = dt.List(dt.int64)
+        token_ids = ta_F.lookup_indices(self.vocab, input["tokens"])
+        token_ids._dtype = dt.List(dt.int64)
+        input["tokens"] = token_ids
         input["tokens"] = input["tokens"].transform(self.add_bos, format="python")
         input["tokens"] = input["tokens"].transform(self.add_eos, format="python")
         return input
@@ -162,8 +163,8 @@ def benchmark_roberta_dataframe(args):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument("--batch-size", default=4, type=int)
+    parser.add_argument("--batch-size", default=32, type=int)
     parser.add_argument("--dataset-name", default="SST2", type=str)
     parser.add_argument("--columns", default=["text", "label"], nargs="+")
-    # benchmark_roberta_datapipe(parser.parse_args())
+    benchmark_roberta_datapipe(parser.parse_args())
     benchmark_roberta_dataframe(parser.parse_args())

--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -10,7 +10,6 @@ import torchtext.transforms as T
 from benchmark.utils import Timer
 from torch.hub import load_state_dict_from_url
 from torch.nn import Module
-from torch.utils.data import DataLoader
 from torchtext.datasets import DATASETS
 
 
@@ -99,11 +98,8 @@ def benchmark_roberta_datapipe(args):
         train_dp = train_dp.map(partial(F.to_tensor, padding_value=1), input_col="tokens")
         train_dp = train_dp.map(F.to_tensor, input_col="label")
 
-    # create DataLoader
-    dl = DataLoader(train_dp, batch_size=None)
-
     with Timer("Execute Pipeline"):
-        list(dl)
+        list(train_dp)
 
 
 def benchmark_roberta_dataframe(args):
@@ -133,11 +129,8 @@ def benchmark_roberta_dataframe(args):
         # convert DataFrame to tensor (This will yeild named tuple)
         train_dp = train_dp.map(lambda x: x.to_tensor({"tokens": tap.PadSequence(padding_value=1)}))
 
-    # create DataLoader
-    dl = DataLoader(train_dp, batch_size=None)
-
     with Timer("Execute Pipeline"):
-        list(dl)
+        list(train_dp)
 
 
 if __name__ == "__main__":
@@ -145,5 +138,5 @@ if __name__ == "__main__":
     parser.add_argument("--batch-size", default=32, type=int)
     parser.add_argument("--dataset-name", default="SST2", type=str)
     parser.add_argument("--columns", default=["text", "label"], nargs="+")
-    # benchmark_roberta_datapipe(parser.parse_args())
+    benchmark_roberta_datapipe(parser.parse_args())
     benchmark_roberta_dataframe(parser.parse_args())

--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -70,7 +70,7 @@ def benchmark_roberta_dataframe(args, native_ops):
         # Remove not required columns
         train_dp = train_dp.map(lambda x: x.drop(["text"]))
 
-        # convert DataFrame to tensor (This will yeild named tuple)
+        # convert DataFrame to tensor (This will yield named tuple)
         train_dp = train_dp.map(lambda x: x.to_tensor({"tokens": tap.PadSequence(padding_value=1)}))
 
     with Timer("Execute Pipeline"):

--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -1,134 +1,15 @@
-import json
+import os, sys
 from argparse import ArgumentParser
 from functools import partial
-from typing import Dict, Any
 
-import torch
-import torcharrow as ta
-import torcharrow._torcharrow as _ta
-import torcharrow.dtypes as dt
 import torcharrow.pytorch as tap
 import torchtext.functional as F
-import torchtext.transforms as T
 from benchmark.utils import Timer
-from torch.hub import load_state_dict_from_url
-from torch.nn import Module
-from torcharrow import functional as ta_F
 from torchtext.datasets import DATASETS
-from torchtext.utils import get_asset_local_path
 
-
-class RobertaTransformDataPipe(Module):
-    def __init__(self) -> None:
-        super().__init__()
-        # Instantiate various transforms
-
-        # Tokenizer to split input text into tokens
-        encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
-        vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
-        self.tokenizer = T.GPT2BPETokenizer(encoder_json_path, vocab_bpe_path)
-
-        # vocabulary converting tokens to IDs
-        vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
-        self.vocab = T.VocabTransform(load_state_dict_from_url(vocab_path))
-
-        # Add BOS token to the beginning of sentence
-        self.add_bos = T.AddToken(token=0, begin=True)
-
-        # Add EOS token to the end of sentence
-        self.add_eos = T.AddToken(token=2, begin=False)
-
-    def forward(self, input: Dict[str, Any]) -> Dict[str, Any]:
-        tokens = self.tokenizer(input["text"])
-        tokens = F.truncate(tokens, max_seq_len=254)
-        tokens = self.vocab(tokens)
-        tokens = self.add_bos(tokens)
-        tokens = self.add_eos(tokens)
-        input["tokens"] = tokens
-        return input
-
-
-def init_ta_gpt2bpe_encoder():
-    encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
-    vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
-
-    encoder_json_path = get_asset_local_path(encoder_json_path)
-    vocab_bpe_path = get_asset_local_path(vocab_bpe_path)
-    _seperator = "\u0001"
-
-    # load bpe encoder and bpe decoder
-    with open(encoder_json_path, "r", encoding="utf-8") as f:
-        bpe_encoder = json.load(f)
-    # load bpe vocab
-    with open(vocab_bpe_path, "r", encoding="utf-8") as f:
-        bpe_vocab = f.read()
-    bpe_merge_ranks = {
-        _seperator.join(merge_pair.split()): i for i, merge_pair in enumerate(bpe_vocab.split("\n")[1:-1])
-    }
-    # Caching is enabled in Eager mode
-    bpe = _ta.GPT2BPEEncoder(bpe_encoder, bpe_merge_ranks, _seperator, T.bytes_to_unicode(), True)
-    return bpe
-
-
-def init_ta_gpt2bpe_vocab():
-    vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
-    vocab_path = get_asset_local_path(vocab_path)
-    vocab = torch.load(vocab_path)
-    ta_vocab = _ta.Vocab(vocab.get_itos(), vocab.get_default_index())
-    return ta_vocab
-
-
-class RobertaTransformDataFrameNativeOps(Module):
-    def __init__(self) -> None:
-        super().__init__()
-        # Tokenizer to split input text into tokens
-        self.tokenizer = init_ta_gpt2bpe_encoder()
-
-        # vocabulary converting tokens to IDs
-        self.vocab = init_ta_gpt2bpe_vocab()
-
-        # Add BOS token to the beginning of sentence
-        self.add_bos = T.AddToken(token=0, begin=True)
-
-        # Add EOS token to the end of sentence
-        self.add_eos = T.AddToken(token=2, begin=False)
-
-    def forward(self, input: ta.DataFrame) -> ta.DataFrame:
-        input["tokens"] = ta_F.bpe_tokenize(self.tokenizer, input["text"])
-        input["tokens"] = input["tokens"].list.slice(stop=254)
-        input["tokens"] = ta_F.lookup_indices(self.vocab, input["tokens"])
-        input["tokens"] = input["tokens"].transform(self.add_bos, format="python")
-        input["tokens"] = input["tokens"].transform(self.add_eos, format="python")
-        return input
-
-
-class RobertaTransformDataFrameUDF(Module):
-    def __init__(self) -> None:
-        super().__init__()
-        # Instantiate various transforms
-
-        # Tokenizer to split input text into tokens
-        encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
-        vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
-        self.tokenizer = T.GPT2BPETokenizer(encoder_json_path, vocab_bpe_path)
-
-        # vocabulary converting tokens to IDs
-        vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
-        self.vocab = T.VocabTransform(load_state_dict_from_url(vocab_path))
-
-        # Add BOS token to the beginning of sentence
-        self.add_bos = T.AddToken(token=0, begin=True)
-
-        # Add EOS token to the end of sentence
-        self.add_eos = T.AddToken(token=2, begin=False)
-
-    def forward(self, input: ta.DataFrame) -> ta.DataFrame:
-        input["tokens"] = input["text"].transform(self.tokenizer, dtype=dt.List(dt.string), format="python")
-        input["tokens"] = input["tokens"].list.slice(stop=254)
-        input["tokens"] = input["tokens"].transform(self.vocab, dtype=dt.List(dt.int32), format="python")
-        input["tokens"] = input["tokens"].transform(self.add_bos, format="python")
-        input["tokens"] = input["tokens"].transform(self.add_eos, format="python")
-        return input
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../examples"))
+from data_pipeline.roberta_dataframe import RobertaTransformDataFrameNativeOps, RobertaTransformDataFrameUDF
+from data_pipeline.roberta_datapipe import RobertaTransformDataPipe
 
 
 def benchmark_roberta_datapipe(args):

--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -83,7 +83,7 @@ def benchmark_roberta_datapipe(args):
     with Timer("Initialize Roberta Transform (for datapipe)"):
         transform = RobertaTransformDataPipe()
 
-    with Timer("Initialize datapipe"):
+    with Timer("Initialize Pipeline"):
         # Create SST2 datapipe and apply pre-processing
         train_dp = DATASETS[dataset_name](split="train")
         train_dp = train_dp.batch(batch_size).rows2columnar(columns)
@@ -98,7 +98,7 @@ def benchmark_roberta_datapipe(args):
     # create DataLoader
     dl = DataLoader(train_dp, batch_size=None)
 
-    with Timer("Execute datapipe"):
+    with Timer("Execute Pipeline"):
         list(dl)
 
 
@@ -112,12 +112,12 @@ def benchmark_roberta_dataframe(args):
     with Timer("Initialize Roberta Transform (for DataFrame)"):
         transform = RobertaTransformDataFrame()
 
-    with Timer("Initialize datapipe"):
+    with Timer("Initialize Pipeline"):
         # Create SST2 datapipe and apply pre-processing
         train_dp = DATASETS[dataset_name](split="train")
 
         # convert to DataFrame of size batches
-        # TODO: Figure out how to create DataFrame of larger size and create batches consequently
+        # TODO: Figure out how to create DataFrame of larger size and create smaller batches
         train_dp = train_dp.dataframe(columns=columns, dataframe_size=batch_size)
 
         # Apply transformation on DataFrame
@@ -132,7 +132,7 @@ def benchmark_roberta_dataframe(args):
     # create DataLoader
     dl = DataLoader(train_dp, batch_size=None)
 
-    with Timer("Execute datapipe"):
+    with Timer("Execute Pipeline"):
         list(dl)
 
 

--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -1,44 +1,21 @@
+import json
 from argparse import ArgumentParser
 from functools import partial
 from typing import Dict, Any
 
+import torch
 import torcharrow as ta
 import torcharrow._torcharrow as _ta
-import json
-from torchtext.utils import get_asset_local_path
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as tap
 import torchtext.functional as F
 import torchtext.transforms as T
-from torcharrow import functional as ta_F
 from benchmark.utils import Timer
 from torch.hub import load_state_dict_from_url
 from torch.nn import Module
+from torcharrow import functional as ta_F
 from torchtext.datasets import DATASETS
-
-
-def init_bpe_encoder():
-    encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
-    vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
-    encoder_json_path = get_asset_local_path(encoder_json_path)
-    vocab_bpe_path = get_asset_local_path(vocab_bpe_path)
-    _seperator = "\u0001"
-
-    # load bpe encoder and bpe decoder
-    with open(encoder_json_path, "r", encoding="utf-8") as f:
-        bpe_encoder = json.load(f)
-    # load bpe vocab
-    with open(vocab_bpe_path, "r", encoding="utf-8") as f:
-        bpe_vocab = f.read()
-    bpe_merge_ranks = {
-        _seperator.join(merge_pair.split()): i
-        for i, merge_pair in enumerate(bpe_vocab.split("\n")[1:-1])
-    }
-    # Caching is enabled in Eager mode
-    bpe = _ta.GPT2BPEEncoder(
-        bpe_encoder, bpe_merge_ranks, _seperator, T.bytes_to_unicode(), True
-    )
-    return bpe
+from torchtext.utils import get_asset_local_path
 
 
 class RobertaTransformDataPipe(Module):
@@ -71,21 +48,44 @@ class RobertaTransformDataPipe(Module):
         return input
 
 
+def init_ta_gpt2bpe_encoder():
+    encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
+    vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
+
+    encoder_json_path = get_asset_local_path(encoder_json_path)
+    vocab_bpe_path = get_asset_local_path(vocab_bpe_path)
+    _seperator = "\u0001"
+
+    # load bpe encoder and bpe decoder
+    with open(encoder_json_path, "r", encoding="utf-8") as f:
+        bpe_encoder = json.load(f)
+    # load bpe vocab
+    with open(vocab_bpe_path, "r", encoding="utf-8") as f:
+        bpe_vocab = f.read()
+    bpe_merge_ranks = {
+        _seperator.join(merge_pair.split()): i for i, merge_pair in enumerate(bpe_vocab.split("\n")[1:-1])
+    }
+    # Caching is enabled in Eager mode
+    bpe = _ta.GPT2BPEEncoder(bpe_encoder, bpe_merge_ranks, _seperator, T.bytes_to_unicode(), True)
+    return bpe
+
+
+def init_ta_gpt2bpe_vocab():
+    vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
+    vocab_path = get_asset_local_path(vocab_path)
+    vocab = torch.load(vocab_path)
+    ta_vocab = _ta.Vocab(vocab.get_itos(), vocab.get_default_index())
+    return ta_vocab
+
+
 class RobertaTransformDataFrame(Module):
     def __init__(self) -> None:
         super().__init__()
-        # Instantiate various transforms
-
         # Tokenizer to split input text into tokens
-        encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
-        vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
-        self.tokenizer = T.GPT2BPETokenizer(encoder_json_path, vocab_bpe_path)
-
-        # self.tokenizer = init_bpe_encoder()
+        self.tokenizer = init_ta_gpt2bpe_encoder()
 
         # vocabulary converting tokens to IDs
-        vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
-        self.vocab = T.VocabTransform(load_state_dict_from_url(vocab_path))
+        self.vocab = init_ta_gpt2bpe_vocab()
 
         # Add BOS token to the beginning of sentence
         self.add_bos = T.AddToken(token=0, begin=True)
@@ -94,11 +94,10 @@ class RobertaTransformDataFrame(Module):
         self.add_eos = T.AddToken(token=2, begin=False)
 
     def forward(self, input: ta.DataFrame) -> ta.DataFrame:
-        input["tokens"] = input["text"].transform(self.tokenizer, dtype=dt.List(dt.string), format="python")
         input["tokens"] = ta_F.bpe_tokenize(self.tokenizer, input["text"])
         input["tokens"] = input["tokens"].list.slice(stop=254)
-        input["tokens"] = input["tokens"].map(lambda x: [str(i) for i in input], dtype=dt.List(dt.string))
-        input["tokens"] = input["tokens"].transform(self.vocab, dtype=dt.List(dt.int32), format="python")
+        input["tokens"] = ta_F.lookup_indices(self.vocab, input["tokens"])
+        input["tokens"]._dtype = dt.List(dt.int64)
         input["tokens"] = input["tokens"].transform(self.add_bos, format="python")
         input["tokens"] = input["tokens"].transform(self.add_eos, format="python")
         return input
@@ -151,20 +150,20 @@ def benchmark_roberta_dataframe(args):
         # Apply transformation on DataFrame
         train_dp = train_dp.map(transform)
 
-        # # Remove not required columns
-        # train_dp = train_dp.map(lambda x: x.drop(["text"]))
+        # Remove not required columns
+        train_dp = train_dp.map(lambda x: x.drop(["text"]))
 
-        # # convert DataFrame to tensor (This will yeild named tuple)
-        # train_dp = train_dp.map(lambda x: x.to_tensor({"tokens": tap.PadSequence(padding_value=1)}))
+        # convert DataFrame to tensor (This will yeild named tuple)
+        train_dp = train_dp.map(lambda x: x.to_tensor({"tokens": tap.PadSequence(padding_value=1)}))
 
     with Timer("Execute Pipeline"):
-        list(train_dp.header(1))
+        list(train_dp)
 
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument("--batch-size", default=32, type=int)
+    parser.add_argument("--batch-size", default=4, type=int)
     parser.add_argument("--dataset-name", default="SST2", type=str)
     parser.add_argument("--columns", default=["text", "label"], nargs="+")
-    benchmark_roberta_datapipe(parser.parse_args())
+    # benchmark_roberta_datapipe(parser.parse_args())
     benchmark_roberta_dataframe(parser.parse_args())

--- a/benchmark/benchmark_roberta_pipeline.py
+++ b/benchmark/benchmark_roberta_pipeline.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser
 from functools import partial
-from typing import Callable, Dict, Any, List
+from typing import Dict, Any
 
 import torcharrow as ta
 import torcharrow.dtypes as dt
@@ -41,10 +41,6 @@ class RobertaTransformDataPipe(Module):
         tokens = self.add_eos(tokens)
         input["tokens"] = tokens
         return input
-
-
-def batch_tokenize(input: List[str], tokenizer: Callable) -> List[List[str]]:
-    return tokenizer(input)
 
 
 class RobertaTransformDataFrame(Module):

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -1,0 +1,28 @@
+import time
+
+
+class Timer:
+    def __init__(self, text="") -> None:
+        self._text = text
+        self._start = None
+
+    def start(self):
+        if self._start is not None:
+            raise Exception("Time is already running. Call .stop() to stop it")
+
+        self._start = time.perf_counter()
+
+    def stop(self):
+        if self._start is None:
+            raise Exception("Timer is not running. Call .start() to start the timer.")
+
+        elapsed = time.perf_counter() - self._start
+
+        print(self._text + " ... Total running time: {}".format(elapsed))
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.stop()

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -8,7 +8,7 @@ class Timer:
 
     def start(self):
         if self._start is not None:
-            raise Exception("Time is already running. Call .stop() to stop it")
+            raise Exception("Timer is already running. Call .stop() to stop it")
 
         self._start = time.perf_counter()
 

--- a/examples/data_pipeline/roberta_dataframe.py
+++ b/examples/data_pipeline/roberta_dataframe.py
@@ -1,16 +1,75 @@
+import json
 from argparse import ArgumentParser
 
+import torch
 import torcharrow as ta
+import torcharrow._torcharrow as _ta
 import torcharrow.dtypes as dt
 import torcharrow.pytorch as tap
 import torchtext.transforms as T
 from torch.hub import load_state_dict_from_url
 from torch.nn import Module
 from torch.utils.data import DataLoader
+from torcharrow import functional as ta_F
 from torchtext.datasets import SST2
+from torchtext.utils import get_asset_local_path
 
 
-class RobertaTransform(Module):
+def init_ta_gpt2bpe_encoder():
+    encoder_json_path = "https://download.pytorch.org/models/text/gpt2_bpe_encoder.json"
+    vocab_bpe_path = "https://download.pytorch.org/models/text/gpt2_bpe_vocab.bpe"
+
+    encoder_json_path = get_asset_local_path(encoder_json_path)
+    vocab_bpe_path = get_asset_local_path(vocab_bpe_path)
+    _seperator = "\u0001"
+
+    # load bpe encoder and bpe decoder
+    with open(encoder_json_path, "r", encoding="utf-8") as f:
+        bpe_encoder = json.load(f)
+    # load bpe vocab
+    with open(vocab_bpe_path, "r", encoding="utf-8") as f:
+        bpe_vocab = f.read()
+    bpe_merge_ranks = {
+        _seperator.join(merge_pair.split()): i for i, merge_pair in enumerate(bpe_vocab.split("\n")[1:-1])
+    }
+    # Caching is enabled in Eager mode
+    bpe = _ta.GPT2BPEEncoder(bpe_encoder, bpe_merge_ranks, _seperator, T.bytes_to_unicode(), True)
+    return bpe
+
+
+def init_ta_gpt2bpe_vocab():
+    vocab_path = "https://download.pytorch.org/models/text/roberta.vocab.pt"
+    vocab_path = get_asset_local_path(vocab_path)
+    vocab = torch.load(vocab_path)
+    ta_vocab = _ta.Vocab(vocab.get_itos(), vocab.get_default_index())
+    return ta_vocab
+
+
+class RobertaTransformDataFrameNativeOps(Module):
+    def __init__(self) -> None:
+        super().__init__()
+        # Tokenizer to split input text into tokens
+        self.tokenizer = init_ta_gpt2bpe_encoder()
+
+        # vocabulary converting tokens to IDs
+        self.vocab = init_ta_gpt2bpe_vocab()
+
+        # Add BOS token to the beginning of sentence
+        self.add_bos = T.AddToken(token=0, begin=True)
+
+        # Add EOS token to the end of sentence
+        self.add_eos = T.AddToken(token=2, begin=False)
+
+    def forward(self, input: ta.DataFrame) -> ta.DataFrame:
+        input["tokens"] = ta_F.bpe_tokenize(self.tokenizer, input["text"])
+        input["tokens"] = input["tokens"].list.slice(stop=254)
+        input["tokens"] = ta_F.lookup_indices(self.vocab, input["tokens"])
+        input["tokens"] = input["tokens"].transform(self.add_bos, format="python")
+        input["tokens"] = input["tokens"].transform(self.add_eos, format="python")
+        return input
+
+
+class RobertaTransformDataFrameUDF(Module):
     def __init__(self) -> None:
         super().__init__()
         # Instantiate various transforms
@@ -31,18 +90,23 @@ class RobertaTransform(Module):
         self.add_eos = T.AddToken(token=2, begin=False)
 
     def forward(self, input: ta.DataFrame) -> ta.DataFrame:
-        input["tokens"] = input["text"].map(self.tokenizer.forward, dtype=dt.List(dt.string))
+        input["tokens"] = input["text"].transform(self.tokenizer, dtype=dt.List(dt.string), format="python")
         input["tokens"] = input["tokens"].list.slice(stop=254)
-        input["tokens"] = input["tokens"].map(self.vocab, dtype=dt.List(dt.int32))
-        input["tokens"] = input["tokens"].map(self.add_bos)
-        input["tokens"] = input["tokens"].map(self.add_eos)
+        input["tokens"] = input["tokens"].transform(self.vocab, dtype=dt.List(dt.int32), format="python")
+        input["tokens"] = input["tokens"].transform(self.add_bos, format="python")
+        input["tokens"] = input["tokens"].transform(self.add_eos, format="python")
         return input
 
 
 def main(args):
 
     # Instantiate transform
-    transform = RobertaTransform()
+    if args.ops_type == "udf":
+        transform = RobertaTransformDataFrameUDF()
+    elif args.ops_type == "native":
+        transform = RobertaTransformDataFrameNativeOps()
+    else:
+        raise Exception("Wrong ops type provided. Available options are `udf` and `native`")
 
     # Create SST2 datapipe and apply pre-processing
     train_dp = SST2(split="train")
@@ -68,8 +132,9 @@ def main(args):
         if i == train_steps:
             break
 
-        # model_input = batch.tokens
-        # target = batch.labels
+        model_input = batch.tokens
+        target = batch.labels
+        print(model_input, target)
         ...
 
 
@@ -77,5 +142,5 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--batch-size", default=4, type=int)
     parser.add_argument("--train-steps", default=-1, type=int)
-    parser.add_argument("--dataframe-size", default=100, type=int)
+    parser.add_argument("--ops-type", default="udf", choices=["udf", "native"], type=str)
     main(parser.parse_args())

--- a/examples/data_pipeline/roberta_dataframe.py
+++ b/examples/data_pipeline/roberta_dataframe.py
@@ -132,9 +132,8 @@ def main(args):
         if i == train_steps:
             break
 
-        model_input = batch.tokens
-        target = batch.labels
-        print(model_input, target)
+        # model_input = batch.tokens
+        # target = batch.labels
         ...
 
 

--- a/examples/data_pipeline/roberta_datapipe.py
+++ b/examples/data_pipeline/roberta_datapipe.py
@@ -10,7 +10,7 @@ from torch.utils.data import DataLoader
 from torchtext.datasets import SST2
 
 
-class RobertaTransform(Module):
+class RobertaTransformDataPipe(Module):
     def __init__(self) -> None:
         super().__init__()
         # Instantiate various transforms
@@ -42,7 +42,7 @@ class RobertaTransform(Module):
 
 def main(args):
     # Instantiate transform
-    transform = RobertaTransform()
+    transform = RobertaTransformDataPipe()
 
     # Create SST2 datapipe and apply pre-processing
     batch_size = args.batch_size
@@ -64,8 +64,9 @@ def main(args):
         if i == train_steps:
             break
 
-        # model_input = batch["tokens"]
-        # target = batch["label"]
+        model_input = batch["tokens"]
+        target = batch["label"]
+        print(model_input, target)
         ...
 
 

--- a/examples/data_pipeline/roberta_datapipe.py
+++ b/examples/data_pipeline/roberta_datapipe.py
@@ -64,9 +64,8 @@ def main(args):
         if i == train_steps:
             break
 
-        model_input = batch["tokens"]
-        target = batch["label"]
-        print(model_input, target)
+        # model_input = batch["tokens"]
+        # target = batch["label"]
         ...
 
 


### PR DESCRIPTION
## Summary 
This PR adds benchmark for end-2-end preproc pipeline for RoBERTa based text pre-processing. All the pipelines are based on DataPipes.
* **Pipeline 1 (benchmark_roberta_datapipe):** Using operators/transforms implemented in torchtext and are directly applied on text
* **Pipeline 2 (benchmark_roberta_dataframe):** This pipeline first convert the input text (python tuples) into DataFrame of sizes batch_size on the fly. It then does text processing directly on dataframe.
  * **Pipeline 2.2 (Using Ops as UDFs):** This pipeline uses operators implemented in torchtext and are applied to TA dataframe as a UDFs using it's transform API  
  * **Pipeline 2.1 (Using Native Ops):** This pipeline used native operators implemented directly in TorchArrow 

## Results
Current end-2-end benchmarking results:
Settings: Macbook pro, SST2 dataset, batch_size 32, single run

Pipeline 1: ~ 5 seconds
Pipeline 2.1: ~28 seconds
Pipeline 2.2: ~73 seconds