### PR TITLE
Add torchdata to testing requirements in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ Sphinx
 pytest
 expecttest
 parameterized
+torchdata
 
 # Lets pytest find our code by automatically modifying PYTHONPATH
 pytest-pythonpath


### PR DESCRIPTION
Torchdata is a requirement to run the test suite, but it doesn't look like this is documented anywhere. This change proposes adding it to the testing section of the requirements.txt.