### PR TITLE
Fix push on release reference name

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set Release CHANNEL (for release)
         if:
           ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref,
-          'release') }}
+          'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
       - name: Build TorchText M1 wheel


### PR DESCRIPTION
Fix push on release reference name
We want to compare it against refs/heads/release rather then release
Tests: https://github.com/atalman/vision/commit/af17cd95d2d43ca13354fb700e2da42108dd5a87
Sets correctly release chanell (wheels): https://github.com/atalman/vision/runs/6901327010?check_suite_focus=true