### PR TITLE
Update CircleCI Xcode image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - designate_upload_channel
@@ -232,7 +232,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - designate_upload_channel
@@ -440,7 +440,7 @@ jobs:
   unittest_macos:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -206,7 +206,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - designate_upload_channel
@@ -232,7 +232,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - designate_upload_channel
@@ -440,7 +440,7 @@ jobs:
   unittest_macos:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
CircleCI is removing Xcode 12.4.0 image on August, and there was a planned
burnout on July 6th. [[detail](https://discuss.circleci.com/t/xcode-image-deprecation/44294?mkt_tok=NDg1LVpNSC02MjYAAAGFbbxbX7nSPCzN0MCKN078pw0VLJ-TMdICr8_gouRNYBM8C55RL8NDKLXA_9CQGPqnhJE5lsSFdetLRF-nH7iBLzoPGBfYpf2vuJ-XkW_C4__4)]

https://app.circleci.com/pipelines/github/pytorch/text/5996/workflows/0bfa021d-b532-4385-b406-c56373c8e9ce/jobs/204435

This commit updates Xcode image to 12.5