### PR TITLE
Remove `future` dependency from Windows

### DIFF
--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -16,7 +16,6 @@ dependencies:
       - spacy
       - tqdm
       - certifi
-      - future
       - expecttest
       - https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.0.0/de_core_news_sm-3.0.0.tar.gz#egg=de_core_news_sm==3.0.0
       - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm==3.0.0


### PR DESCRIPTION
## Description
- Building this dep is causing our unit tests to error out (i.e. [failed CI job](https://app.circleci.com/pipelines/github/pytorch/text/6170/workflows/025cf88a-d431-477f-b921-1663cdc30d20/jobs/211022))