### PR TITLE
Added missing `-> None:` type hint to applicable tests

### DIFF
--- a/test/common/torchtext_test_case.py
+++ b/test/common/torchtext_test_case.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class TorchtextTestCase(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         logging.basicConfig(format=("%(asctime)s - %(levelname)s - " "%(name)s - %(message)s"), level=logging.INFO)
         # Directory where everything temporary and test-related is written
         self.project_root = os.path.abspath(
@@ -28,7 +28,7 @@ class TorchtextTestCase(TestCase):
         self.test_dataset_splitting_path = os.path.join(self.test_dir, "test_dataset_split")
         self.test_nested_key_json_dataset_path = os.path.join(self.test_dir, "test_nested_key_json")
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         try:
             shutil.rmtree(self.test_dir)
         except:
@@ -68,7 +68,7 @@ class TorchtextTestCase(TestCase):
                 else:
                     raise ValueError("Invalid format {}".format(data_format))
 
-    def write_test_nested_key_json_dataset(self):
+    def write_test_nested_key_json_dataset(self) -> None:
         """
         Used only to test nested key parsing of Example.fromJSON()
         """
@@ -91,7 +91,7 @@ class TorchtextTestCase(TestCase):
             for example in dict_dataset:
                 test_nested_key_json_dataset_file.write(json.dumps(example) + "\n")
 
-    def write_test_numerical_features_dataset(self):
+    def write_test_numerical_features_dataset(self) -> None:
         with open(self.test_numerical_features_dataset_path, "w") as test_numerical_features_dataset_file:
             test_numerical_features_dataset_file.write("0.1\t1\tteststring1\n")
             test_numerical_features_dataset_file.write("0.5\t12\tteststring2\n")

--- a/test/csrc/test_gpt2_bpe_tokenizer.py
+++ b/test/csrc/test_gpt2_bpe_tokenizer.py
@@ -6,7 +6,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestGPT2BPETokenizer(TorchtextTestCase):
-    def test_gpt2_bpe_pre_tokenizer(self):
+    def test_gpt2_bpe_pre_tokenizer(self) -> None:
         # Regex pattern for GPT-2 BPE which includes the negative lookahead
         # Reference: https://github.com/pytorch/fairseq/blob/main/fairseq/data/encoders/gpt2_bpe_utils.py#L69
         gpt2_bpe_pattern = re.compile(r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""")

--- a/test/data/test_functional.py
+++ b/test/data/test_functional.py
@@ -19,7 +19,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestFunctional(TorchtextTestCase):
-    def test_generate_sp_model(self):
+    def test_generate_sp_model(self) -> None:
         """
         Test the function to train a sentencepiece tokenizer.
         """
@@ -42,7 +42,7 @@ class TestFunctional(TorchtextTestCase):
             sp_model = load_sp_model(model_file)
             self.assertEqual(sp_model.GetPieceSize(), 23456)
 
-    def test_sentencepiece_numericalizer(self):
+    def test_sentencepiece_numericalizer(self) -> None:
         test_sample = "SentencePiece is an unsupervised text tokenizer and detokenizer"
         model_path = get_asset_path("spm_example.model")
         sp_model = load_sp_model(model_path)
@@ -74,7 +74,7 @@ class TestFunctional(TorchtextTestCase):
 
         self.assertEqual(list(spm_generator([test_sample]))[0], ref_results)
 
-    def test_sentencepiece_tokenizer(self):
+    def test_sentencepiece_tokenizer(self) -> None:
         test_sample = "SentencePiece is an unsupervised text tokenizer and detokenizer"
         model_path = get_asset_path("spm_example.model")
         sp_model = load_sp_model(open(model_path, "rb"))
@@ -106,19 +106,19 @@ class TestFunctional(TorchtextTestCase):
 
         self.assertEqual(list(spm_generator([test_sample]))[0], ref_results)
 
-    def test_sentencepiece_unsupported_input_type(self):
+    def test_sentencepiece_unsupported_input_type(self) -> None:
         with self.assertRaisesRegex(
             TypeError, "Unsupported type for spm argument: dict. " "Supported types are: str, io.BufferedReader"
         ):
             load_sp_model(dict())
 
-    def test_custom_replace(self):
+    def test_custom_replace(self) -> None:
         custom_replace_transform = custom_replace([(r"S", "s"), (r"\s+", " ")])
         test_sample = ["test     cuStom   replace", "with   uSer   instruction"]
         ref_results = ["test custom replace", "with user instruction"]
         self.assertEqual(list(custom_replace_transform(test_sample)), ref_results)
 
-    def test_simple_space_split(self):
+    def test_simple_space_split(self) -> None:
         test_sample = ["test simple space split function"]
         ref_results = ["test", "simple", "space", "split", "function"]
         self.assertEqual(list(simple_space_split(test_sample))[0], ref_results)
@@ -143,14 +143,14 @@ class ScriptableSP(torch.jit.ScriptModule):
 
 
 class TestScriptableSP(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         model_path = get_asset_path("spm_example.model")
         with tempfile.TemporaryDirectory() as dir_name:
             jit_model_path = os.path.join(dir_name, "spm_example.model")
             torch.jit.script(ScriptableSP(model_path)).save(jit_model_path)
             self.model = torch.jit.load(jit_model_path)
 
-    def test_encode(self):
+    def test_encode(self) -> None:
         input = "SentencePiece is an unsupervised text tokenizer and detokenizer"
         expected = [
             "▁Sent",
@@ -177,7 +177,7 @@ class TestScriptableSP(unittest.TestCase):
         output = self.model.encode(input)
         self.assertEqual(expected, output)
 
-    def test_encode_as_ids(self):
+    def test_encode_as_ids(self) -> None:
         input = "SentencePiece is an unsupervised text tokenizer and detokenizer"
         expected = [
             15340,
@@ -204,7 +204,7 @@ class TestScriptableSP(unittest.TestCase):
         output = self.model.encode_as_ids(input)
         self.assertEqual(expected, output)
 
-    def test_encode_as_pieces(self):
+    def test_encode_as_pieces(self) -> None:
         input = "SentencePiece is an unsupervised text tokenizer and detokenizer"
         expected = [
             "\u2581Sent",

--- a/test/data/test_jit.py
+++ b/test/data/test_jit.py
@@ -6,7 +6,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestJIT(TorchtextTestCase):
-    def test_torchscript_multiheadattention(self):
+    def test_torchscript_multiheadattention(self) -> None:
         embed_dim, nhead, tgt_len, src_len, bsz = 10, 5, 6, 10, 64
         # Build torchtext MultiheadAttention models
         in_proj_container = InProjContainer(

--- a/test/data/test_metrics.py
+++ b/test/data/test_metrics.py
@@ -4,7 +4,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestUtils(TorchtextTestCase):
-    def test_bleu_score(self):
+    def test_bleu_score(self) -> None:
         # Full match
         candidate = [["My", "full", "pytorch", "test"]]
         refs = [[["My", "full", "pytorch", "test"], ["Completely", "Different"]]]

--- a/test/data/test_modules.py
+++ b/test/data/test_modules.py
@@ -9,7 +9,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestModels(TorchtextTestCase):
-    def test_multiheadattention(self):
+    def test_multiheadattention(self) -> None:
         embed_dim, nhead, tgt_len, src_len, bsz = 10, 5, 6, 10, 64
         # Build torchtext MultiheadAttention module
         in_proj = InProjContainer(
@@ -64,7 +64,7 @@ class TestModels(TorchtextTestCase):
         attn_weights = attn_weights.view(bsz, nhead, tgt_len, src_len + 1).sum(dim=1) / nhead
         self.assertEqual(attn_weights, torch_mha_weights)
 
-    def test_mha_batch_first(self):
+    def test_mha_batch_first(self) -> None:
         embed_dim, nhead, tgt_len, src_len, bsz = 10, 5, 6, 10, 64
         # Build torchtext MultiheadAttention module
         in_proj = InProjContainer(
@@ -121,7 +121,7 @@ class TestModels(TorchtextTestCase):
         attn_weights_1st = attn_weights_1st.view(bsz, nhead, tgt_len, src_len + 1).sum(dim=1) / nhead
         self.assertEqual(attn_weights_1st, torch_mha_weights)
 
-    def test_broadcast_scaled_dot_product(self):
+    def test_broadcast_scaled_dot_product(self) -> None:
         embed_dim, nhead, tgt_len, src_len, bsz = 10, 5, 6, 10, 64
         SDP = ScaledDotProduct()
         query = torch.rand((tgt_len, 1, embed_dim))
@@ -251,7 +251,7 @@ class TestModels(TorchtextTestCase):
                 attn_mask=attn_mask.expand(*attn_mask_size) if attn_mask_size else attn_mask,
             )
 
-    def test_sdp_batch_first(self):
+    def test_sdp_batch_first(self) -> None:
         embed_dim, nhead, tgt_len, src_len, bsz = 10, 5, 6, 10, 64
         SDP = ScaledDotProduct(batch_first=True)
         query = torch.rand((1, tgt_len, embed_dim))
@@ -267,7 +267,7 @@ class TestModels(TorchtextTestCase):
 
         self.assertEqual(list(sdp_attn_output.size()), [bsz * nhead, tgt_len, embed_dim])
 
-    def test_generate_square_subsequent_mask(self):
+    def test_generate_square_subsequent_mask(self) -> None:
         configs = [(3, 2), (1, 3), (1, 1), (3, 1), (2, 3)]
         for nbatch, sz in configs:
             out = generate_square_subsequent_mask(nbatch, sz)

--- a/test/data/test_utils.py
+++ b/test/data/test_utils.py
@@ -6,12 +6,12 @@ from ..common.torchtext_test_case import TorchtextTestCase
 class TestUtils(TorchtextTestCase):
     TEST_STR = "A string, particularly one with slightly complex punctuation."
 
-    def test_get_tokenizer_split(self):
+    def test_get_tokenizer_split(self) -> None:
         # Test the default case with str.split
         assert get_tokenizer(str.split) == str.split
         assert get_tokenizer(str.split)(self.TEST_STR) == str.split(self.TEST_STR)
 
-    def test_get_tokenizer_toktokt(self):
+    def test_get_tokenizer_toktokt(self) -> None:
         # Test Toktok option. Test strings taken from NLTK doctests.
         # Note that internally, MosesTokenizer converts to unicode if applicable
         toktok_tokenizer = get_tokenizer("toktok")

--- a/test/datasets/test_enwik9.py
+++ b/test/datasets/test_enwik9.py
@@ -56,7 +56,7 @@ class TestEnWik9(TempDirMixin, TorchtextTestCase):
         cls.patcher.stop()
         super().tearDownClass()
 
-    def test_enwik9(self):
+    def test_enwik9(self) -> None:
         dataset = EnWik9(root=self.root_dir)
 
         samples = list(dataset)

--- a/test/datasets/test_qqp.py
+++ b/test/datasets/test_qqp.py
@@ -50,7 +50,7 @@ class TestQQP(TempDirMixin, TorchtextTestCase):
         cls.patcher.stop()
         super().tearDownClass()
 
-    def test_qqp(self):
+    def test_qqp(self) -> None:
         dataset = QQP(root=self.root_dir)
 
         samples = list(dataset)

--- a/test/models/test_models.py
+++ b/test/models/test_models.py
@@ -9,7 +9,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 
 
 class TestModels(TorchtextTestCase):
-    def test_roberta_bundler_build_model(self):
+    def test_roberta_bundler_build_model(self) -> None:
         from torchtext.models import RobertaClassificationHead, RobertaEncoderConf, RobertaModel, RobertaBundle
 
         dummy_encoder_conf = RobertaEncoderConf(
@@ -53,7 +53,7 @@ class TestModels(TorchtextTestCase):
         )
         self.assertEqual(model.state_dict(), dummy_classifier.state_dict())
 
-    def test_roberta_bundler_train(self):
+    def test_roberta_bundler_train(self) -> None:
         from torchtext.models import RobertaClassificationHead, RobertaEncoderConf, RobertaModel, RobertaBundle
 
         dummy_encoder_conf = RobertaEncoderConf(
@@ -119,7 +119,7 @@ class TestModels(TorchtextTestCase):
             "The encoder is not loaded with pre-trained weights. Setting freeze_encoder to True will hinder encoder from learning appropriate weights."
         )
 
-    def test_roberta_bundler_raise_checkpoint(self):
+    def test_roberta_bundler_raise_checkpoint(self) -> None:
         from torchtext.models import RobertaClassificationHead, RobertaEncoderConf, RobertaBundle
 
         with self.assertRaises(TypeError):
@@ -134,7 +134,7 @@ class TestModels(TorchtextTestCase):
                 checkpoint=1,
             )
 
-    def test_roberta_bundler_encode_conf_property(self):
+    def test_roberta_bundler_encode_conf_property(self) -> None:
         from torchtext.models import RobertaEncoderConf, RobertaBundle
 
         dummy_encoder_conf = RobertaEncoderConf(

--- a/test/prototype/integration_tests/test_models.py
+++ b/test/prototype/integration_tests/test_models.py
@@ -27,17 +27,17 @@ class TestT5(TorchtextTestCase):
         expected = torch.load(expected_asset_path)
         torch.testing.assert_close(actual, expected, atol=1e-04, rtol=2.5e-06)
 
-    def test_t5_base_encoder_model(self):
+    def test_t5_base_encoder_model(self) -> None:
         expected_asset_name = "t5.base.encoder.output.pt"
         test_text = ["Hello world", "Attention rocks!"]
         self._t5_model(t5_model=T5_BASE_ENCODER, expected_asset_name=expected_asset_name, test_text=test_text)
 
-    def test_t5_base_model(self):
+    def test_t5_base_model(self) -> None:
         expected_asset_name = "t5.base.output.pt"
         test_text = ["Hello world", "Attention rocks!"]
         self._t5_model(t5_model=T5_BASE, expected_asset_name=expected_asset_name, test_text=test_text)
 
-    def test_t5_base_generation_model(self):
+    def test_t5_base_generation_model(self) -> None:
         expected_asset_name = "t5.base.generation.output.pt"
         test_text = ["Hello world", "Attention rocks!"]
         self._t5_model(t5_model=T5_BASE_GENERATION, expected_asset_name=expected_asset_name, test_text=test_text)

--- a/test/prototype/models/test_models.py
+++ b/test/prototype/models/test_models.py
@@ -7,7 +7,7 @@ from torch.nn import functional as F
 
 
 class TestModels(TorchtextTestCase):
-    def test_t5_bundler_build_model(self):
+    def test_t5_bundler_build_model(self) -> None:
         from torchtext.prototype.models import T5Conf, T5Model, T5Bundle
 
         # case: user provides encoder checkpoint state dict
@@ -76,7 +76,7 @@ class TestModels(TorchtextTestCase):
             "The model is not loaded with pre-trained weights. Setting freeze_model to True will hinder model from learning appropriate weights."
         )
 
-    def test_t5_bundler_raise_checkpoint(self):
+    def test_t5_bundler_raise_checkpoint(self) -> None:
         from torchtext.prototype.models import T5Conf, T5Bundle
 
         # encoder-only
@@ -131,7 +131,7 @@ class TestModels(TorchtextTestCase):
                 checkpoint=1,
             )
 
-    def test_t5_bundler_conf_property(self):
+    def test_t5_bundler_conf_property(self) -> None:
         from torchtext.prototype.models import T5Conf, T5Bundle
 
         dummy_t5_conf = T5Conf(
@@ -146,7 +146,7 @@ class TestModels(TorchtextTestCase):
         t5_bundle = T5Bundle(dummy_t5_conf)
         self.assertTrue(isinstance(t5_bundle.config, T5Conf))
 
-    def test_t5_bundler_train(self):
+    def test_t5_bundler_train(self) -> None:
         from torch.optim import SGD
         from torchtext.prototype.models import T5Conf, T5Model, T5Bundle
 

--- a/test/prototype/models/test_transforms.py
+++ b/test/prototype/models/test_transforms.py
@@ -36,10 +36,10 @@ class TestTransforms(TorchtextTestCase):
         expected = ["Hello World!, how are you?"]
         self.assertEqual(actual, expected)
 
-    def test_t5tokenizer(self):
+    def test_t5tokenizer(self) -> None:
         """test tokenization on string input (encode) and translation from token ids to strings (decode)"""
         self._t5tokenizer(test_scripting=False)
 
-    def test_t5tokenizer_jit(self):
+    def test_t5tokenizer_jit(self) -> None:
         """test tokenization on string input (encode) and translation from token ids to strings (decode) with scripting"""
         self._t5tokenizer(test_scripting=True)

--- a/test/prototype/test_functional.py
+++ b/test/prototype/test_functional.py
@@ -12,7 +12,7 @@ from ..common.torchtext_test_case import TorchtextTestCase
 class TestFunctional(TorchtextTestCase):
     # TODO(Nayef211): remove decorator once https://github.com/pytorch/pytorch/issues/38207 is closed
     @unittest.skipIf(platform.system() == "Windows", "Test is known to fail on Windows.")
-    def test_BasicEnglishNormalize(self):
+    def test_BasicEnglishNormalize(self) -> None:
         test_sample = "'\".<br />,()!?;:   Basic English Normalization for a Line of Text   '\".<br />,()!?;:"
         ref_results = [
             "'",
@@ -57,7 +57,7 @@ class TestFunctional(TorchtextTestCase):
         self.assertEqual(eager_tokens, ref_results)
         self.assertEqual(experimental_eager_tokens, ref_results)
 
-    def test_basicEnglishNormalize_load_and_save(self):
+    def test_basicEnglishNormalize_load_and_save(self) -> None:
         test_sample = "'\".<br />,()!?;:   Basic English Normalization for a Line of Text   '\".<br />,()!?;:"
         ref_results = [
             "'",

--- a/test/prototype/test_transforms.py
+++ b/test/prototype/test_transforms.py
@@ -18,7 +18,7 @@ from ..common.parameterized_utils import nested_params
 
 
 class TestTransforms(TorchtextTestCase):
-    def test_sentencepiece_processor(self):
+    def test_sentencepiece_processor(self) -> None:
         model_path = get_asset_path("spm_example.model")
         spm_transform = sentencepiece_processor(model_path)
         jit_spm_transform = torch.jit.script(spm_transform)
@@ -50,7 +50,7 @@ class TestTransforms(TorchtextTestCase):
         self.assertEqual(spm_transform.decode(ref_results), test_sample)
         self.assertEqual(jit_spm_transform.decode(ref_results), test_sample)
 
-    def test_sentencepiece_tokenizer(self):
+    def test_sentencepiece_tokenizer(self) -> None:
         model_path = get_asset_path("spm_example.model")
         spm_tokenizer = sentencepiece_tokenizer(model_path)
         jit_spm_tokenizer = torch.jit.script(spm_tokenizer)
@@ -83,7 +83,7 @@ class TestTransforms(TorchtextTestCase):
         self.assertEqual(jit_spm_tokenizer(test_sample), ref_results)
         self.assertEqual(jit_spm_tokenizer.decode(ref_results), test_sample)
 
-    def test_vector_transform(self):
+    def test_vector_transform(self) -> None:
         asset_name = "wiki.en.vec"
         asset_path = get_asset_path(asset_name)
 
@@ -99,7 +99,7 @@ class TestTransforms(TorchtextTestCase):
             self.assertEqual(vector_transform(["the", "world"])[:, 0:3], expected_fasttext_simple_en)
             self.assertEqual(jit_vector_transform(["the", "world"])[:, 0:3], expected_fasttext_simple_en)
 
-    def test_sentencepiece_load_and_save(self):
+    def test_sentencepiece_load_and_save(self) -> None:
         model_path = get_asset_path("spm_example.model")
         input = "SentencePiece is an unsupervised text tokenizer and detokenizer"
         expected = [
@@ -241,7 +241,7 @@ class TestMaskTransform(TorchtextTestCase):
                 exp_tokens = torch.tensor([[6, 5, 5, 5, 5], [6, 5, 5, 4, 4]])
                 self.assertEqual(exp_tokens, masked_tokens)
 
-    def test_mask_transform_mask_bos(self):
+    def test_mask_transform_mask_bos(self) -> None:
         # MaskTransform has boolean parameter mask_bos to indicate whether or not [BOS] tokens
         # should be eligible for replacement. The above tests of MaskTransform are under default value
         # mask_bos = False. Here we test the case where mask_bos = True

--- a/test/prototype/test_vectors.py
+++ b/test/prototype/test_vectors.py
@@ -9,12 +9,12 @@ from torchtext.prototype.vectors import build_vectors
 
 
 class TestVectors(TorchtextTestCase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         torch._C._jit_clear_class_registry()
         torch.jit._recursive.concrete_type_store = torch.jit._recursive.ConcreteTypeStore()
 
-    def test_empty_vectors(self):
+    def test_empty_vectors(self) -> None:
         tokens = []
         vecs = torch.empty(0, dtype=torch.float)
         unk_tensor = torch.tensor([0], dtype=torch.float)
@@ -22,7 +22,7 @@ class TestVectors(TorchtextTestCase):
         vectors_obj = build_vectors(tokens, vecs, unk_tensor)
         self.assertEqual(vectors_obj["not_in_it"], unk_tensor)
 
-    def test_empty_unk(self):
+    def test_empty_unk(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         expected_unk_tensor = torch.tensor([0, 0], dtype=torch.float)
 
@@ -32,7 +32,7 @@ class TestVectors(TorchtextTestCase):
 
         self.assertEqual(vectors_obj["not_in_it"], expected_unk_tensor)
 
-    def test_vectors_basic(self):
+    def test_vectors_basic(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1], dtype=torch.float)
 
@@ -45,7 +45,7 @@ class TestVectors(TorchtextTestCase):
         self.assertEqual(vectors_obj["b"], tensorB)
         self.assertEqual(vectors_obj["not_in_it"], unk_tensor)
 
-    def test_vectors_jit(self):
+    def test_vectors_jit(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1], dtype=torch.float)
 
@@ -64,7 +64,7 @@ class TestVectors(TorchtextTestCase):
         self.assertEqual(vectors_obj["b"], jit_vectors_obj["b"])
         self.assertEqual(vectors_obj["not_in_it"], jit_vectors_obj["not_in_it"])
 
-    def test_vectors_forward(self):
+    def test_vectors_forward(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1], dtype=torch.float)
 
@@ -82,7 +82,7 @@ class TestVectors(TorchtextTestCase):
         self.assertEqual(expected_vectors, vectors_by_tokens)
         self.assertEqual(expected_vectors, jit_vectors_by_tokens)
 
-    def test_vectors_lookup_vectors(self):
+    def test_vectors_lookup_vectors(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1], dtype=torch.float)
 
@@ -97,7 +97,7 @@ class TestVectors(TorchtextTestCase):
 
         self.assertEqual(expected_vectors, vectors_by_tokens)
 
-    def test_vectors_add_item(self):
+    def test_vectors_add_item(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         unk_tensor = torch.tensor([0, 0], dtype=torch.float)
 
@@ -112,7 +112,7 @@ class TestVectors(TorchtextTestCase):
         self.assertEqual(vectors_obj["b"], tensorB)
         self.assertEqual(vectors_obj["not_in_it"], unk_tensor)
 
-    def test_vectors_update(self):
+    def test_vectors_update(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1], dtype=torch.float)
         tensorC = torch.tensor([1, 1], dtype=torch.float)
@@ -129,7 +129,7 @@ class TestVectors(TorchtextTestCase):
         self.assertEqual(vectors_obj["b"], tensorC)
         self.assertEqual(vectors_obj["not_in_it"], expected_unk_tensor)
 
-    def test_vectors_load_and_save(self):
+    def test_vectors_load_and_save(self) -> None:
         tensorA = torch.tensor([1, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1], dtype=torch.float)
         expected_unk_tensor = torch.tensor([0, 0], dtype=torch.float)
@@ -161,7 +161,7 @@ class TestVectors(TorchtextTestCase):
     # we separate out these errors because Windows runs into seg faults when propagating
     # exceptions from C++ using pybind11
     @unittest.skipIf(platform.system() == "Windows", "Test is known to fail on Windows.")
-    def test_errors_vectors_cpp(self):
+    def test_errors_vectors_cpp(self) -> None:
         tensorA = torch.tensor([1, 0, 0], dtype=torch.float)
         tensorB = torch.tensor([0, 1, 0], dtype=torch.float)
         tensorC = torch.tensor([0, 0, 1], dtype=torch.float)

--- a/test/prototype/test_with_asset.py
+++ b/test/prototype/test_with_asset.py
@@ -28,7 +28,7 @@ def _batch_func(spm_processor, data):
 
 
 class TestTransformsWithAsset(TorchtextTestCase):
-    def test_vocab_transform(self):
+    def test_vocab_transform(self) -> None:
         asset_name = "vocab_test2.txt"
         asset_path = get_asset_path(asset_name)
         vocab_transform = VocabTransform(load_vocab_from_file(asset_path))
@@ -36,7 +36,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
         jit_vocab_transform = torch.jit.script(vocab_transform)
         self.assertEqual(jit_vocab_transform(["of", "that", "new", "that"]), [7, 18, 24, 18])
 
-    def test_errors_vectors_python(self):
+    def test_errors_vectors_python(self) -> None:
         tokens = []
         vecs = torch.empty(0, dtype=torch.float)
 
@@ -68,7 +68,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
                 # incorrect dim
                 GloVe(name="6B", dim=500, root=dir_name, validate_file=False)
 
-    def test_glove(self):
+    def test_glove(self) -> None:
         # copy the asset file into the expected download location
         # note that this is just a zip file with the first 100 entries of the GloVe 840B dataset
         asset_name = "glove.840B.300d.zip"
@@ -90,7 +90,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
                 self.assertEqual(vectors_obj[word][:3], expected_glove[word])
                 self.assertEqual(jit_vectors_obj[word][:3], expected_glove[word])
 
-    def test_glove_different_dims(self):
+    def test_glove_different_dims(self) -> None:
         # copy the asset file into the expected download location
         # note that this is just a zip file with 1 line txt files used to test that the
         # correct files are being loaded
@@ -126,7 +126,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
                 for word in expected_glove.keys():
                     self.assertEqual(vectors_obj[word][:3], expected_glove[word])
 
-    def test_vocab_from_file(self):
+    def test_vocab_from_file(self) -> None:
         asset_name = "vocab_test.txt"
         asset_path = get_asset_path(asset_name)
         v = load_vocab_from_file(asset_path)
@@ -135,7 +135,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-    def test_vocab_from_raw_text_file(self):
+    def test_vocab_from_raw_text_file(self) -> None:
         asset_name = "vocab_raw_text_test.txt"
         asset_path = get_asset_path(asset_name)
 
@@ -196,7 +196,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
         self.assertEqual(v2.get_itos(), expected_itos)
         self.assertEqual(dict(v2.get_stoi()), expected_stoi)
 
-    def test_builtin_pretrained_sentencepiece_processor(self):
+    def test_builtin_pretrained_sentencepiece_processor(self) -> None:
         sp_model_path = download_from_url(PRETRAINED_SP_MODEL["text_unigram_25000"])
         spm_tokenizer = sentencepiece_tokenizer(sp_model_path)
         _path = os.path.join(self.project_root, ".data", "text_unigram_25000.model")
@@ -215,7 +215,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
 
     # we separate out these errors because Windows runs into seg faults when propagating
     # exceptions from C++ using pybind11
-    def test_sentencepiece_with_dataloader(self):
+    def test_sentencepiece_with_dataloader(self) -> None:
         example_strings = ["the pretrained spm model names"] * 64
         ref_results = torch.tensor([[13, 1465, 12824, 304, 24935, 5771, 3776]] * 16, dtype=torch.long)
 
@@ -227,7 +227,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
         for item in dataloader:
             self.assertEqual(item, ref_results)
 
-    def test_vectors_from_file(self):
+    def test_vectors_from_file(self) -> None:
         asset_name = "vectors_test.csv"
         asset_path = get_asset_path(asset_name)
         vectors_obj = load_vectors_from_file_path(asset_path)
@@ -240,7 +240,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
         self.assertEqual(vectors_obj["b"], expected_tensorB)
         self.assertEqual(vectors_obj["not_in_it"], expected_unk_tensor)
 
-    def test_fast_text(self):
+    def test_fast_text(self) -> None:
         # copy the asset file into the expected download location
         # note that this is just a file with the first 100 entries of the FastText english dataset
         asset_name = "wiki.en.vec"

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -11,7 +11,7 @@ from .common.torchtext_test_case import TorchtextTestCase
 class TestDataUtils(TorchtextTestCase):
     TEST_STR = "A string, particularly one with slightly complex punctuation."
 
-    def test_get_tokenizer_spacy(self):
+    def test_get_tokenizer_spacy(self) -> None:
         # Test SpaCy option, and verify it properly handles punctuation.
         assert torchtext.data.get_tokenizer("spacy", language="en_core_web_sm")(str(self.TEST_STR)) == [
             "A",
@@ -26,7 +26,7 @@ class TestDataUtils(TorchtextTestCase):
             ".",
         ]
 
-    def test_get_tokenizer_moses(self):
+    def test_get_tokenizer_moses(self) -> None:
         # Test Moses option.
         # Note that internally, MosesTokenizer converts to unicode if applicable
         moses_tokenizer = torchtext.data.get_tokenizer("moses")
@@ -48,7 +48,7 @@ class TestDataUtils(TorchtextTestCase):
 
 
 class TestVocab(TorchtextTestCase):
-    def test_vectors_get_vecs(self):
+    def test_vectors_get_vecs(self) -> None:
         vec = torchtext.vocab.GloVe(name="twitter.27B", dim="25")
         self.assertEqual(vec.vectors.shape[0], len(vec))
 
@@ -64,7 +64,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(token_one_vec.shape[0], vec.dim)
         self.assertEqual(vec[tokens[0].lower()], token_one_vec)
 
-    def test_download_charngram_vectors(self):
+    def test_download_charngram_vectors(self) -> None:
         # Build a vocab and get vectors twice to test caching.
         for _ in range(2):
             vectors = torchtext.vocab.CharNGram()
@@ -83,7 +83,7 @@ class TestVocab(TorchtextTestCase):
             expected_oov_token_charngram = [-0.1070, -0.2240, -0.3043, -0.1092, 0.0953]
             self.assertEqual(vectors["OOV token"][0, :5], expected_oov_token_charngram, atol=0, rtol=10e-4)
 
-    def test_download_custom_vectors(self):
+    def test_download_custom_vectors(self) -> None:
         # Build a vocab and get vectors twice to test caching.
         for _ in range(2):
             vectors = torchtext.vocab.Vectors("wiki.simple.vec", url=torchtext.vocab.FastText.url_base.format("simple"))
@@ -99,7 +99,7 @@ class TestVocab(TorchtextTestCase):
 
             self.assertEqual(vectors["<unk>"], torch.zeros(300))
 
-    def test_download_fasttext_vectors(self):
+    def test_download_fasttext_vectors(self) -> None:
         # Build a vocab and get vectors twice to test caching.
         for _ in range(2):
             vectors = torchtext.vocab.FastText(language="simple")
@@ -116,7 +116,7 @@ class TestVocab(TorchtextTestCase):
             self.assertEqual(vectors["<unk>"], torch.zeros(300))
             self.assertEqual(vectors["OOV token"], torch.zeros(300))
 
-    def test_download_glove_vectors(self):
+    def test_download_glove_vectors(self) -> None:
         # Build a vocab and get vectors twice to test caching.
         vectors = torchtext.vocab.GloVe(name="twitter.27B", dim="25")
         # The first 5 entries in each vector.
@@ -131,7 +131,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(vectors["<unk>"], torch.zeros(25))
         self.assertEqual(vectors["OOV token"], torch.zeros(25))
 
-    def test_vectors_custom_cache(self):
+    def test_vectors_custom_cache(self) -> None:
         vector_cache = os.path.join("/tmp", "vector_cache")
         # Build a vocab and get vectors twice to test caching.
         for i in range(2):

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -25,7 +25,7 @@ class TestFunctional(TorchtextTestCase):
         expected = torch.tensor(expected_list, dtype=torch.long)
         torch.testing.assert_close(actual, expected)
 
-    def test_to_tensor_assert_raises(self):
+    def test_to_tensor_assert_raises(self) -> None:
         """test raise type error if input provided is not in Union[List[int],List[List[int]]]"""
         with self.assertRaises(TypeError):
             functional.to_tensor("test")
@@ -50,7 +50,7 @@ class TestFunctional(TorchtextTestCase):
         actual = func(inputs, max_seq_len=max_seq_len)
         self.assertEqual(actual, expected)
 
-    def test_truncate_assert_raises(self):
+    def test_truncate_assert_raises(self) -> None:
         """test raise type error if input provided is not in Union[List[Union[str, int]], List[List[Union[str, int]]]]"""
         with self.assertRaises(TypeError):
             functional.truncate("test", max_seq_len=2)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -27,11 +27,11 @@ class TestTransforms(TorchtextTestCase):
         expected = ["▁Hello", "▁World", "!", ",", "▁how", "▁are", "▁you", "?"]
         self.assertEqual(actual, expected)
 
-    def test_spmtokenizer(self):
+    def test_spmtokenizer(self) -> None:
         """test tokenization on single sentence input as well as batch on sentences"""
         self._spmtokenizer(test_scripting=False)
 
-    def test_spmtokenizer_jit(self):
+    def test_spmtokenizer_jit(self) -> None:
         """test tokenization with scripting on single sentence input as well as batch on sentences"""
         self._spmtokenizer(test_scripting=True)
 
@@ -48,11 +48,11 @@ class TestTransforms(TorchtextTestCase):
         expected = [0, 1, 2]
         self.assertEqual(actual, expected)
 
-    def test_vocab_transform(self):
+    def test_vocab_transform(self) -> None:
         """test token to indices on both sequence of input tokens as well as batch of sequence"""
         self._vocab_transform(test_scripting=False)
 
-    def test_vocab_transform_jit(self):
+    def test_vocab_transform_jit(self) -> None:
         """test token to indices with scripting on both sequence of input tokens as well as batch of sequence"""
         self._vocab_transform(test_scripting=True)
 
@@ -72,11 +72,11 @@ class TestTransforms(TorchtextTestCase):
         expected = torch.tensor([1, 2], dtype=torch.long)
         torch.testing.assert_close(actual, expected)
 
-    def test_totensor(self):
+    def test_totensor(self) -> None:
         """test tensorization on both single sequence and batch of sequence"""
         self._totensor(test_scripting=False)
 
-    def test_totensor_jit(self):
+    def test_totensor_jit(self) -> None:
         """test tensorization with scripting on both single sequence and batch of sequence"""
         self._totensor(test_scripting=True)
 
@@ -112,11 +112,11 @@ class TestTransforms(TorchtextTestCase):
         expected = [0, 1, 2]
         self.assertEqual(actual, expected)
 
-    def test_labeltoindex(self):
+    def test_labeltoindex(self) -> None:
         """test labe to ids on single label input as well as batch of labels"""
         self._labeltoindex(test_scripting=False)
 
-    def test_labeltoindex_jit(self):
+    def test_labeltoindex_jit(self) -> None:
         """test labe to ids with scripting on single label input as well as batch of labels"""
         self._labeltoindex(test_scripting=True)
 
@@ -146,11 +146,11 @@ class TestTransforms(TorchtextTestCase):
         expected = ["a", "b"]
         self.assertEqual(actual, expected)
 
-    def test_truncate(self):
+    def test_truncate(self) -> None:
         """test truncation on both sequence and batch of sequence with both str and int types"""
         self._truncate(test_scripting=False)
 
-    def test_truncate_jit(self):
+    def test_truncate_jit(self) -> None:
         """test truncation with scripting on both sequence and batch of sequence with both str and int types"""
         self._truncate(test_scripting=True)
 
@@ -201,10 +201,10 @@ class TestTransforms(TorchtextTestCase):
         expected = ["1", "2", "0"]
         self.assertEqual(actual, expected)
 
-    def test_add_token(self):
+    def test_add_token(self) -> None:
         self._add_token(test_scripting=False)
 
-    def test_add_token_jit(self):
+    def test_add_token_jit(self) -> None:
         self._add_token(test_scripting=True)
 
     def _pad_transform(self, test_scripting):
@@ -254,10 +254,10 @@ class TestTransforms(TorchtextTestCase):
             msg=f"actual: {padded_2d_tensor_actual}, expected: {padded_2d_tensor_expected}",
         )
 
-    def test_pad_transform(self):
+    def test_pad_transform(self) -> None:
         self._pad_transform(test_scripting=False)
 
-    def test_pad_transform_jit(self):
+    def test_pad_transform_jit(self) -> None:
         self._pad_transform(test_scripting=True)
 
     def _str_to_int_transform(self, test_scripting):
@@ -281,10 +281,10 @@ class TestTransforms(TorchtextTestCase):
         for i in range(len(expected_2d_int_list)):
             self.assertListEqual(expected_2d_int_list[i], actual_2d_int_list[i])
 
-    def test_str_to_int_transform(self):
+    def test_str_to_int_transform(self) -> None:
         self._str_to_int_transform(test_scripting=False)
 
-    def test_str_to_int_transform_jit(self):
+    def test_str_to_int_transform_jit(self) -> None:
         self._str_to_int_transform(test_scripting=True)
 
 
@@ -306,11 +306,11 @@ class TestSequential(TorchtextTestCase):
         expected = torch.tensor(input)
         torch.testing.assert_close(actual, expected)
 
-    def test_sequential(self):
+    def test_sequential(self) -> None:
         """test pipelining transforms using Sequential transform"""
         self._sequential(test_scripting=False)
 
-    def test_sequential_jit(self):
+    def test_sequential_jit(self) -> None:
         """test pipelining transforms using Sequential transform, ensuring the composite transform is scriptable"""
         self._sequential(test_scripting=True)
 
@@ -367,14 +367,14 @@ class TestGPT2BPETokenizer(TorchtextTestCase):
         """test tokenization on single sentence input as well as batch on sentences"""
         self._gpt2_bpe_tokenizer(self._load_tokenizer(test_scripting=test_scripting, return_tokens=return_tokens))
 
-    def test_gpt2_bpe_tokenizer_save_load_pybind(self):
+    def test_gpt2_bpe_tokenizer_save_load_pybind(self) -> None:
         tokenizer = self._load_tokenizer(test_scripting=False, return_tokens=False)
         tokenizer_path = os.path.join(self.test_dir, "gpt2_tokenizer_pybind.pt")
         torch.save(tokenizer, tokenizer_path)
         loaded_tokenizer = torch.load(tokenizer_path)
         self._gpt2_bpe_tokenizer((loaded_tokenizer))
 
-    def test_gpt2_bpe_tokenizer_save_load_torchscript(self):
+    def test_gpt2_bpe_tokenizer_save_load_torchscript(self) -> None:
         tokenizer = self._load_tokenizer(test_scripting=False, return_tokens=False)
         tokenizer_path = os.path.join(self.test_dir, "gpt2_tokenizer_torchscript.pt")
         # Call the __prepare_scriptable__() func and convert the building block to the torbhind version
@@ -567,14 +567,14 @@ class TestCLIPTokenizer(TorchtextTestCase):
             )
         )
 
-    def test_clip_tokenizer_save_load_pybind(self):
+    def test_clip_tokenizer_save_load_pybind(self) -> None:
         tokenizer = self._load_tokenizer(init_using_merge_only=True, test_scripting=False, return_tokens=False)
         tokenizer_path = os.path.join(self.test_dir, "gpt2_tokenizer_pybind.pt")
         torch.save(tokenizer, tokenizer_path)
         loaded_tokenizer = torch.load(tokenizer_path)
         self._clip_tokenizer((loaded_tokenizer))
 
-    def test_clip_tokenizer_save_load_torchscript(self):
+    def test_clip_tokenizer_save_load_torchscript(self) -> None:
         tokenizer = self._load_tokenizer(init_using_merge_only=True, test_scripting=False, return_tokens=False)
         tokenizer_path = os.path.join(self.test_dir, "gpt2_tokenizer_torchscript.pt")
         # Call the __prepare_scriptable__() func and convert the building block to the torbhind version
@@ -717,7 +717,7 @@ class TestRegexTokenizer(TorchtextTestCase):
         (r"\s+", " "),
     ]
 
-    def test_regex_tokenizer(self):
+    def test_regex_tokenizer(self) -> None:
         r_tokenizer = RegexTokenizer(self.patterns_list)
         eager_tokens = r_tokenizer(self.test_sample)
 
@@ -732,7 +732,7 @@ class TestRegexTokenizer(TorchtextTestCase):
         self.assertEqual(eager_tokens, self.ref_results)
         self.assertEqual(jit_tokens, self.ref_results)
 
-    def test_regex_tokenizer_save_load(self):
+    def test_regex_tokenizer_save_load(self) -> None:
 
         with self.subTest("pybind"):
             save_path = os.path.join(self.test_dir, "regex_pybind.pt")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,7 +18,7 @@ def conditional_remove(f):
 
 
 class TestUtils(TorchtextTestCase):
-    def test_download_extract_tar(self):
+    def test_download_extract_tar(self) -> None:
         # create root directory for downloading data
         root = os.path.abspath(".data")
         if not os.path.exists(root):
@@ -46,7 +46,7 @@ class TestUtils(TorchtextTestCase):
             conditional_remove(f)
         conditional_remove(archive_path)
 
-    def test_download_extract_gz(self):
+    def test_download_extract_gz(self) -> None:
         # create root directory for downloading data
         root = os.path.abspath(".data")
         if not os.path.exists(root):
@@ -74,7 +74,7 @@ class TestUtils(TorchtextTestCase):
             conditional_remove(f)
         conditional_remove(archive_path)
 
-    def test_download_extract_zip(self):
+    def test_download_extract_zip(self) -> None:
         # create root directory for downloading data
         root = os.path.abspath(".data")
         if not os.path.exists(root):
@@ -110,7 +110,7 @@ class TestUtils(TorchtextTestCase):
         os.rmdir(os.path.join(root, "en-ud-v2"))
         conditional_remove(archive_path)
 
-    def test_no_download(self):
+    def test_no_download(self) -> None:
         asset_name = "glove.840B.300d.zip"
         asset_path = get_asset_path(asset_name)
         root = os.path.abspath(".data")
@@ -122,7 +122,7 @@ class TestUtils(TorchtextTestCase):
         self.assertEqual(file_path, data_path)
         conditional_remove(data_path)
 
-    def test_download_extract_to_path(self):
+    def test_download_extract_to_path(self) -> None:
         # create root directory for downloading data
         root = os.path.abspath(".data")
         if not os.path.exists(root):
@@ -156,7 +156,7 @@ class TestUtils(TorchtextTestCase):
         conditional_remove(archive_path)
 
     @unittest.skip("Download temp. slow.")
-    def test_extract_non_tar_zip(self):
+    def test_extract_non_tar_zip(self) -> None:
         # create root directory for downloading data
         root = os.path.abspath(".data")
         if not os.path.exists(root):

--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -9,12 +9,12 @@ from torchtext.vocab import build_vocab_from_iterator, vocab
 
 
 class TestVocab(TorchtextTestCase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         torch._C._jit_clear_class_registry()
         torch.jit._recursive.concrete_type_store = torch.jit._recursive.ConcreteTypeStore()
 
-    def test_vocab_membership(self):
+    def test_vocab_membership(self) -> None:
         token_to_freq = {"<unk>": 2, "a": 2, "b": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -25,7 +25,7 @@ class TestVocab(TorchtextTestCase):
         self.assertTrue("b" in v)
         self.assertFalse("c" in v)
 
-    def test_vocab_get_item(self):
+    def test_vocab_get_item(self) -> None:
         token_to_freq = {"<unk>": 2, "a": 2, "b": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -35,7 +35,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v["a"], 1)
         self.assertEqual(v["b"], 2)
 
-    def test_default_index(self):
+    def test_default_index(self) -> None:
         token_to_freq = {"<unk>": 2, "a": 2, "b": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -52,7 +52,7 @@ class TestVocab(TorchtextTestCase):
         with self.assertRaises(RuntimeError):
             v["not in vocab"]
 
-    def test_default_index_jit(self):
+    def test_default_index_jit(self) -> None:
         token_to_freq = {"<unk>": 2, "a": 2, "b": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -65,7 +65,7 @@ class TestVocab(TorchtextTestCase):
         with self.assertRaises(RuntimeError):
             v_jit["not in vocab"]
 
-    def test_vocab_insert_token(self):
+    def test_vocab_insert_token(self) -> None:
         c = OrderedDict({"<unk>": 2, "a": 2})
 
         # add item to end
@@ -88,7 +88,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-    def test_vocab_append_token(self):
+    def test_vocab_append_token(self) -> None:
         c = OrderedDict({"a": 2})
         v = vocab(c)
         v.append_token("b")
@@ -103,7 +103,7 @@ class TestVocab(TorchtextTestCase):
         with self.assertRaises(RuntimeError):
             v.append_token("b")
 
-    def test_vocab_len(self):
+    def test_vocab_len(self) -> None:
         token_to_freq = {"a": 2, "b": 2, "c": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -111,7 +111,7 @@ class TestVocab(TorchtextTestCase):
 
         self.assertEqual(len(v), 3)
 
-    def test_vocab_basic(self):
+    def test_vocab_basic(self) -> None:
         token_to_freq = {"hello": 4, "world": 3, "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T": 5, "freq_too_low": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
 
@@ -124,7 +124,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-    def test_vocab_jit(self):
+    def test_vocab_jit(self) -> None:
         token_to_freq = {"hello": 4, "world": 3, "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T": 5, "freq_too_low": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
 
@@ -143,7 +143,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(jit_v.get_itos(), expected_itos)
         self.assertEqual(dict(jit_v.get_stoi()), expected_stoi)
 
-    def test_vocab_forward(self):
+    def test_vocab_forward(self) -> None:
         token_to_freq = {"a": 2, "b": 2, "c": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
 
@@ -157,7 +157,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v(tokens), expected_indices)
         self.assertEqual(jit_v(tokens), expected_indices)
 
-    def test_vocab_lookup_token(self):
+    def test_vocab_lookup_token(self) -> None:
         token_to_freq = {"a": 2, "b": 2, "c": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -167,7 +167,7 @@ class TestVocab(TorchtextTestCase):
         with self.assertRaises(RuntimeError):
             v.lookup_token(100)
 
-    def test_vocab_lookup_tokens(self):
+    def test_vocab_lookup_tokens(self) -> None:
         token_to_freq = {"a": 2, "b": 2, "c": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -178,7 +178,7 @@ class TestVocab(TorchtextTestCase):
 
         self.assertEqual(v.lookup_tokens(indices), expected_tokens)
 
-    def test_vocab_lookup_indices(self):
+    def test_vocab_lookup_indices(self) -> None:
         token_to_freq = {"a": 2, "b": 2, "c": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
         c = OrderedDict(sorted_by_freq_tuples)
@@ -189,7 +189,7 @@ class TestVocab(TorchtextTestCase):
 
         self.assertEqual(v.lookup_indices(tokens), expected_indices)
 
-    def test_vocab_load_and_save(self):
+    def test_vocab_load_and_save(self) -> None:
         token_to_freq = {"hello": 4, "world": 3, "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T": 5, "freq_too_low": 2}
         sorted_by_freq_tuples = sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True)
 
@@ -221,7 +221,7 @@ class TestVocab(TorchtextTestCase):
             self.assertEqual(dict(loaded_v.get_stoi()), expected_stoi)
             self.assertEqual(v["not in vocab"], 0)
 
-    def test_build_vocab_iterator(self):
+    def test_build_vocab_iterator(self) -> None:
         iterator = [
             [
                 "hello",
@@ -257,7 +257,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
-    def test_vocab_specials(self):
+    def test_vocab_specials(self) -> None:
         token_to_freq = {"hello": 4, "world": 3, "ᑌᑎIᑕOᗪᕮ_Tᕮ᙭T": 5, "freq_too_low": 2}
         sorted_by_freq_tuples = OrderedDict(sorted(token_to_freq.items(), key=lambda x: x[1], reverse=True))
         specials = ["<unk>", "<bos>", "<eos>", "pad"]
@@ -274,7 +274,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(v2.get_itos(), expected_itos)
         self.assertEqual(dict(v2.get_stoi()), expected_stoi)
 
-    def test_build_vocab_sorts_descending_frequency_then_lexigraphically(self):
+    def test_build_vocab_sorts_descending_frequency_then_lexigraphically(self) -> None:
         it = [["a", "b"], ["a", "b"]]
         vocab = build_vocab_from_iterator(it)
         self.assertEqual(vocab["a"], 0)
@@ -285,7 +285,7 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(vocab["b"], 0)
         self.assertEqual(vocab["a"], 1)
 
-    def test_build_vocab_from_iterator_max_tokens(self):
+    def test_build_vocab_from_iterator_max_tokens(self) -> None:
         it = [["hello", "world"], ["hello"]]
         max_tokens = 1
         specials = ["<unk>", "<pad>"]


### PR DESCRIPTION
I noticed that some of the tests were missing the  `-> None:` type hint. This PR adds the missing type hint.