### PR TITLE
Add support for return_all_layers with nested tensor in torchtext

### DIFF
--- a/test/integration_tests/test_models.py
+++ b/test/integration_tests/test_models.py
@@ -1,5 +1,10 @@
 import torch
-from torchtext.models import ROBERTA_BASE_ENCODER, ROBERTA_LARGE_ENCODER, XLMR_BASE_ENCODER, XLMR_LARGE_ENCODER
+from torchtext.models import (
+    ROBERTA_BASE_ENCODER,
+    ROBERTA_LARGE_ENCODER,
+    XLMR_BASE_ENCODER,
+    XLMR_LARGE_ENCODER,
+)
 
 from ..common.assets import get_asset_path
 from ..common.parameterized_utils import nested_params
@@ -7,28 +12,15 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestModels(TorchtextTestCase):
-    @nested_params(
-        [
-            ("xlmr.base.output.pt", "XLMR base Model Comparison", XLMR_BASE_ENCODER),
-            ("xlmr.large.output.pt", "XLMR base Model Comparison", XLMR_LARGE_ENCODER),
-            (
-                "roberta.base.output.pt",
-                "Roberta base Model Comparison",
-                ROBERTA_BASE_ENCODER,
-            ),
-            (
-                "roberta.large.output.pt",
-                "Roberta base Model Comparison",
-                ROBERTA_LARGE_ENCODER,
-            ),
-        ],
-        [True, False],
-    )
-    def test_model(self, model_args, is_jit):
+    def _xlmr_base_model(self, is_jit):
         """Verify pre-trained XLM-R and Roberta models in torchtext produce
         the same output as the reference implementation within fairseq
         """
-        expected_asset_name, test_text, model_bundler = model_args
+        expected_asset_name, test_text, model_bundler = (
+            "xlmr.base.output.pt",
+            "XLMR base Model Comparison",
+            XLMR_BASE_ENCODER,
+        )
 
         expected_asset_path = get_asset_path(expected_asset_name)
 
@@ -44,3 +36,40 @@ class TestModels(TorchtextTestCase):
         actual = model(model_input)
         expected = torch.load(expected_asset_path)
         torch.testing.assert_close(actual, expected)
+
+    def test_xlmr_base_model(self):
+        self._xlmr_base_model(is_jit=False)
+
+    def test_xlmr_base_model_jit(self):
+        self._xlmr_base_model(is_jit=True)
+
+    def _xlmr_large_model(self, is_jit):
+        """Verify pre-trained XLM-R and Roberta models in torchtext produce
+        the same output as the reference implementation within fairseq
+        """
+        expected_asset_name, test_text, model_bundler = (
+            "xlmr.large.output.pt",
+            "XLMR base Model Comparison",
+            XLMR_LARGE_ENCODER,
+        )
+
+        expected_asset_path = get_asset_path(expected_asset_name)
+
+        transform = model_bundler.transform()
+        model = model_bundler.get_model()
+        model = model.eval()
+
+        if is_jit:
+            transform = torch.jit.script(transform)
+            model = torch.jit.script(model)
+
+        model_input = torch.tensor(transform([test_text]))
+        actual = model(model_input)
+        expected = torch.load(expected_asset_path)
+        torch.testing.assert_close(actual, expected)
+
+    def test_xlmr_large_model(self):
+        self._xlmr_large_model(is_jit=False)
+
+    def test_xlmr_large_model_jit(self):
+        self._xlmr_large_model(is_jit=True)


### PR DESCRIPTION
Summary:
As we may automatically switch to use nested tensor, we need further support of this in torchtext,
especially for return_all_layers

Reviewed By: mikekgfb, parmeet

Differential Revision: D36213184

