### PR TITLE
Change root directory for datasets

### DIFF
--- a/torchtext/__init__.py
+++ b/torchtext/__init__.py
@@ -4,7 +4,7 @@ import os
 from torchtext import _extension  # noqa: F401
 
 _TEXT_BUCKET = "https://download.pytorch.org/models/text/"
-_CACHE_DIR = os.path.expanduser("~/.torchtext/cache")
+_CACHE_DIR = os.path.expanduser("~/.cache/torch/text")
 
 from . import data, datasets, experimental, functional, models, nn, transforms, utils, vocab
 

--- a/torchtext/data/datasets_utils.py
+++ b/torchtext/data/datasets_utils.py
@@ -187,7 +187,7 @@ def _create_dataset_directory(dataset_name):
 
         @functools.wraps(fn)
         def wrapper(root=_CACHE_DIR, *args, **kwargs):
-            new_root = os.path.join(root, dataset_name)
+            new_root = os.path.join(root, "datasets", dataset_name)
             if not os.path.exists(new_root):
                 os.makedirs(new_root, exist_ok=True)
             return fn(root=new_root, *args, **kwargs)


### PR DESCRIPTION
Following conversations in this [post](https://fb.workplace.com/groups/473278361165956/permalink/517067430120382/) internally with @NicolasHug , this is the first step to change the root directory of datasets.

Follow-up:

- [ ] Enable setting root directory programmatically once the APIs are aligned. 