### PR TITLE
remove padding mask for input embeddings

### DIFF
--- a/torchtext/models/roberta/modules.py
+++ b/torchtext/models/roberta/modules.py
@@ -149,10 +149,8 @@ class TransformerEncoder(Module):
             embedded = self.embedding_layer_norm(embedded)
         embedded = self.dropout(embedded)
 
-        padded_embedded = embedded * (1 - padding_mask.unsqueeze(-1).type_as(embedded))
-
         if self.return_all_layers:
-            encoded = padded_embedded
+            encoded = embedded
             # B x T x C
             # Then transpose back to T x B x C
             states = [encoded.transpose(1, 0)]
@@ -167,7 +165,7 @@ class TransformerEncoder(Module):
         else:
             # B x T x C
             # Then transpose back to T x B x C
-            encoded = self.layers(padded_embedded, src_key_padding_mask=padding_mask).transpose(1, 0)
+            encoded = self.layers(embedded, src_key_padding_mask=padding_mask).transpose(1, 0)
             if self.normalize_before:
                 encoded = self.embedding_layer_norm(encoded)
             return encoded


### PR DESCRIPTION
This PR removes the masking at Padded tokens for the input embeddings. 

In fairseq, the masking is applied to input embedding [here](https://github.com/facebookresearch/fairseq/blob/08fe88479f8dd1f53705e203474a031d14cc2d75/fairseq/models/transformer/transformer_encoder.py#L211) but not in HF implementation. This causes MisMatch in output embedding for the padded tokens. 

Ideally, it should not matter the output for padded tokens. Per the investigations from @ebsmothers, it is somehow causing results to differ for MDETR model. In order for Torch MM to upstream dependency on torchtext for RoBERTa encoder, this change is necessary.