### PR TITLE
fix OBO error while reading vocab files with empty lines in BERT tokenizer

### DIFF
--- a/torchtext/csrc/bert_tokenizer.h
+++ b/torchtext/csrc/bert_tokenizer.h
@@ -6,6 +6,8 @@
 namespace torchtext {
 
 typedef std::basic_string<uint32_t> UString;
+typedef ska_ordered::order_preserving_flat_hash_map<std::string, int64_t>
+    IndexDict;
 
 // stores (do_lower_case, strip_accents, list of tokens in vocabulary)
 typedef std::tuple<bool, c10::optional<bool>, std::vector<std::string>>


### PR DESCRIPTION
fixes #1840 