### PR TITLE
[BUG FIX] Fixing incorrect inputs to add_eos and_bos operators in torcharrow operator benchmark

### DIFF
--- a/benchmark/benchmark_torcharrow_ops.py
+++ b/benchmark/benchmark_torcharrow_ops.py
@@ -38,8 +38,8 @@ def run_torchtext_ops():
         token_ids = vocab(tokenized_text)
 
     with Timer("Running torchtext's add tokens operation (string)"):
-        add_bos_str(token_ids)
-        add_eos_str(token_ids)
+        add_bos_str(tokenized_text)
+        add_eos_str(tokenized_text)
 
     with Timer("Running torchtext's add tokens operation (int)"):
         add_bos_int(token_ids)


### PR DESCRIPTION
## Description
- Followup to https://github.com/pytorch/text/pull/1807 to fix incorrect inputs to `add_eos` and `add_bos` operator