### PR TITLE
Fix bug in RTE and WNLI testing

### DIFF
--- a/test/datasets/test_qnli.py
+++ b/test/datasets/test_qnli.py
@@ -54,7 +54,7 @@ class TestQNLI(TempDirMixin, TorchtextTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.root_dir = cls.get_base_temp_dir()
-        cls.samples = _get_mock_dataset(os.path.join(cls.root_dir, "datasets"))
+        cls.samples = _get_mock_dataset(cls.root_dir)
         cls.patcher = patch("torchdata.datapipes.iter.util.cacheholder._hash_check", return_value=True)
         cls.patcher.start()
 

--- a/test/datasets/test_qnli.py
+++ b/test/datasets/test_qnli.py
@@ -54,7 +54,7 @@ class TestQNLI(TempDirMixin, TorchtextTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.root_dir = cls.get_base_temp_dir()
-        cls.samples = _get_mock_dataset(cls.root_dir)
+        cls.samples = _get_mock_dataset(os.path.join(cls.root_dir, "datasets"))
         cls.patcher = patch("torchdata.datapipes.iter.util.cacheholder._hash_check", return_value=True)
         cls.patcher.start()
 

--- a/test/datasets/test_rte.py
+++ b/test/datasets/test_rte.py
@@ -9,7 +9,7 @@ from torchtext.datasets.rte import RTE
 from ..common.case_utils import TempDirMixin, zip_equal, get_random_unicode
 from ..common.torchtext_test_case import TorchtextTestCase
 
-LABELS = ["not_entailment", "entailment"]
+LABELS = ["entailment", "not_entailment"]
 
 
 def _get_mock_dataset(root_dir):

--- a/test/datasets/test_rte.py
+++ b/test/datasets/test_rte.py
@@ -51,7 +51,7 @@ def _get_mock_dataset(root_dir):
     return mocked_data
 
 
-class TestSST2(TempDirMixin, TorchtextTestCase):
+class TestRTE(TempDirMixin, TorchtextTestCase):
     root_dir = None
     samples = []
 

--- a/test/datasets/test_rte.py
+++ b/test/datasets/test_rte.py
@@ -9,6 +9,8 @@ from torchtext.datasets.rte import RTE
 from ..common.case_utils import TempDirMixin, zip_equal, get_random_unicode
 from ..common.torchtext_test_case import TorchtextTestCase
 
+LABELS = ["not_entailment", "entailment"]
+
 
 def _get_mock_dataset(root_dir):
     """
@@ -25,14 +27,14 @@ def _get_mock_dataset(root_dir):
         with open(txt_file, "w", encoding="utf-8") as f:
             f.write("index\tsentence1\tsentence2\tlabel\n")
             for i in range(5):
-                label = seed % 2
+                label = LABELS[seed % 2]
                 rand_string_1 = get_random_unicode(seed)
                 rand_string_2 = get_random_unicode(seed + 1)
                 if file_name == "test.tsv":
                     dataset_line = (rand_string_1, rand_string_2)
                     f.write(f"{i}\t{rand_string_1}\t{rand_string_2}\n")
                 else:
-                    dataset_line = (label, rand_string_1, rand_string_2)
+                    dataset_line = (seed % 2, rand_string_1, rand_string_2)
                     f.write(f"{i}\t{rand_string_1}\t{rand_string_2}\t{label}\n")
 
                 # append line to correct dataset split
@@ -57,7 +59,7 @@ class TestSST2(TempDirMixin, TorchtextTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.root_dir = cls.get_base_temp_dir()
-        cls.samples = _get_mock_dataset(cls.root_dir)
+        cls.samples = _get_mock_dataset(os.path.join(cls.root_dir, "datasets"))
         cls.patcher = patch("torchdata.datapipes.iter.util.cacheholder._hash_check", return_value=True)
         cls.patcher.start()
 

--- a/test/datasets/test_wnli.py
+++ b/test/datasets/test_wnli.py
@@ -57,7 +57,7 @@ class TestWNLI(TempDirMixin, TorchtextTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.root_dir = cls.get_base_temp_dir()
-        cls.samples = _get_mock_dataset(cls.root_dir)
+        cls.samples = _get_mock_dataset(os.path.join(cls.root_dir, "datasets"))
         cls.patcher = patch("torchdata.datapipes.iter.util.cacheholder._hash_check", return_value=True)
         cls.patcher.start()
 

--- a/torchtext/datasets/rte.py
+++ b/torchtext/datasets/rte.py
@@ -36,6 +36,8 @@ _EXTRACTED_FILES = {
     "test": os.path.join("RTE", "test.tsv"),
 }
 
+MAP_LABELS = {"not_entailment": 1, "entailment": 0}
+
 
 def _filepath_fn(root, x=None):
     return os.path.join(root, os.path.basename(x))
@@ -53,7 +55,7 @@ def _modify_res(split, x):
     if split == "test":
         return (x[1], x[2])
     else:
-        return (int(x[3]), x[1], x[2])
+        return (MAP_LABELS[x[3]], x[1], x[2])
 
 
 @_create_dataset_directory(dataset_name=DATASET_NAME)

--- a/torchtext/datasets/rte.py
+++ b/torchtext/datasets/rte.py
@@ -36,7 +36,7 @@ _EXTRACTED_FILES = {
     "test": os.path.join("RTE", "test.tsv"),
 }
 
-MAP_LABELS = {"not_entailment": 1, "entailment": 0}
+MAP_LABELS = {"entailment": 0, "not_entailment": 1}
 
 
 def _filepath_fn(root, x=None):

--- a/torchtext/datasets/rte.py
+++ b/torchtext/datasets/rte.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import csv
 import os
 from functools import partial
 
@@ -98,5 +99,7 @@ def RTE(root, split):
     cache_decompressed_dp = cache_decompressed_dp.end_caching(mode="wb", same_filepath_fn=True)
 
     data_dp = FileOpener(cache_decompressed_dp, encoding="utf-8")
-    parsed_data = data_dp.parse_csv(skip_lines=1, delimiter="\t").map(partial(_modify_res, split))
+    parsed_data = data_dp.parse_csv(skip_lines=1, delimiter="\t", quoting=csv.QUOTE_NONE).map(
+        partial(_modify_res, split)
+    )
     return parsed_data.shuffle().set_shuffle(False).sharding_filter()


### PR DESCRIPTION
This PR fixes issues RTE and WNLI testing:
* In both tests, "dataset" directory was not taken into account causing it to download the real data instead of working with mock data
* RTE dataset was not converting string labels into proper integer IDs
* RTE dataset was not parsed properly. Need to pass quoting=csv.QUOTE_NONE in parse_csv to fix the issue.