### PR TITLE
Add test to compare encoder inference on input with and without padding

### DIFF
--- a/test/models/test_transformers.py
+++ b/test/models/test_transformers.py
@@ -14,7 +14,7 @@ class TestTransformers(TorchtextTestCase):
         from torchtext.models import RobertaEncoderConf, RobertaModel
 
         def encoder_inference(encoder, input_lst, with_no_grad):
-            if(with_no_grad):
+            if with_no_grad:
                 with torch.no_grad():
                     res = [encoder(eval_input) for eval_input in input_lst]
             else:
@@ -24,12 +24,12 @@ class TestTransformers(TorchtextTestCase):
         # Roberta config except for less layers (2 instead of 12)
         pad_idx = 1
         encoder_conf = RobertaEncoderConf(
-            vocab_size=250002, 
-            embedding_dim=768, 
-            ffn_dimension=3072, 
-            padding_idx = pad_idx,
-            max_seq_len = 514,
-            num_attention_heads=12, 
+            vocab_size=250002,
+            embedding_dim=768,
+            ffn_dimension=3072,
+            padding_idx=pad_idx,
+            max_seq_len=514,
+            num_attention_heads=12,
             num_encoder_layers=2,
             dropout=0.1,
             scaling=None,
@@ -42,7 +42,7 @@ class TestTransformers(TorchtextTestCase):
 
         # result from converting string "some text" to tensor using xlmr_base embeddings
         input_no_pad = torch.Tensor([[0, 3060, 7986, 2]]).to(torch.int)
-        data_len = input_no_pad.shape[1] # sequence length of non-pad data
+        data_len = input_no_pad.shape[1]  # sequence length of non-pad data
         # add two padding tokens to input_no_pad
         input_pad = torch.Tensor([[0, 3060, 7986, 2, pad_idx, pad_idx]]).to(torch.int)
         input_lst = [input_no_pad, input_pad]

--- a/test/models/test_transformers.py
+++ b/test/models/test_transformers.py
@@ -50,7 +50,3 @@ class TestTransformers(TorchtextTestCase):
 
         output_no_pad, output_pad = encoder_inference(model, input_lst, with_no_grad)
         torch.testing.assert_close(output_no_pad, output_pad[:, :data_len, :])
-
-
-
-    

--- a/test/models/test_transformers.py
+++ b/test/models/test_transformers.py
@@ -1,0 +1,56 @@
+import torch
+import torchtext
+
+from ..common.parameterized_utils import nested_params
+from ..common.torchtext_test_case import TorchtextTestCase
+
+
+class TestTransformers(TorchtextTestCase):
+    @nested_params(
+        [True, False],
+        [True, False],
+    )
+    def test_padded_input_inference(self, with_no_grad, return_all_layers):
+        """test transformerencoder inference same with and without padding"""
+        from torchtext.models import RobertaEncoderConf, RobertaModel
+
+        def encoder_inference(encoder, input_lst, with_no_grad):
+            if(with_no_grad):
+                with torch.no_grad():
+                    res = [encoder(eval_input) for eval_input in input_lst]
+            else:
+                res = [encoder(eval_input) for eval_input in input_lst]
+            return res
+
+        # Roberta config except for less layers (2 instead of 12)
+        pad_idx = 1
+        encoder_conf = RobertaEncoderConf(
+            vocab_size=250002, 
+            embedding_dim=768, 
+            ffn_dimension=3072, 
+            padding_idx = pad_idx,
+            max_seq_len = 514,
+            num_attention_heads=12, 
+            num_encoder_layers=2,
+            dropout=0.1,
+            scaling=None,
+            normalize_before=False,
+        )
+        model = RobertaModel(encoder_conf)
+        model = model.eval()
+        # TODO: make return_all_layers a property of RobertaEncoderConf so it can be passed as arg
+        model.encoder.transformer.return_all_layers = return_all_layers
+
+        # result from converting string "some text" to tensor using xlmr_base embeddings
+        input_no_pad = torch.Tensor([[0, 3060, 7986, 2]]).to(torch.int)
+        data_len = input_no_pad.shape[1] # sequence length of non-pad data
+        # add two padding tokens to input_no_pad
+        input_pad = torch.Tensor([[0, 3060, 7986, 2, pad_idx, pad_idx]]).to(torch.int)
+        input_lst = [input_no_pad, input_pad]
+
+        output_no_pad, output_pad = encoder_inference(model, input_lst, with_no_grad)
+        torch.testing.assert_close(output_no_pad, output_pad[:, :data_len, :])
+
+
+
+    

--- a/test/models/test_transformers.py
+++ b/test/models/test_transformers.py
@@ -1,5 +1,4 @@
 import torch
-import torchtext
 
 from ..common.parameterized_utils import nested_params
 from ..common.torchtext_test_case import TorchtextTestCase


### PR DESCRIPTION
Encoder inference should output identical embeddings if given a padded vs. non-padded input (assuming the non-padded data is the same). Check that this is the case. 

We make this check for four paths by setting the below two flags. 
- with_no_grad = [True, False] -> this is performing inference with and without torch.no_grad(). When torch.no_grad() is turned on, we hit the fast path of torch.nn.TransformerEncoder (BetterTransformer). 
- return_all_layers = [True, False]. When set to False, torch.nn.TransformerEncoder is directly called, and when set to True, torchtext encoder loops through torch.nn.TransformerEncoderLayer directly to save the intermediate outputs of each layer.