### PR TITLE
Fix bug in QNLI dataset and corresponding test

### DIFF
--- a/test/datasets/test_qnli.py
+++ b/test/datasets/test_qnli.py
@@ -10,6 +10,9 @@ from ..common.case_utils import TempDirMixin, zip_equal, get_random_unicode
 from ..common.torchtext_test_case import TorchtextTestCase
 
 
+LABELS = ["entailment", "not_entailment"]
+
+
 def _get_mock_dataset(root_dir):
     """
     root_dir: directory to the mocked dataset
@@ -28,9 +31,14 @@ def _get_mock_dataset(root_dir):
                 label = seed % 2
                 rand_string_1 = get_random_unicode(seed)
                 rand_string_2 = get_random_unicode(seed + 1)
-                dataset_line = (label, rand_string_1, rand_string_2)
-                label_str = "entailment" if label == 1 else "not_entailment"
-                f.write(f"{i}\t{rand_string_1}\t{rand_string_2}\t{label_str}\n")
+                label_str = LABELS[label]
+
+                if file_name == "test.tsv":
+                    dataset_line = (rand_string_1, rand_string_2)
+                    f.write(f"{i}\t{rand_string_1}\t{rand_string_2}\n")
+                else:
+                    dataset_line = (label, rand_string_1, rand_string_2)
+                    f.write(f"{i}\t{rand_string_1}\t{rand_string_2}\t{label_str}\n")
 
                 # append line to correct dataset split
                 mocked_data[os.path.splitext(file_name)[0]].append(dataset_line)
@@ -54,7 +62,7 @@ class TestQNLI(TempDirMixin, TorchtextTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.root_dir = cls.get_base_temp_dir()
-        cls.samples = _get_mock_dataset(cls.root_dir)
+        cls.samples = _get_mock_dataset(os.path.join(cls.root_dir, "datasets"))
         cls.patcher = patch("torchdata.datapipes.iter.util.cacheholder._hash_check", return_value=True)
         cls.patcher.start()
 

--- a/torchtext/datasets/qnli.py
+++ b/torchtext/datasets/qnli.py
@@ -50,6 +50,10 @@ def _filter_fn(split, x):
     return _EXTRACTED_FILES[split] in x[0]
 
 
+def _modify_test_res(x):
+    return (x[1], x[2])
+
+
 def _modify_res(x):
     return (int(x[3] == "entailment"), x[1], x[2])
 
@@ -94,5 +98,7 @@ def QNLI(root, split):
     cache_decompressed_dp = cache_decompressed_dp.end_caching(mode="wb", same_filepath_fn=True)
 
     data_dp = FileOpener(cache_decompressed_dp, encoding="utf-8")
-    parsed_data = data_dp.parse_csv(skip_lines=1, delimiter="\t", quoting=csv.QUOTE_NONE).map(_modify_res)
+
+    modify_res_fn = _modify_test_res if split == "test" else _modify_res
+    parsed_data = data_dp.parse_csv(skip_lines=1, delimiter="\t", quoting=csv.QUOTE_NONE).map(modify_res_fn)
     return parsed_data.shuffle().set_shuffle(False).sharding_filter()

--- a/torchtext/datasets/qnli.py
+++ b/torchtext/datasets/qnli.py
@@ -37,6 +37,8 @@ _EXTRACTED_FILES = {
     "test": os.path.join("QNLI", "test.tsv"),
 }
 
+MAP_LABELS = {"not_entailment": 1, "entailment": 0}
+
 
 def _filepath_fn(root, x=None):
     return os.path.join(root, os.path.basename(x))
@@ -50,12 +52,11 @@ def _filter_fn(split, x):
     return _EXTRACTED_FILES[split] in x[0]
 
 
-def _modify_test_res(x):
-    return (x[1], x[2])
-
-
-def _modify_res(x):
-    return (int(x[3] == "entailment"), x[1], x[2])
+def _modify_res(split, x):
+    if split == "test":
+        return (x[1], x[2])
+    else:
+        return (MAP_LABELS[x[3]], x[1], x[2])
 
 
 @_create_dataset_directory(dataset_name=DATASET_NAME)
@@ -98,7 +99,7 @@ def QNLI(root, split):
     cache_decompressed_dp = cache_decompressed_dp.end_caching(mode="wb", same_filepath_fn=True)
 
     data_dp = FileOpener(cache_decompressed_dp, encoding="utf-8")
-
-    modify_res_fn = _modify_test_res if split == "test" else _modify_res
-    parsed_data = data_dp.parse_csv(skip_lines=1, delimiter="\t", quoting=csv.QUOTE_NONE).map(modify_res_fn)
+    parsed_data = data_dp.parse_csv(skip_lines=1, delimiter="\t", quoting=csv.QUOTE_NONE).map(
+        partial(_modify_res, split)
+    )
     return parsed_data.shuffle().set_shuffle(False).sharding_filter()


### PR DESCRIPTION
# Description
- QNLI dataset had a bug where we weren't taking into account that the `test` split did not have a label entry
- Additionally the `root_dir` for the mock dataset was not set correctly so the entire dataset was downloaded
- Updated dataset implementation and corresponding test

# Testing
` pytest test/datasets/test_qnli.py`