### PR TITLE
Removed ticks (``) from the url under is_module_available

### DIFF
--- a/torchtext/datasets/wikitext2.py
+++ b/torchtext/datasets/wikitext2.py
@@ -64,7 +64,7 @@ def WikiText2(root: str, split: Union[Tuple[str], str]):
     """
     if not is_module_available("torchdata"):
         raise ModuleNotFoundError(
-            "Package `torchdata` not found. Please install following instructions at `https://github.com/pytorch/data`"
+            "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
 
     url_dp = IterableWrapper([URL])


### PR DESCRIPTION
Ticks can result in re-direction to 'https://github.com/pytorch/data%60' instead of 'https://github.com/pytorch/data', which is not a valid resource.
Tested in Colab.