### PR TITLE
Pin setuptools to 58.0.4 on Windows

### DIFF
--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -3,6 +3,7 @@ channels:
 dependencies:
   - codecov
   - pip
+  - setuptools == 58.0.4
   - pip:
       - dataclasses
       - nltk

--- a/torchtext/__init__.py
+++ b/torchtext/__init__.py
@@ -7,7 +7,7 @@ _TEXT_BUCKET = "https://download.pytorch.org/models/text/"
 
 _TORCH_HOME = os.getenv("TORCH_HOME")
 if _TORCH_HOME is None:
-    _TORCH_HOME = "~/.cache/torch" #default
+    _TORCH_HOME = "~/.cache/torch"  # default
 _CACHE_DIR = os.path.expanduser(os.path.join(_TORCH_HOME, "text"))
 
 from . import data, datasets, experimental, functional, models, nn, transforms, utils, vocab


### PR DESCRIPTION
## Description

The CI jobs [unittest_windows_py3.7](https://app.circleci.com/pipelines/github/pytorch/text/5592/workflows/a789d228-fac5-4b98-9c37-5ee1a2d0d58f/jobs/189407) fails with:
```
error: can't copy 'build\lib.win-amd64-3.7\pyd': doesn't exist or not a regular file
```

Following the changes in https://github.com/pytorch/vision/pull/5868 to fix this