### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET=10.9 for binary job (#1835)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ binary_common: &binary_common
     BUILD_VERSION: << parameters.build_version >>
     PYTORCH_VERSION: << parameters.pytorch_version >>
     CU_VERSION: cpu
+    MACOSX_DEPLOYMENT_TARGET: 10.9
 
 smoke_test_common: &smoke_test_common
   <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -53,6 +53,7 @@ binary_common: &binary_common
     BUILD_VERSION: << parameters.build_version >>
     PYTORCH_VERSION: << parameters.pytorch_version >>
     CU_VERSION: cpu
+    MACOSX_DEPLOYMENT_TARGET: 10.9
 
 smoke_test_common: &smoke_test_common
   <<: *binary_common

--- a/packaging/torchtext/meta.yaml
+++ b/packaging/torchtext/meta.yaml
@@ -29,6 +29,7 @@ build:
   string: py{{py}}
   script_env:
     - BUILD_VERSION
+    - MACOSX_DEPLOYMENT_TARGET
 
 test:
   imports:


### PR DESCRIPTION
Recent CircleCI migration https://github.com/pytorch/text/pull/1818
silently bumped the minimum supported macOS version to 11.

PyTorch still supports 10.9 and the ecosystem still uses 10.9.
Issue: https://github.com/pytorch/text/issues/1834

This commit sets MACOSX_DEPLOYMENT_TARGET=10.9, so that binary
distribution are compatible with macOS=10.9.