### PR TITLE
Modify get_local_asset_path to take overwrite option and use it in BERTTokenizer

### DIFF
--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -572,7 +572,9 @@ class BERTTokenizer(Module):
         self, vocab_path: str, do_lower_case: bool = True, strip_accents: Optional[bool] = None, return_tokens=False
     ) -> None:
         super().__init__()
-        self.bert_model = BERTEncoderPyBind(get_asset_local_path(vocab_path), do_lower_case, strip_accents)
+        self.bert_model = BERTEncoderPyBind(
+            get_asset_local_path(vocab_path, overwite=True), do_lower_case, strip_accents
+        )
         self._return_tokens = return_tokens
         self._vocab_path = vocab_path
         self._do_lower_case = do_lower_case

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -209,10 +209,11 @@ def _log_class_usage(klass):
     torch._C._log_api_usage_once(identifier)
 
 
-def get_asset_local_path(asset_path: str) -> str:
+def get_asset_local_path(asset_path: str, overwite=False) -> str:
     """Get local path for assets. Download if path does not exost locally
     Args:
         asset_path: Local path to asset or remote URL
+        overwrite: Indicate whether to overwrite the file when downloading from URL (default: False)
     Returns:
         bool: local path of the asset after downloading or reading from cache
     Examples:
@@ -225,5 +226,5 @@ def get_asset_local_path(asset_path: str) -> str:
     if os.path.exists(asset_path):
         local_path = asset_path
     else:
-        local_path = download_from_url(url=asset_path, root=_CACHE_DIR)
+        local_path = download_from_url(url=asset_path, root=_CACHE_DIR, overwrite=overwite)
     return local_path


### PR DESCRIPTION
Summary: 
get_local_asset_path does not overwrite local file if it already exists. In certain scenarios, this may be needed. As an example, all the [vocab files](https://github.com/huggingface/transformers/blob/8581a798c0a48fca07b29ce2ca2ef55adcae8c7e/src/transformers/models/bert/tokenization_bert.py#L31) of BERTTokenizer are named as vocab.txt. When instantiating BERTTokenizer with different vocab file, this causes issue since it won't get overwritten. Hence we provide explicit overwrite argument in get_local_asset_path which the client code can use according to it's needs.