### PR TITLE
Adding support for batch input in BERT Tokenizer with perf benchmark

### DIFF
--- a/benchmark/benchmark_bert_tokenizer.py
+++ b/benchmark/benchmark_bert_tokenizer.py
@@ -1,0 +1,42 @@
+from argparse import ArgumentParser
+
+from benchmark.utils import Timer
+from tokenizers import Tokenizer as hf_tokenizer_lib
+from torchtext.datasets import EnWik9
+from torchtext.transforms import BERTTokenizer as tt_bert_tokenizer
+from transformers import BertTokenizer as hf_bert_tokenizer_slow
+
+
+VOCAB_FILE = "https://huggingface.co/bert-base-uncased/resolve/main/vocab.txt"
+
+
+def benchmark_bert_tokenizer(args):
+    tt_tokenizer = tt_bert_tokenizer(VOCAB_FILE, return_tokens=True)
+    hf_tokenizer_slow = hf_bert_tokenizer_slow.from_pretrained("bert-base-uncased")
+    hf_tokenizer_fast = hf_tokenizer_lib.from_pretrained("bert-base-uncased")
+    dp = EnWik9().header(args.num_samples)
+    samples = list(dp)
+
+    with Timer("Running TorchText BERT Tokenizer on non-batched input"):
+        for s in samples:
+            tt_tokenizer(s)
+
+    with Timer("Running HF BERT Tokenizer (slow) on non-batched input"):
+        for s in samples:
+            hf_tokenizer_slow.tokenize(s)
+
+    with Timer("Running HF BERT Tokenizer (fast) on non-batched input"):
+        for s in samples:
+            hf_tokenizer_fast.encode(s)
+
+    with Timer("Running TorchText BERT Tokenizer on batched input"):
+        tt_tokenizer(samples)
+
+    with Timer("Running HF BERT Tokenizer (fast) on batched input"):
+        hf_tokenizer_fast.encode_batch(samples)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--num-samples", default=1000, type=int)
+    benchmark_bert_tokenizer(parser.parse_args())

--- a/torchtext/__init__.py
+++ b/torchtext/__init__.py
@@ -7,7 +7,7 @@ _TEXT_BUCKET = "https://download.pytorch.org/models/text/"
 
 _TORCH_HOME = os.getenv("TORCH_HOME")
 if _TORCH_HOME is None:
-    _TORCH_HOME = "~/.cache/torch" #default
+    _TORCH_HOME = "~/.cache/torch"  # default
 _CACHE_DIR = os.path.expanduser(os.path.join(_TORCH_HOME, "text"))
 
 from . import data, datasets, experimental, functional, models, nn, transforms, utils, vocab

--- a/torchtext/csrc/bert_tokenizer.cpp
+++ b/torchtext/csrc/bert_tokenizer.cpp
@@ -292,6 +292,24 @@ std::vector<int64_t> BERTEncoder::Encode(std::string text) {
   return indices;
 }
 
+std::vector<std::vector<std::string>> BERTEncoder::BatchTokenize(
+    std::vector<std::string> text) {
+  std::vector<std::vector<std::string>> output;
+  for (const auto& t : text) {
+    output.push_back(Tokenize(t));
+  }
+  return output;
+}
+
+std::vector<std::vector<int64_t>> BERTEncoder::BatchEncode(
+    std::vector<std::string> text) {
+  std::vector<std::vector<int64_t>> output;
+  for (const auto& t : text) {
+    output.push_back(Encode(t));
+  }
+  return output;
+}
+
 BERTEncoderStates _serialize_bert_encoder(
     const c10::intrusive_ptr<BERTEncoder>& self) {
   return std::make_tuple(

--- a/torchtext/csrc/bert_tokenizer.h
+++ b/torchtext/csrc/bert_tokenizer.h
@@ -21,6 +21,10 @@ struct BERTEncoder : torch::CustomClassHolder {
       c10::optional<bool> strip_accents);
   std::vector<std::string> Tokenize(std::string text);
   std::vector<int64_t> Encode(std::string text);
+  std::vector<std::vector<std::string>> BatchTokenize(
+      std::vector<std::string> text);
+  std::vector<std::vector<int64_t>> BatchEncode(std::vector<std::string> text);
+
   Vocab vocab_;
   bool do_lower_case_;
   c10::optional<bool> strip_accents_ = {};

--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -224,27 +224,25 @@ PYBIND11_MODULE(_torchtext, m) {
           "batch_encode",
           [](const c10::intrusive_ptr<BERTEncoder>& self,
              const py::list& items) {
-            std::vector<std::vector<int64_t>> ids(items.size());
-            int64_t counter = 0;
+            std::vector<std::string> input;
             for (const auto& item : items) {
               Py_ssize_t length;
               const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
-              ids[counter++] = self->Encode(std::string(buffer));
+              input.push_back(std::string(buffer));
             }
-            return ids;
+            return self->BatchEncode(input);
           })
       .def(
           "batch_tokenize",
           [](const c10::intrusive_ptr<BERTEncoder>& self,
              const py::list& items) {
-            std::vector<std::vector<std::string>> tokens(items.size());
-            int64_t counter = 0;
+            std::vector<std::string> input;
             for (const auto& item : items) {
               Py_ssize_t length;
               const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
-              tokens[counter++] = self->Tokenize(std::string(buffer));
+              input.push_back(std::string(buffer));
             }
-            return tokens;
+            return self->BatchTokenize(input);
           })
       .def(py::pickle(
           // __getstate__

--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -220,6 +220,32 @@ PYBIND11_MODULE(_torchtext, m) {
       .def(py::init<const std::string, bool, c10::optional<bool>>())
       .def("encode", &BERTEncoder::Encode)
       .def("tokenize", &BERTEncoder::Tokenize)
+      .def(
+          "batch_encode",
+          [](const c10::intrusive_ptr<BERTEncoder>& self,
+             const py::list& items) {
+            std::vector<std::vector<int64_t>> ids(items.size());
+            int64_t counter = 0;
+            for (const auto& item : items) {
+              Py_ssize_t length;
+              const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
+              ids[counter++] = self->Encode(std::string(buffer));
+            }
+            return ids;
+          })
+      .def(
+          "batch_tokenize",
+          [](const c10::intrusive_ptr<BERTEncoder>& self,
+             const py::list& items) {
+            std::vector<std::vector<std::string>> tokens(items.size());
+            int64_t counter = 0;
+            for (const auto& item : items) {
+              Py_ssize_t length;
+              const char* buffer = PyUnicode_AsUTF8AndSize(item.ptr(), &length);
+              tokens[counter++] = self->Tokenize(std::string(buffer));
+            }
+            return tokens;
+          })
       .def(py::pickle(
           // __getstate__
           [](const c10::intrusive_ptr<BERTEncoder>& self) -> BERTEncoderStates {

--- a/torchtext/csrc/register_torchbindings.cpp
+++ b/torchtext/csrc/register_torchbindings.cpp
@@ -177,6 +177,28 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
       .def(torch::init<const std::string, bool, c10::optional<bool>>())
       .def("encode", &BERTEncoder::Encode)
       .def("tokenize", &BERTEncoder::Tokenize)
+      .def(
+          "batch_encode",
+          [](const c10::intrusive_ptr<BERTEncoder>& self,
+             const std::vector<std::string>& items) {
+            std::vector<std::vector<int64_t>> ids(items.size());
+            int64_t counter = 0;
+            for (const auto& item : items) {
+              ids[counter++] = self->Encode(item);
+            }
+            return ids;
+          })
+      .def(
+          "batch_tokenize",
+          [](const c10::intrusive_ptr<BERTEncoder>& self,
+             const std::vector<std::string>& items) {
+            std::vector<std::vector<std::string>> tokens(items.size());
+            int64_t counter = 0;
+            for (const auto& item : items) {
+              tokens[counter++] = self->Tokenize(item);
+            }
+            return tokens;
+          })
       .def_pickle(
           // __getstate__
           [](const c10::intrusive_ptr<BERTEncoder>& self) -> BERTEncoderStates {

--- a/torchtext/csrc/register_torchbindings.cpp
+++ b/torchtext/csrc/register_torchbindings.cpp
@@ -181,23 +181,13 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
           "batch_encode",
           [](const c10::intrusive_ptr<BERTEncoder>& self,
              const std::vector<std::string>& items) {
-            std::vector<std::vector<int64_t>> ids(items.size());
-            int64_t counter = 0;
-            for (const auto& item : items) {
-              ids[counter++] = self->Encode(item);
-            }
-            return ids;
+            return self->BatchEncode(items);
           })
       .def(
           "batch_tokenize",
           [](const c10::intrusive_ptr<BERTEncoder>& self,
              const std::vector<std::string>& items) {
-            std::vector<std::vector<std::string>> tokens(items.size());
-            int64_t counter = 0;
-            for (const auto& item : items) {
-              tokens[counter++] = self->Tokenize(item);
-            }
-            return tokens;
+            return self->BatchTokenize(items);
           })
       .def_pickle(
           // __getstate__

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -599,17 +599,7 @@ class BERTTokenizer(Module):
 
     @torch.jit.export
     def _batch_encode(self, text: List[str]) -> List[List[str]]:
-        """Encode text into a list of tokens IDs
-
-        Args:
-            text: An input text string.
-
-        Returns:
-            A list of token ids represents each sub-word
-
-        For example:
-            --> "Hello world!" --> token ids: [707, 5927, 11, 707, 68]
-        """
+        """Batch version of _encode i.e operate on list of str"""
         token_ids: List[List[int]] = self.bert_model.batch_encode([t.strip() for t in text])
         tokens_ids_str: List[List[str]] = [[str(t) for t in token_id] for token_id in token_ids]
         return tokens_ids_str
@@ -631,17 +621,7 @@ class BERTTokenizer(Module):
 
     @torch.jit.export
     def _batch_tokenize(self, text: List[str]) -> List[List[str]]:
-        """Tokenize text into a list of tokens
-
-        Args:
-            text: An input text string.
-
-        Returns:
-            A list of tokens (sub-words)
-
-        For example:
-            --> "Hello World!": ["Hello", "World", "!"]
-        """
+        """Batch version of _tokenize i.e operate on list of str"""
         return self.bert_model.batch_tokenize([t.strip() for t in text])
 
     def forward(self, input: Any) -> Any:


### PR DESCRIPTION
This PR add support for batch tokenizer directly implemented at C++ kernel layer.

It also add benchmarking code for tokenizer. Following result is obtained by running tokenizer on 100000 samples.

```python
python benchmark/benchmark_bert_tokenizer.py --num-samples num_samples
```

**batch size 100**
Running TorchText BERT Tokenizer on non-batched input ... Total running time: 0.0014495829999998655
Running HF BERT Tokenizer (slow) on non-batched input ... Total running time: 0.01610425200000032
Running HF BERT Tokenizer (fast) on non-batched input ... Total running time: 0.0037178359999998634
Running TorchText BERT Tokenizer on batched input ... Total running time: 0.0007109650000001189
Running HF BERT Tokenizer (fast) on batched input ... Total running time: 0.0010531449999997555

**batch size 1000**
Running TorchText BERT Tokenizer on non-batched input ... Total running time: 0.021309904000000213
Running HF BERT Tokenizer (slow) on non-batched input ... Total running time: 0.383976283
Running HF BERT Tokenizer (fast) on non-batched input ... Total running time: 0.07770123400000006
Running TorchText BERT Tokenizer on batched input ... Total running time: 0.01940807400000022
Running HF BERT Tokenizer (fast) on batched input ... Total running time: 0.015243869999999937

**Observations**
*  ~15x on non-batched input compared to HF slow tokenizer (python based).
*  ~3x on non-batched input compared to HF fast tokenizer (Rust based)
*  torchtext is faster for batch processing up-to certain batch size but then as the batch size increases HF implementation becomes significantly faster (20-25%). This is likely because the kernel implementation of HF is faster compared to torchtext's but the overhead to call the binding for HF is higher compared to torchtext. 

Performance next steps:

- [ ] Perform analysis on the impact of batch size for batch processing.
- [ ] Identify and improve performance gaps in batch processing 
- [ ] Make use of timeit module in benchmark code