### PR TITLE
fix pad transform test

### DIFF
--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -235,7 +235,7 @@ class PadTransform(Module):
     def __init__(self, max_length: int, pad_value: int):
         super().__init__()
         self.max_length = max_length
-        self.pad_value = pad_value
+        self.pad_value = float(pad_value)
 
     def forward(self, x: Tensor) -> Tensor:
         """


### PR DESCRIPTION
This PR fixes the PAD transform test in scripting mode.

The [torch.nn.function.pad](https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html) function expect float value, and when providing with int,  it complains in script mode. 