### PR TITLE
[fbsync] Enable model testing in FBCode

### DIFF
--- a/test/integration_tests/test_models.py
+++ b/test/integration_tests/test_models.py
@@ -1,39 +1,25 @@
 import torch
-from torchtext.models import ROBERTA_BASE_ENCODER, ROBERTA_LARGE_ENCODER, XLMR_BASE_ENCODER, XLMR_LARGE_ENCODER
+from parameterized import parameterized
+from torchtext.models import (
+    ROBERTA_BASE_ENCODER,
+    ROBERTA_LARGE_ENCODER,
+    XLMR_BASE_ENCODER,
+    XLMR_LARGE_ENCODER,
+)
 
 from ..common.assets import get_asset_path
-from ..common.parameterized_utils import nested_params
 from ..common.torchtext_test_case import TorchtextTestCase
 
 
-class TestModels(TorchtextTestCase):
-    @nested_params(
-        [
-            ("xlmr.base.output.pt", "XLMR base Model Comparison", XLMR_BASE_ENCODER),
-            ("xlmr.large.output.pt", "XLMR base Model Comparison", XLMR_LARGE_ENCODER),
-            (
-                "roberta.base.output.pt",
-                "Roberta base Model Comparison",
-                ROBERTA_BASE_ENCODER,
-            ),
-            (
-                "roberta.large.output.pt",
-                "Roberta base Model Comparison",
-                ROBERTA_LARGE_ENCODER,
-            ),
-        ],
-        [True, False],
-    )
-    def test_model(self, model_args, is_jit):
+class TestRobertaEncoders(TorchtextTestCase):
+    def _roberta_encoders(self, is_jit, encoder, expected_asset_name, test_text):
         """Verify pre-trained XLM-R and Roberta models in torchtext produce
         the same output as the reference implementation within fairseq
         """
-        expected_asset_name, test_text, model_bundler = model_args
-
         expected_asset_path = get_asset_path(expected_asset_name)
 
-        transform = model_bundler.transform()
-        model = model_bundler.get_model()
+        transform = encoder.transform()
+        model = encoder.get_model()
         model = model.eval()
 
         if is_jit:
@@ -44,3 +30,47 @@ class TestModels(TorchtextTestCase):
         actual = model(model_input)
         expected = torch.load(expected_asset_path)
         torch.testing.assert_close(actual, expected)
+
+    @parameterized.expand([("jit", True), ("not_jit", False)])
+    def test_xlmr_base_model(self, name, is_jit):
+        expected_asset_name = "xlmr.base.output.pt"
+        test_text = "XLMR base Model Comparison"
+        self._roberta_encoders(
+            is_jit=is_jit,
+            encoder=XLMR_BASE_ENCODER,
+            expected_asset_name=expected_asset_name,
+            test_text=test_text,
+        )
+
+    @parameterized.expand([("jit", True), ("not_jit", False)])
+    def test_xlmr_large_model(self, name, is_jit):
+        expected_asset_name = "xlmr.large.output.pt"
+        test_text = "XLMR base Model Comparison"
+        self._roberta_encoders(
+            is_jit=is_jit,
+            encoder=XLMR_LARGE_ENCODER,
+            expected_asset_name=expected_asset_name,
+            test_text=test_text,
+        )
+
+    @parameterized.expand([("jit", True), ("not_jit", False)])
+    def test_roberta_base_model(self, name, is_jit):
+        expected_asset_name = "roberta.base.output.pt"
+        test_text = "Roberta base Model Comparison"
+        self._roberta_encoders(
+            is_jit=is_jit,
+            encoder=ROBERTA_BASE_ENCODER,
+            expected_asset_name=expected_asset_name,
+            test_text=test_text,
+        )
+
+    @parameterized.expand([("jit", True), ("not_jit", False)])
+    def test_robeta_large_model(self, name, is_jit):
+        expected_asset_name = "roberta.large.output.pt"
+        test_text = "Roberta base Model Comparison"
+        self._roberta_encoders(
+            is_jit=is_jit,
+            encoder=ROBERTA_LARGE_ENCODER,
+            expected_asset_name=expected_asset_name,
+            test_text=test_text,
+        )


### PR DESCRIPTION
Summary:
This diff enables Model testing in FB code

Notes:
1. it only tests XLM-R models (base and large) in integration tests. We need to do a follow-up diff to enable RoBERTa testing since corresponding assets are missing in FBcode.

Edit: Addressed the Roberta model testing in this diff itself

2. parameterized was giving some weird long names to the test which was creating some unknown issue for running them in sandcastlle. Removed it for now to get the proper names for test.

Edit: refactored test suit since nested_params was creating long string names (400+ characters) for test methods due to RobertaBundle objects

Reviewed By: mikekgfb

Differential Revision: D35973306

fbshipit-source-id: 8a50d03466f60c8a4a0fbd5857611e68c92ebf08