### PR TITLE
Export symbols in `common.h` file

### DIFF
--- a/torchtext/csrc/common.cpp
+++ b/torchtext/csrc/common.cpp
@@ -2,10 +2,7 @@
 
 #include <fstream>
 #include <ios>
-#include <iostream>
 #include <limits>
-#include <string>
-#include <vector>
 
 namespace torchtext {
 namespace impl {

--- a/torchtext/csrc/common.cpp
+++ b/torchtext/csrc/common.cpp
@@ -1,9 +1,12 @@
+#include <torchtext/csrc/common.h>
+
 #include <fstream>
 #include <ios>
 #include <iostream>
 #include <limits>
 #include <string>
 #include <vector>
+
 
 namespace torchtext {
 namespace impl {

--- a/torchtext/csrc/common.cpp
+++ b/torchtext/csrc/common.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 
-
 namespace torchtext {
 namespace impl {
 

--- a/torchtext/csrc/common.h
+++ b/torchtext/csrc/common.h
@@ -1,8 +1,10 @@
+#include <torchtext/csrc/export.h>
+
 namespace torchtext {
 
 namespace impl {
-int64_t divup(int64_t x, int64_t y);
-void infer_offsets(
+TORCHTEXT_API int64_t divup(int64_t x, int64_t y);
+TORCHTEXT_API void infer_offsets(
     const std::string& file_path,
     int64_t num_lines,
     int64_t chunk_size,

--- a/torchtext/csrc/common.h
+++ b/torchtext/csrc/common.h
@@ -1,5 +1,9 @@
 #include <torchtext/csrc/export.h>
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 namespace torchtext {
 
 namespace impl {

--- a/torchtext/csrc/vocab_factory.cpp
+++ b/torchtext/csrc/vocab_factory.cpp
@@ -1,9 +1,9 @@
 #include <ATen/Parallel.h> // @manual
+#include <pybind11/stl.h>
 #include <torch/torch.h> // @manual
 #include <torchtext/csrc/common.h>
 #include <torchtext/csrc/vocab.h> // @manual
 #include <torchtext/csrc/vocab_factory.h> // @manual
-#include <pybind11/stl.h>
 
 #include <fstream>
 #include <stdexcept>

--- a/torchtext/csrc/vocab_factory.cpp
+++ b/torchtext/csrc/vocab_factory.cpp
@@ -3,6 +3,7 @@
 #include <torchtext/csrc/common.h>
 #include <torchtext/csrc/vocab.h> // @manual
 #include <torchtext/csrc/vocab_factory.h> // @manual
+#include <pybind11/stl.h>
 
 #include <fstream>
 #include <stdexcept>

--- a/torchtext/csrc/vocab_factory.h
+++ b/torchtext/csrc/vocab_factory.h
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <torchtext/csrc/export.h>
 #include <torchtext/csrc/vocab.h> // @manual
 
 namespace py = pybind11;

--- a/torchtext/csrc/vocab_factory.h
+++ b/torchtext/csrc/vocab_factory.h
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <torchtext/csrc/vocab.h> // @manual
 
 namespace py = pybind11;

--- a/torchtext/csrc/vocab_factory.h
+++ b/torchtext/csrc/vocab_factory.h
@@ -1,11 +1,12 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <torchtext/csrc/vocab.h> // @manual
 
 namespace py = pybind11;
 
 namespace torchtext {
 
-Vocab _build_vocab_from_text_file_using_python_tokenizer(
+TORCHTEXT_API Vocab _build_vocab_from_text_file_using_python_tokenizer(
     const std::string& file_path,
     const int64_t min_freq,
     py::object tokenizer);
@@ -14,6 +15,7 @@ TORCHTEXT_API Vocab _load_vocab_from_file(
     const std::string& file_path,
     const int64_t min_freq,
     const int64_t num_cpus);
+
 TORCHTEXT_API Vocab _build_vocab_from_text_file(
     const std::string& file_path,
     const int64_t min_freq,


### PR DESCRIPTION
## Description
- https://github.com/pytorch/text/pull/1806 added a `TORCHTEXT_API` to export relevant symbols on Windows platform
- We add the macro to the methods in `common.h` as these are used by functions in `vocab_factory.h`