### PR TITLE
Automatically initialize submodule

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -33,7 +33,6 @@ printf "Installing torchdata nightly\n"
 pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 printf "* Installing torchtext\n"
-git submodule update --init --recursive
 python setup.py develop
 
 printf "* Installing parameterized\n"

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -26,7 +26,6 @@ curl --output pywin32_postinstall.py https://raw.githubusercontent.com/mhammond/
 python pywin32_postinstall.py -install
 
 printf "* Installing torchtext\n"
-git submodule update --init --recursive
 "$root_dir/packaging/vc_env_helper.bat" python setup.py develop
 
 printf "* Installing parameterized\n"

--- a/packaging/torchtext/bld.bat
+++ b/packaging/torchtext/bld.bat
@@ -1,7 +1,4 @@
 @echo off
 
-git submodule update --init --recursive
-if errorlevel 1 exit /b 1
-
 python setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit /b 1

--- a/packaging/torchtext/build.sh
+++ b/packaging/torchtext/build.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -ex
 
-git submodule update --init --recursive
 python setup.py install --single-version-externally-managed --record=record.txt

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import distutils.command.clean
 import io
 import os
+import sys
 import shutil
 import subprocess
 from pathlib import Path
@@ -44,6 +45,18 @@ def _export_version(version, sha):
         fileobj.write("git_version = {}\n".format(repr(sha)))
 
 
+def _init_submodule():
+    print(" --- Initializing submodules")
+    try:
+        subprocess.check_call(["git", "submodule", "init"])
+        subprocess.check_call(["git", "submodule", "update"])
+    except Exception:
+        print(" --- Submodule initalization failed")
+        print("Please run:\n\tgit submodule update --init --recursive")
+        sys.exit(1)
+    print(" --- Initialized submodule")
+
+
 VERSION, SHA = _get_version()
 _export_version(VERSION, SHA)
 
@@ -76,6 +89,7 @@ class clean(distutils.command.clean.clean):
                 shutil.rmtree(str(path), ignore_errors=True)
 
 
+_init_submodule()
 setup_info = dict(
     # Metadata
     name="torchtext",

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 import distutils.command.clean
 import io
 import os
-import sys
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 from build_tools import setup_helpers


### PR DESCRIPTION
This commit adds `git` submodule initialization commands at the beginning
of setup, so that third party modules become available automatically.

This makes it possible to install torchtext with a command like
`pip install --no-use-pep517 git+https://github.com/pytorch/text.git`
[example](https://colab.research.google.com/drive/11K2RB540Td0PDniIMjm9bGnXaAH_Z8oY#scrollTo=Vme1nc8DbT7_)

See also:
- https://github.com/pytorch/text/pull/1154
- https://github.com/pytorch/audio/pull/1966

closes #1154