### PR TITLE
Remove sphinx_rtd_theme from requirements.txt

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -13,8 +13,6 @@ dependencies:
       - pytest-pythonpath
       - sacremoses
       - spacy
-      - sphinx
-      - sphinx-rtd-theme
       - tqdm
       - expecttest
       - https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.0.0/de_core_news_sm-3.0.0.tar.gz#egg=de_core_news_sm==3.0.0

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -14,8 +14,6 @@ dependencies:
       - pytest-pythonpath
       - sacremoses
       - spacy
-      - sphinx
-      - sphinx-rtd-theme
       - tqdm
       - certifi
       - future

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ git+https://github.com/jekbradbury/revtok.git
 
 # Documentation
 Sphinx
-sphinx_rtd_theme
 
 # Required for tests only:
 


### PR DESCRIPTION
## Description
- `sphinx_rtd_theme` is a legacy dependency when torchtext was hosted on Read the Docs ([link](https://torchtext.readthedocs.io/en/latest/))
- Building this dep is causing our unit tests to error out (i.e. [failed CI job](https://app.circleci.com/pipelines/github/pytorch/text/6170/workflows/025cf88a-d431-477f-b921-1663cdc30d20/jobs/211026?invite=true#step-105-601))