### PR TITLE
Allow CNNDM to be imported from torchtext.datasets

### DIFF
--- a/examples/tutorials/t5_demo.py
+++ b/examples/tutorials/t5_demo.py
@@ -258,7 +258,7 @@ def generate(encoder_tokens: Tensor, eos_idx: int, model: T5Model, beam_size: in
 from functools import partial
 
 from torch.utils.data import DataLoader
-from torchtext.datasets.cnndm import CNNDM
+from torchtext.datasets import CNNDM
 
 cnndm_batch_size = 5
 cnndm_datapipe = CNNDM(split="test")

--- a/test/datasets/test_cnndm.py
+++ b/test/datasets/test_cnndm.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from unittest.mock import patch
 
 from parameterized import parameterized
-from torchtext.datasets.cnndm import CNNDM
+from torchtext.datasets import CNNDM
 
 from ..common.case_utils import TempDirMixin, zip_equal, get_random_unicode
 from ..common.torchtext_test_case import TorchtextTestCase

--- a/torchtext/datasets/__init__.py
+++ b/torchtext/datasets/__init__.py
@@ -4,6 +4,7 @@ from .ag_news import AG_NEWS
 from .amazonreviewfull import AmazonReviewFull
 from .amazonreviewpolarity import AmazonReviewPolarity
 from .cc100 import CC100
+from .cnndm import CNNDM
 from .cola import CoLA
 from .conll2000chunking import CoNLL2000Chunking
 from .dbpedia import DBpedia
@@ -62,6 +63,7 @@ DATASETS = {
     "YahooAnswers": YahooAnswers,
     "YelpReviewFull": YelpReviewFull,
     "YelpReviewPolarity": YelpReviewPolarity,
+    "CNNDM": CNNDM,
 }
 
 URLS = {}

--- a/torchtext/datasets/cnndm.py
+++ b/torchtext/datasets/cnndm.py
@@ -20,7 +20,7 @@ if is_module_available("torchdata"):
 
 DATASET_NAME = "CNNDM"
 
-URL_LIST = {
+SPLIT_LIST = {
     "cnn_train": "https://raw.githubusercontent.com/abisee/cnn-dailymail/master/url_lists/cnn_wayback_training_urls.txt",
     "cnn_val": "https://raw.githubusercontent.com/abisee/cnn-dailymail/master/url_lists/cnn_wayback_validation_urls.txt",
     "cnn_test": "https://raw.githubusercontent.com/abisee/cnn-dailymail/master/url_lists/cnn_wayback_test_urls.txt",
@@ -29,7 +29,7 @@ URL_LIST = {
     "dailymail_test": "https://raw.githubusercontent.com/abisee/cnn-dailymail/master/url_lists/dailymail_wayback_test_urls.txt",
 }
 
-STORIES_LIST = {
+URL = {
     "cnn": "https://drive.google.com/uc?export=download&id=0BwmD_VLjROrfTHk4NFg2SndKcjQ",
     "dailymail": "https://drive.google.com/uc?export=download&id=0BwmD_VLjROrfM1BxdkxVaTY2bWs",
 }
@@ -39,11 +39,17 @@ PATH_LIST = {
     "dailymail": "dailymail_stories.tgz",
 }
 
-STORIES_MD5 = {"cnn": "85ac23a1926a831e8f46a6b8eaf57263", "dailymail": "f9c5f565e8abe86c38bfa4ae8f96fd72"}
+MD5 = {"cnn": "85ac23a1926a831e8f46a6b8eaf57263", "dailymail": "f9c5f565e8abe86c38bfa4ae8f96fd72"}
 
 _EXTRACTED_FOLDERS = {
     "cnn": os.path.join("cnn", "stories"),
     "dailymail": os.path.join("dailymail", "stories"),
+}
+
+NUM_LINES = {
+    "train": 287227,
+    "val": 13368,
+    "test": 11490,
 }
 
 story_fnames = defaultdict(set)
@@ -84,16 +90,16 @@ def _hash_urls(s: tuple):
 
 
 def _get_split_list(source: str, split: str):
-    url_dp = IterableWrapper([URL_LIST[source + "_" + split]])
+    url_dp = IterableWrapper([SPLIT_LIST[source + "_" + split]])
     online_dp = OnlineReader(url_dp)
     return online_dp.readlines().map(fn=_hash_urls)
 
 
 def _load_stories(root: str, source: str, split: str):
-    story_dp = IterableWrapper([STORIES_LIST[source]])
+    story_dp = IterableWrapper([URL[source]])
     cache_compressed_dp = story_dp.on_disk_cache(
         filepath_fn=partial(_filepath_fn, root, source),
-        hash_dict={_filepath_fn(root, source): STORIES_MD5[source]},
+        hash_dict={_filepath_fn(root, source): MD5[source]},
         hash_type="md5",
     )
     cache_compressed_dp = GDriveReader(cache_compressed_dp).end_caching(mode="wb", same_filepath_fn=True)


### PR DESCRIPTION
# Description

Currently can only import CNNDM from `torchtext.datasets.cnndm`. Update so that can import from `torchtext.datasetes`

# Process

Add CNNDM to `torchtext.datasets.__init__.py` and rename certain class objects to align with expected names in `torchtext.datasets.__init__.py`. Update CNNDM import statements.

# Test

`pytest test/datasets/test_cnndm.py` (this imports CNNDM, so import statement is tested)