### PR TITLE
Usage setup-minicoda action for m1 build

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -169,7 +169,7 @@ jobs:
         run: |
           conda install -yq anaconda-client
           set -x
-          anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/miniconda3/conda-bld/osx-arm64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+          anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload dist/osx-arm64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
 
 concurrency:
   group:

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -38,14 +38,14 @@ jobs:
           'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
       - name: Build TorchText M1 wheel
         shell: arch -arch arm64 bash {0}
         env:
           ENV_NAME: conda-env-${{ github.run_id }}
           PY_VERS: ${{ matrix.py_vers }}
         run: |
-          echo $PATH
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           . packaging/pkg_helpers.bash
           # if we are uploading to test channell, our version consist only of the base: 0.x.x - no date string or suffix added
@@ -69,7 +69,6 @@ jobs:
           ENV_NAME: conda-test-env-${{ github.run_id }}
           PY_VERS: ${{ matrix.py_vers }}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy
           conda run -p ${ENV_NAME} python3 -mpip install torch --pre --extra-index-url=https://download.pytorch.org/whl/${CHANNEL}
@@ -119,13 +118,13 @@ jobs:
           'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
       - name: Install conda-build and purge previous artifacts
         shell: arch -arch arm64 bash {0}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           conda install -yq conda-build
           conda build purge-all
-
       - name: Build TorchText M1 conda package
         shell: arch -arch arm64 bash {0}
         env:
@@ -133,7 +132,6 @@ jobs:
           PYTHON_VERSION: ${{ matrix.py_vers }}
           CU_VERSION: cpu
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           . packaging/pkg_helpers.bash
 
@@ -169,7 +167,6 @@ jobs:
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           conda install -yq anaconda-client
           set -x
           anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/miniconda3/conda-bld/osx-arm64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force


### PR DESCRIPTION
Usage setup-minicoda action for m1 build
We want to try to address space issues on m1. The following action:
```
pytorch/test-infra/.github/actions/setup-miniconda@main
```

Sets up miniconda in temp folder which should be cleaned between runs
