### PR TITLE
Fix type conversion from py::object to STL container

### DIFF
--- a/torchtext/csrc/vocab_factory.h
+++ b/torchtext/csrc/vocab_factory.h
@@ -1,11 +1,12 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <torchtext/csrc/vocab.h> // @manual
 
 namespace py = pybind11;
 
 namespace torchtext {
 
-Vocab _build_vocab_from_text_file_using_python_tokenizer(
+TORCHTEXT_API Vocab _build_vocab_from_text_file_using_python_tokenizer(
     const std::string& file_path,
     const int64_t min_freq,
     py::object tokenizer);
@@ -14,6 +15,7 @@ TORCHTEXT_API Vocab _load_vocab_from_file(
     const std::string& file_path,
     const int64_t min_freq,
     const int64_t num_cpus);
+
 TORCHTEXT_API Vocab _build_vocab_from_text_file(
     const std::string& file_path,
     const int64_t min_freq,


### PR DESCRIPTION
As title