### PR TITLE
Make BERT benchmark code more robust

### DIFF
--- a/benchmark/benchmark_bert_tokenizer.py
+++ b/benchmark/benchmark_bert_tokenizer.py
@@ -14,29 +14,36 @@ def benchmark_bert_tokenizer(args):
     tt_tokenizer = tt_bert_tokenizer(VOCAB_FILE, return_tokens=True)
     hf_tokenizer_slow = hf_bert_tokenizer_slow.from_pretrained("bert-base-uncased")
     hf_tokenizer_fast = hf_tokenizer_lib.from_pretrained("bert-base-uncased")
-    dp = EnWik9().header(args.num_samples)
+    dp = EnWik9().header(args.num_samples).batch(args.batch_size)
     samples = list(dp)
 
     with Timer("Running TorchText BERT Tokenizer on non-batched input"):
-        for s in samples:
-            tt_tokenizer(s)
+        for batch in samples:
+            for s in batch:
+                tt_tokenizer(s)
 
     with Timer("Running HF BERT Tokenizer (slow) on non-batched input"):
-        for s in samples:
-            hf_tokenizer_slow.tokenize(s)
+        for batch in samples:
+            for s in batch:
+                hf_tokenizer_slow.tokenize(s)
 
     with Timer("Running HF BERT Tokenizer (fast) on non-batched input"):
-        for s in samples:
-            hf_tokenizer_fast.encode(s)
+        for batch in samples:
+            for s in batch:
+                hf_tokenizer_fast.encode(s)
 
     with Timer("Running TorchText BERT Tokenizer on batched input"):
-        tt_tokenizer(samples)
+        for batch in samples:
+            tt_tokenizer(batch)
 
     with Timer("Running HF BERT Tokenizer (fast) on batched input"):
-        hf_tokenizer_fast.encode_batch(samples)
+        for batch in samples:
+            hf_tokenizer_fast.encode_batch(batch)
 
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument("--num-samples", default=1000, type=int)
+    parser.add_argument("--num-samples", default=10000, type=int)
+    parser.add_argument("--batch-size", default=100, type=int)
+
     benchmark_bert_tokenizer(parser.parse_args())


### PR DESCRIPTION
Updated benchmark code to run on pre-defined number of samples and batch size. By running on higher number of samples gives more robust statistics because 1) we show more variable length samples to tokenizer 2) we are running for larger number of batches instead of just 1 as currently the case.

## Benchmark results
**Number or samples:** 100000

### non-batched input

TorchText BERT Tokenizer: 1.7653241670000002
HF BERT Tokenizer (slow): 27.455106365
HF BERT Tokenizer (fast): 5.351107693000003

### Batched input

**Batch-size: 50**
TorchText BERT Tokenizer: 1.376252063
HF BERT Tokenizer (fast): 1.5889374279999995

**Batch-size: 100**
TorchText BERT Tokenizer: 1.3049638119999996
HF BERT Tokenizer (fast): 1.4069846630000002

**Batch-size: 200**
TorchText BERT Tokenizer: 1.275028583
HF BERT Tokenizer (fast): 1.2769447180000002

**Batch-size: 400**
TorchText BERT Tokenizer: 1.3523340929999996
HF BERT Tokenizer (fast): 1.2558808729999997

Apparently, for HF tokenizer the operator call is slower compared to torchtext but the backend implementation is faster. This is why after increase batch size to certain point, HF tokenizer (fast) is more performant compared to torchtext's implementation.
