### PR TITLE
Fix test utils

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,6 +5,7 @@ import shutil
 import unittest
 
 from test.common.assets import get_asset_path
+from torchtext import _TEXT_BUCKET
 from torchtext import utils
 
 from .common.torchtext_test_case import TorchtextTestCase
@@ -23,7 +24,7 @@ class TestUtils(TorchtextTestCase):
             os.makedirs(root)
 
         # ensure archive is not already downloaded, if it is then delete
-        url = "http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz"
+        url = os.path.join(_TEXT_BUCKET, "assets", "validation.tar.gz")
         target_archive_path = os.path.join(root, "validation.tar.gz")
         conditional_remove(target_archive_path)
 
@@ -132,7 +133,7 @@ class TestUtils(TorchtextTestCase):
             os.makedirs(root)
 
         # ensure archive is not already downloaded, if it is then delete
-        url = "http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz"
+        url = os.path.join(_TEXT_BUCKET, "assets", "validation.tar.gz")
         target_archive_path = os.path.join(root, "validation.tar.gz")
         conditional_remove(target_archive_path)
 


### PR DESCRIPTION
The [validation.tar.gz](http://www.quest.dcs.shef.ac.uk/wmt16_files_mmt/validation.tar.gz)  file used in test_utils.py is broken. Ideally we should not rely on public assets for testing.

This PR creates a mock asset and upload it it _TEXT_BUCKET ("https://download.pytorch.org/models/text/") which is used for testing.