### PR TITLE
Split `spacy` install and `spacy` models downloads

### DIFF
--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -4,6 +4,7 @@ dependencies:
   - codecov
   - pip
   - setuptools == 58.0.4
+  - spacy
   - pip:
       - dataclasses
       - nltk
@@ -13,7 +14,6 @@ dependencies:
       - pytest-cov
       - pytest-pythonpath
       - sacremoses
-      - spacy
       - tqdm
       - certifi
       - expecttest


### PR DESCRIPTION
## Description

Previously, Unit Tests on Windows with Python 3.10 would not complete setup install. After some experimentation, it was discovered that the hangup was caused by having the `spacy` dependency and the `spacy` models both downloaded in by `pip`.  Therefore, the `spacy` dependency was moved to be directly downloaded by `conda`.

Closes #1893