### PR TITLE
Add missing type hints

### DIFF
--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -125,7 +125,7 @@ class TestFunctional(TorchtextTestCase):
 
 
 class ScriptableSP(torch.jit.ScriptModule):
-    def __init__(self, model_path):
+    def __init__(self, model_path) -> None:
         super().__init__()
         self.spm = load_sp_model(model_path)
 

--- a/torchtext/data/functional.py
+++ b/torchtext/data/functional.py
@@ -295,7 +295,7 @@ def to_map_style_dataset(iter_data):
 
     # Inner class to convert iterable-style to map-style dataset
     class _MapStyleDataset(torch.utils.data.Dataset):
-        def __init__(self, iter_data):
+        def __init__(self, iter_data) -> None:
             # TODO Avoid list issue #1296
             self._data = list(iter_data)
 

--- a/torchtext/data/utils.py
+++ b/torchtext/data/utils.py
@@ -232,7 +232,7 @@ class RandomShuffler(object):
     """Use random functions while keeping track of the random state to make it
     reproducible and deterministic."""
 
-    def __init__(self, random_state=None):
+    def __init__(self, random_state=None) -> None:
         self._random_state = random_state
         if self._random_state is None:
             self._random_state = random.getstate()

--- a/torchtext/experimental/transforms.py
+++ b/torchtext/experimental/transforms.py
@@ -78,7 +78,7 @@ class BasicEnglishNormalize(nn.Module):
         regex_tokenizer (torch.classes.torchtext.RegexTokenizer or torchtext._torchtext.RegexTokenizer): a cpp regex tokenizer object.
     """
 
-    def __init__(self, regex_tokenizer):
+    def __init__(self, regex_tokenizer) -> None:
         super(BasicEnglishNormalize, self).__init__()
         self.regex_tokenizer = regex_tokenizer
 
@@ -185,7 +185,7 @@ class SentencePieceTokenizer(nn.Module):
        spm_model: the sentencepiece model instance
     """
 
-    def __init__(self, spm_model):
+    def __init__(self, spm_model) -> None:
         super(SentencePieceTokenizer, self).__init__()
         self.sp_model = spm_model
 
@@ -245,7 +245,7 @@ class SentencePieceProcessor(nn.Module):
        spm_model: the sentencepiece model instance
     """
 
-    def __init__(self, spm_model):
+    def __init__(self, spm_model) -> None:
         super(SentencePieceProcessor, self).__init__()
         self.sp_model = spm_model
 
@@ -293,7 +293,7 @@ class VocabTransform(nn.Module):
         >>> jit_vocab_transform = torch.jit.script(vocab_transform)
     """
 
-    def __init__(self, vocab):
+    def __init__(self, vocab) -> None:
         super(VocabTransform, self).__init__()
         self.vocab = vocab
 
@@ -324,7 +324,7 @@ class VectorTransform(nn.Module):
         >>> jit_vector_transform = torch.jit.script(vector_transform)
     """
 
-    def __init__(self, vector):
+    def __init__(self, vector) -> None:
         super(VectorTransform, self).__init__()
         self.vector = vector
 

--- a/torchtext/experimental/vectors.py
+++ b/torchtext/experimental/vectors.py
@@ -207,7 +207,7 @@ class Vectors(nn.Module):
         vectors (torch.classes.torchtext.Vectors or torchtext._torchtext.Vectors): a cpp vectors object.
     """
 
-    def __init__(self, vectors):
+    def __init__(self, vectors) -> None:
         super(Vectors, self).__init__()
         self.vectors = vectors
 

--- a/torchtext/models/roberta/model.py
+++ b/torchtext/models/roberta/model.py
@@ -109,7 +109,9 @@ class RobertaModel(Module):
         >>> classifier = RobertaModel(config=roberta_encoder_conf, head=classifier_head)
     """
 
-    def __init__(self, encoder_conf: RobertaEncoderConf, head: Optional[Module] = None, freeze_encoder: bool = False) -> None:
+    def __init__(
+        self, encoder_conf: RobertaEncoderConf, head: Optional[Module] = None, freeze_encoder: bool = False
+    ) -> None:
         super().__init__()
         assert isinstance(encoder_conf, RobertaEncoderConf)
 

--- a/torchtext/models/roberta/model.py
+++ b/torchtext/models/roberta/model.py
@@ -41,7 +41,7 @@ class RobertaEncoder(Module):
         scaling: Optional[float] = None,
         normalize_before: bool = False,
         freeze: bool = False,
-    ):
+    ) -> None:
         super().__init__()
         if not scaling:
             head_dim = embedding_dim // num_attention_heads
@@ -79,7 +79,7 @@ class RobertaEncoder(Module):
 class RobertaClassificationHead(nn.Module):
     def __init__(
         self, num_classes, input_dim, inner_dim: Optional[int] = None, dropout: float = 0.1, activation=nn.ReLU
-    ):
+    ) -> None:
         super().__init__()
         if not inner_dim:
             inner_dim = input_dim
@@ -109,7 +109,7 @@ class RobertaModel(Module):
         >>> classifier = RobertaModel(config=roberta_encoder_conf, head=classifier_head)
     """
 
-    def __init__(self, encoder_conf: RobertaEncoderConf, head: Optional[Module] = None, freeze_encoder: bool = False):
+    def __init__(self, encoder_conf: RobertaEncoderConf, head: Optional[Module] = None, freeze_encoder: bool = False) -> None:
         super().__init__()
         assert isinstance(encoder_conf, RobertaEncoderConf)
 

--- a/torchtext/models/roberta/modules.py
+++ b/torchtext/models/roberta/modules.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class PositionalEmbedding(Module):
-    def __init__(self, num_embeddings: int, embedding_dim: int, pad_index: int):
+    def __init__(self, num_embeddings: int, embedding_dim: int, pad_index: int) -> None:
         super().__init__()
         self.embedding = nn.Embedding(num_embeddings, embedding_dim, pad_index)
         self.pad_index = pad_index
@@ -38,7 +38,7 @@ class TransformerEncoderLayer(Module):
         dropout: float = 0.1,
         normalize_before: bool = False,
         scaling: Optional[float] = None,
-    ):
+    ) -> None:
         super().__init__()
         # TODO Manually setting scaling is not allowed
         ffn_dimension = ffn_dimension or embedding_dim * 4
@@ -106,7 +106,7 @@ class TransformerEncoder(Module):
         normalize_before: bool = False,
         scaling: Optional[float] = None,
         return_all_layers: bool = False,
-    ):
+    ) -> None:
         super().__init__()
         self.padding_idx = padding_idx
         self.token_embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx)

--- a/torchtext/nn/modules/multiheadattention.py
+++ b/torchtext/nn/modules/multiheadattention.py
@@ -4,7 +4,7 @@ import torch
 
 
 class MultiheadAttentionContainer(torch.nn.Module):
-    def __init__(self, nhead, in_proj_container, attention_layer, out_proj, batch_first=False):
+    def __init__(self, nhead, in_proj_container, attention_layer, out_proj, batch_first=False) -> None:
         r"""A multi-head attention container
 
         Args:
@@ -119,7 +119,7 @@ class MultiheadAttentionContainer(torch.nn.Module):
 
 
 class ScaledDotProduct(torch.nn.Module):
-    def __init__(self, dropout=0.0, batch_first=False):
+    def __init__(self, dropout=0.0, batch_first=False) -> None:
         r"""Processes a projected query and key-value pair to apply
         scaled dot product attention.
 
@@ -236,7 +236,7 @@ class ScaledDotProduct(torch.nn.Module):
 
 
 class InProjContainer(torch.nn.Module):
-    def __init__(self, query_proj, key_proj, value_proj):
+    def __init__(self, query_proj, key_proj, value_proj) -> None:
         r"""A in-proj container to project query/key/value in MultiheadAttention. This module happens before reshaping
         the projected query/key/value into multiple heads. See the linear layers (bottom) of Multi-head Attention in
         Fig 2 of Attention Is All You Need paper. Also check the usage example

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -49,7 +49,7 @@ class SentencePieceTokenizer(Module):
         >>> transform(["hello world", "attention is all you need!"])
     """
 
-    def __init__(self, sp_model_path: str):
+    def __init__(self, sp_model_path: str) -> None:
         super().__init__()
         self.sp_model = load_sp_model(get_asset_local_path(sp_model_path))
 
@@ -87,7 +87,7 @@ class VocabTransform(Module):
         >>> jit_vocab_transform = torch.jit.script(vocab_transform)
     """
 
-    def __init__(self, vocab: Vocab):
+    def __init__(self, vocab: Vocab) -> None:
         super().__init__()
         assert isinstance(vocab, Vocab)
         self.vocab = vocab
@@ -151,7 +151,7 @@ class LabelToIndex(Module):
         label_names: Optional[List[str]] = None,
         label_path: Optional[str] = None,
         sort_names=False,
-    ):
+    ) -> None:
         assert label_names or label_path, "label_names or label_path is required"
         assert not (label_names and label_path), "label_names and label_path are mutually exclusive"
         super().__init__()
@@ -238,7 +238,7 @@ class PadTransform(Module):
     :type pad_value: bool
     """
 
-    def __init__(self, max_length: int, pad_value: int):
+    def __init__(self, max_length: int, pad_value: int) -> None:
         super().__init__()
         self.max_length = max_length
         self.pad_value = float(pad_value)
@@ -260,7 +260,7 @@ class PadTransform(Module):
 class StrToIntTransform(Module):
     """Convert string tokens to integers (either single sequence or batch)."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def forward(self, input: Any) -> Any:
@@ -291,7 +291,7 @@ class GPT2BPETokenizer(Module):
     __jit_unused_properties__ = ["is_jitable"]
     _seperator: torch.jit.Final[str]
 
-    def __init__(self, encoder_json_path: str, vocab_bpe_path: str, return_tokens: bool = False):
+    def __init__(self, encoder_json_path: str, vocab_bpe_path: str, return_tokens: bool = False) -> None:
         super().__init__()
         self._seperator = "\u0001"
         # load bpe encoder and bpe decoder
@@ -425,7 +425,7 @@ class CLIPTokenizer(Module):
         encoder_json_path: Optional[str] = None,
         num_merges: Optional[int] = None,
         return_tokens: bool = False,
-    ):
+    ) -> None:
         super().__init__()
         self._seperator = "\u0001"
         # load bpe merges
@@ -679,7 +679,7 @@ class RegexTokenizer(Module):
         >>> tokens = jit_reg_tokenizer(test_sample)
     """
 
-    def __init__(self, patterns_list):
+    def __init__(self, patterns_list) -> None:
         super(RegexTokenizer, self).__init__()
         patterns = [pair[0] for pair in patterns_list]
         replacements = [pair[1] for pair in patterns_list]

--- a/torchtext/vocab/vectors.py
+++ b/torchtext/vocab/vectors.py
@@ -32,7 +32,7 @@ def _infer_shape(f):
 
 
 class Vectors(object):
-    def __init__(self, name, cache=None, url=None, unk_init=None, max_vectors=None):
+    def __init__(self, name, cache=None, url=None, unk_init=None, max_vectors=None) -> None:
         """
         Args:
 
@@ -214,7 +214,7 @@ class GloVe(Vectors):
         "6B": "http://nlp.stanford.edu/data/glove.6B.zip",
     }
 
-    def __init__(self, name="840B", dim=300, **kwargs):
+    def __init__(self, name="840B", dim=300, **kwargs) -> None:
         url = self.url[name]
         name = "glove.{}.{}d.txt".format(name, str(dim))
         super(GloVe, self).__init__(name, url=url, **kwargs)
@@ -224,7 +224,7 @@ class FastText(Vectors):
 
     url_base = "https://dl.fbaipublicfiles.com/fasttext/vectors-wiki/wiki.{}.vec"
 
-    def __init__(self, language="en", **kwargs):
+    def __init__(self, language="en", **kwargs) -> None:
         url = self.url_base.format(language)
         name = os.path.basename(url)
         super(FastText, self).__init__(name, url=url, **kwargs)
@@ -235,7 +235,7 @@ class CharNGram(Vectors):
     name = "charNgram.txt"
     url = "http://www.logos.t.u-tokyo.ac.jp/~hassy/publications/arxiv2016jmt/" "jmt_pre-trained_embeddings.tar.gz"
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super(CharNGram, self).__init__(self.name, url=self.url, **kwargs)
 
     def __getitem__(self, token):

--- a/torchtext/vocab/vocab.py
+++ b/torchtext/vocab/vocab.py
@@ -13,7 +13,7 @@ class Vocab(nn.Module):
         vocab (torch.classes.torchtext.Vocab or torchtext._torchtext.Vocab): a cpp vocab object.
     """
 
-    def __init__(self, vocab):
+    def __init__(self, vocab) -> None:
         super(Vocab, self).__init__()
         self.vocab = vocab
         _log_class_usage(__class__)


### PR DESCRIPTION
I added the `-> None` type hint to all the functions in `torchtext/` and `test/` that were missing it, using some [simple regex code](https://stackoverflow.com/questions/64948233/how-to-add-none-to-the-end-of-init-functions-with-notepad).

Adding `-> None` to `__init__` functions is specified by PEP-0484: https://www.python.org/dev/peps/pep-0484/