### PR TITLE
Delete model checkpoints within integration test

### DIFF
--- a/test/integration_tests/test_models.py
+++ b/test/integration_tests/test_models.py
@@ -6,8 +6,9 @@ from torchtext.models import (
     XLMR_BASE_ENCODER,
     XLMR_LARGE_ENCODER,
 )
+from torchtext.utils import get_asset_local_path
 
-from ..common.assets import get_asset_path
+from ..common.assets import conditional_remove, get_asset_path
 from ..common.torchtext_test_case import TorchtextTestCase
 
 
@@ -30,6 +31,10 @@ class TestRobertaEncoders(TorchtextTestCase):
         actual = model(model_input)
         expected = torch.load(expected_asset_path)
         torch.testing.assert_close(actual, expected)
+
+        # delete checkpoint from cache
+        model_checkpoint_path = get_asset_local_path(encoder._path)
+        conditional_remove(model_checkpoint_path)
 
     @parameterized.expand([("jit", True), ("not_jit", False)])
     def test_xlmr_base_model(self, name, is_jit):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,16 +5,11 @@ import shutil
 import unittest
 from urllib.parse import urljoin
 
-from test.common.assets import get_asset_path
+from test.common.assets import conditional_remove, get_asset_path
 from torchtext import _TEXT_BUCKET
 from torchtext import utils
 
 from .common.torchtext_test_case import TorchtextTestCase
-
-
-def conditional_remove(f):
-    if os.path.isfile(f):
-        os.remove(f)
 
 
 class TestUtils(TorchtextTestCase):

--- a/torchtext/_download_hooks.py
+++ b/torchtext/_download_hooks.py
@@ -1,14 +1,19 @@
 import re
+from functools import partial
 
 import requests
 
 # This is to allow monkey-patching in fbcode
-from torch.hub import load_state_dict_from_url  # noqa
+from torch.hub import load_state_dict_from_url as torchhub_load_state_dict_from_url  # noqa
+from torchtext import _CACHE_DIR
 from torchtext._internal.module_utils import is_module_available
 from tqdm import tqdm
 
 if is_module_available("torchdata"):
     from torchdata.datapipes.iter import HttpReader, GDriveReader  # noqa F401
+
+# we set the model_dir to be equal to _CACHE_DIR so that all checkpoint downloads go into the text specific cache
+load_state_dict_from_url = partial(torchhub_load_state_dict_from_url, model_dir=_CACHE_DIR)
 
 
 def _stream_response(r, chunk_size=16 * 1024):


### PR DESCRIPTION
## Description
- Currently tests in CI are failing due to running out of disk space (i.e. see [example failure](https://app.circleci.com/pipelines/github/pytorch/text/6623/workflows/25d5e336-a916-4855-a9ad-b99b684b979a/jobs/228196))
- This happens because some of the checkpoints downloaded in the integration test are quite large (around 3GB) and several checkpoints are downloaded for the TF and the RoBERTa models
- We mitigate this by removing the checkpoints at the end of every test. The tradeoff is that this will cause more network usage since a single checkpoint may need to be downloaded several times (as several tests may rely on the same checkpoint)
- We also convert `load_state_dict_from_url` within `_download_hooks.py` into a partial function with the default value for `model_dir` set to `_CACHE_DIR`. This ensures that all text assets are downloaded to `$TORCH_HOME/text` folder which is in line with where we download all of our datasets (see the following [internal post](https://fb.workplace.com/groups/473278361165956/permalink/517067430120382/) for relevant discussion) .

## Testing
- Ensure all CI tests are passing
- `pytest test/prototype/integration_tests/test_models.py`
- `pytest test/integration_tests/test_models.py`