### PR TITLE
Fix smoke tests for linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ binary_common: &binary_common
 smoke_test_common: &smoke_test_common
   <<: *binary_common
   docker:
-    - image: pytorch/torchtext_smoke_base:latest
+    - image: pytorch/torchtext_smoke_base:smoke_test-20220427
 
 jobs:
   circleci_consistency:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -61,7 +61,7 @@ binary_common: &binary_common
 smoke_test_common: &smoke_test_common
   <<: *binary_common
   docker:
-    - image: pytorch/torchtext_smoke_base:latest
+    - image: pytorch/torchtext_smoke_base:smoke_test-20220427
 
 jobs:
   circleci_consistency:

--- a/.circleci/smoke_test/docker/Dockerfile
+++ b/.circleci/smoke_test/docker/Dockerfile
@@ -1,13 +1,7 @@
 # this Dockerfile is for torchtext smoke test, it will be created periodically via CI system
 # if you need to do it locally, follow below steps once you have Docker installed
-# assuming you're within the directory where this Dockerfile located
-#  $ docker build . -t torchtext/smoketest
-
-# if you want to push to aws ecr, make sure you have the rights to write to ECR, then run
-# $ eval $(aws ecr get-login --region us-east-1 --no-include-email)
-# $ export MYTAG=localbuild  ## you can choose whatever tag you like
-# $ docker tag torchtext/smoketest 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtext/smoke_test:${MYTAG}
-# $ docker push  308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtext/smoke_test:${MYTAG}
+# to test the build use : docker build . -t torchtext/smoketest
+# to upload the Dockerfile use build_and_push.sh script
 
 FROM ubuntu:latest
 
@@ -34,8 +28,8 @@ RUN conda create -y --name python3.10 python=3.10
 
 SHELL [ "/bin/bash", "-c" ]
 RUN echo "source /usr/local/etc/profile.d/conda.sh" >> ~/.bashrc
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y -c conda-forge sox && conda install -y numpy
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y -c conda-forge sox && conda install -y numpy
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.9 && conda install -y -c conda-forge sox && conda install -y numpy
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.10 && conda install -y -c conda-forge sox && conda install -y numpy
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y numpy
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y numpy
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.9 && conda install -y numpy
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.10 && conda install -y numpy
 CMD [ "/bin/bash"]

--- a/.circleci/smoke_test/docker/Dockerfile
+++ b/.circleci/smoke_test/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq update && apt-get -qq -y install curl bzip2 sox libsox-dev libso
     && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local \
     && rm -rf /tmp/miniconda.sh \
+    && conda install -c conda-forge gcc \
     && conda install -y python=3 \
     && conda update conda \
     && apt-get -qq -y remove curl bzip2 \
@@ -25,12 +26,16 @@ RUN apt-get -qq update && apt-get -qq -y install curl bzip2 sox libsox-dev libso
 
 ENV PATH /opt/conda/bin:$PATH
 
-RUN conda create -y --name python3.6 python=3.6
+
 RUN conda create -y --name python3.7 python=3.7
 RUN conda create -y --name python3.8 python=3.8
+RUN conda create -y --name python3.9 python=3.9
+RUN conda create -y --name python3.10 python=3.10
+
 SHELL [ "/bin/bash", "-c" ]
 RUN echo "source /usr/local/etc/profile.d/conda.sh" >> ~/.bashrc
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.6 && conda install -y -c conda-forge sox && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y -c conda-forge sox && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y -c conda-forge sox && conda install -y numpy
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.9 && conda install -y -c conda-forge sox && conda install -y numpy
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.10 && conda install -y -c conda-forge sox && conda install -y numpy
 CMD [ "/bin/bash"]

--- a/.circleci/smoke_test/docker/build_and_push.sh
+++ b/.circleci/smoke_test/docker/build_and_push.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+datestr="$(date "+%Y%m%d")"
+image="pytorch/torchtext_smoke_base:smoke_test-${datestr}"
+docker build -t "${image}" .
+docker push "${image}"


### PR DESCRIPTION
This PR fixes the smoke tests for torchtext and python 3.9 and 3.10 We will need to rebuild docker image for this.
This is same as [PR audio](https://github.com/pytorch/audio/pull/2348)