### PR TITLE
Provide option to return splited tokens

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -333,6 +333,12 @@ class TestGPT2BPETokenizer(TorchtextTestCase):
             "Avdija Vršajević în",
         ]
 
+        expected_tokens = [
+            ["Hello", "ĠWorld", "!,", "Ġhow", "Ġare", "Ġyou", "?"],
+            ["H", "Ã©", "ll", "Ã³", "Ġ", "ĠWo", "Å", "ķ", "l", "á¸", "Ĭ", "Â", "¿"],
+            ["Res", "public", "a", "Ġsuper", "i", "orem"],
+            ["Av", "d", "ija", "ĠV", "r", "Å¡", "aj", "ev", "i", "Äĩ", "ĠÃ", "®", "n"],
+        ]
         expected_token_ids = [
             ["15496", "2159", "28265", "703", "389", "345", "30"],
             ["39", "2634", "297", "10205", "220", "22173", "129", "243", "75", "41585", "232", "126", "123"],
@@ -342,10 +348,12 @@ class TestGPT2BPETokenizer(TorchtextTestCase):
 
         # test batch of sentences
         self.assertEqual(tokenizer(sample_texts), expected_token_ids)
+        self.assertEqual(tokenizer(sample_texts, return_tokens=True), expected_tokens)
 
         # test individual sentences
         for idx, txt in enumerate(sample_texts):
             self.assertEqual(tokenizer(txt), expected_token_ids[idx])
+            self.assertEqual(tokenizer(txt, return_tokens=True), expected_tokens[idx])
 
     def test_gpt2_bpe_tokenizer(self):
         """test tokenization on single sentence input as well as batch on sentences"""
@@ -398,6 +406,77 @@ class TestCLIPTokenizer(TorchtextTestCase):
             "Hello World!, how are you?",
             "<|startoftext|> the quick brown fox jumped over the lazy dog <|endoftext|>",
             "Awaiting their due award... Photo by Frederick (FN) Noronha. Copyleft. Creative Commons 3.0. Non-commercial. Attribution. May be copied for non-commercial purposes. For other purposes, contact fn at goa-india.org",
+        ]
+
+        expected_tokens = [
+            ["hello</w>", "world</w>", "!,</w>", "how</w>", "are</w>", "you</w>", "?</w>"],
+            [
+                "<|startoftext|>",
+                "the</w>",
+                "quick</w>",
+                "brown</w>",
+                "fox</w>",
+                "jumped</w>",
+                "over</w>",
+                "the</w>",
+                "lazy</w>",
+                "dog</w>",
+                "<|endoftext|>",
+            ],
+            [
+                "awaiting</w>",
+                "their</w>",
+                "due</w>",
+                "award</w>",
+                "...</w>",
+                "photo</w>",
+                "by</w>",
+                "frederick</w>",
+                "(</w>",
+                "fn</w>",
+                ")</w>",
+                "nor",
+                "on",
+                "ha</w>",
+                ".</w>",
+                "copy",
+                "left</w>",
+                ".</w>",
+                "creative</w>",
+                "commons</w>",
+                "3</w>",
+                ".</w>",
+                "0</w>",
+                ".</w>",
+                "non</w>",
+                "-</w>",
+                "commercial</w>",
+                ".</w>",
+                "attribu",
+                "tion</w>",
+                ".</w>",
+                "may</w>",
+                "be</w>",
+                "copied</w>",
+                "for</w>",
+                "non</w>",
+                "-</w>",
+                "commercial</w>",
+                "purposes</w>",
+                ".</w>",
+                "for</w>",
+                "other</w>",
+                "purposes</w>",
+                ",</w>",
+                "contact</w>",
+                "fn</w>",
+                "at</w>",
+                "goa</w>",
+                "-</w>",
+                "india</w>",
+                ".</w>",
+                "org</w>",
+            ],
         ]
 
         expected_token_ids = [
@@ -462,9 +541,12 @@ class TestCLIPTokenizer(TorchtextTestCase):
         # test batch of sentences
         self.assertEqual(tokenizer(sample_texts), expected_token_ids)
 
+        self.assertEqual(tokenizer(sample_texts, return_tokens=True), expected_tokens)
+
         # test individual sentences
         for idx, txt in enumerate(sample_texts):
             self.assertEqual(tokenizer(txt), expected_token_ids[idx])
+            self.assertEqual(tokenizer(txt, return_tokens=True), expected_tokens[idx])
 
     def test_clip_tokenizer(self):
         """test tokenization on single sentence input as well as batch on sentences"""

--- a/torchtext/csrc/clip_tokenizer.cpp
+++ b/torchtext/csrc/clip_tokenizer.cpp
@@ -102,6 +102,10 @@ std::vector<int64_t> CLIPEncoder::Encode(const std::string& text) {
   return GPT2BPEEncoder::Encode(text);
 }
 
+std::vector<std::string> CLIPEncoder::Tokenize(const std::string& text) {
+  return GPT2BPEEncoder::Tokenize(text);
+}
+
 CLIPEncoderStatesPybind _serialize_clip_encoder_pybind(
     const c10::intrusive_ptr<CLIPEncoder>& self) {
   return std::make_tuple(

--- a/torchtext/csrc/clip_tokenizer.h
+++ b/torchtext/csrc/clip_tokenizer.h
@@ -26,6 +26,7 @@ struct CLIPEncoder : GPT2BPEEncoder {
   using GPT2BPEEncoder::GPT2BPEEncoder;
 
   std::vector<int64_t> Encode(const std::string& text);
+  std::vector<std::string> Tokenize(const std::string& text);
 
  protected:
   std::vector<std::string> BPE_(

--- a/torchtext/csrc/gpt2_bpe_tokenizer.cpp
+++ b/torchtext/csrc/gpt2_bpe_tokenizer.cpp
@@ -290,7 +290,6 @@ std::vector<std::string> GPT2BPEEncoder::Tokenize(const std::string& text) {
   return bpe_tokens;
 }
 
-
 std::unordered_map<std::string, int64_t> GPT2BPEEncoder::GetBPEEncoder() const {
   return _c10_dict_to_map(bpe_encoder_);
 }

--- a/torchtext/csrc/gpt2_bpe_tokenizer.cpp
+++ b/torchtext/csrc/gpt2_bpe_tokenizer.cpp
@@ -279,6 +279,18 @@ std::vector<int64_t> GPT2BPEEncoder::Encode(const std::string& text) {
   return bpe_token_ids;
 }
 
+std::vector<std::string> GPT2BPEEncoder::Tokenize(const std::string& text) {
+  std::vector<std::string> bpe_tokens;
+  for (const auto& token : PreTokenize_(text)) {
+    auto byte_encoded_token = ByteEncode_(token);
+    for (const auto& bpe_token : BPE_(byte_encoded_token)) {
+      bpe_tokens.push_back(bpe_token);
+    }
+  }
+  return bpe_tokens;
+}
+
+
 std::unordered_map<std::string, int64_t> GPT2BPEEncoder::GetBPEEncoder() const {
   return _c10_dict_to_map(bpe_encoder_);
 }

--- a/torchtext/csrc/gpt2_bpe_tokenizer.h
+++ b/torchtext/csrc/gpt2_bpe_tokenizer.h
@@ -98,6 +98,7 @@ struct GPT2BPEEncoder : torch::CustomClassHolder {
   //  --> result --> [707, 5927, 11, 707, 68]
   //
   std::vector<int64_t> Encode(const std::string& text);
+  std::vector<std::string> Tokenize(const std::string& text);
 
   std::unordered_map<std::string, int64_t> GetBPEEncoder() const;
   std::unordered_map<std::string, int64_t> GetBPEMergeRanks() const;

--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -177,6 +177,7 @@ PYBIND11_MODULE(_torchtext, m) {
       .def_readonly("seperator_", &GPT2BPEEncoder::seperator_)
       .def_property_readonly("byte_encoder_", &GPT2BPEEncoder::GetByteEncoder)
       .def("encode", &GPT2BPEEncoder::Encode)
+      .def("tokenize", &GPT2BPEEncoder::Tokenize)
       .def(py::pickle(
           // __getstate__
           [](const c10::intrusive_ptr<GPT2BPEEncoder>& self)
@@ -201,6 +202,7 @@ PYBIND11_MODULE(_torchtext, m) {
       .def_readonly("seperator_", &CLIPEncoder::seperator_)
       .def_property_readonly("byte_encoder_", &CLIPEncoder::GetByteEncoder)
       .def("encode", &CLIPEncoder::Encode)
+      .def("tokenize", &CLIPEncoder::Tokenize)
       .def(py::pickle(
           // __getstate__
           [](const c10::intrusive_ptr<CLIPEncoder>& self)

--- a/torchtext/csrc/register_torchbindings.cpp
+++ b/torchtext/csrc/register_torchbindings.cpp
@@ -138,6 +138,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
            c10::Dict<int64_t, std::string>,
            bool>())
       .def("encode", &GPT2BPEEncoder::Encode)
+      .def("tokenize", &GPT2BPEEncoder::Tokenize)
       .def_pickle(
           // __getstate__
           [](const c10::intrusive_ptr<GPT2BPEEncoder>& self)
@@ -158,6 +159,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
            c10::Dict<int64_t, std::string>,
            bool>())
       .def("encode", &CLIPEncoder::Encode)
+      .def("tokenize", &CLIPEncoder::Tokenize)
       .def_pickle(
           // __getstate__
           [](const c10::intrusive_ptr<CLIPEncoder>& self)


### PR DESCRIPTION
# Issue:
The current GPT2BPE and CLIP Tokenizer transforms returns the encoded token IDs. Based on the user feedback, we learnt that for consistency, it would good to expose the option to return tokens directly instead of their encoded IDs. 

# Resolution:
This PR addresses the issue by adding  boolean option `return_tokens` in Tokenizer Transform initialization API that would let users to either return Tokens or their corresponding Token IDs (encoded as strings).


# Test:
pytest -v -s test/test_transforms.py::TestGPT2BPETokenizer
pytest -v -s test/test_transforms.py::TestCLIPTokenizer

