### PR TITLE
Disable `test_vocab_from_raw_text_file` on Linux

### DIFF
--- a/test/prototype/test_with_asset.py
+++ b/test/prototype/test_with_asset.py
@@ -138,7 +138,7 @@ class TestTransformsWithAsset(TorchtextTestCase):
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
     # TODO(Nayef211): remove decorator once https://github.com/pytorch/text/issues/1900 is closed
-    @unittest.skipIf(platform.system() == "Linux", "Test is known to fail on Linux.")
+    @unittest.skipIf("CI" in os.environ and platform.system() == "Linux", "Test is known to fail on Linux.")
     def test_vocab_from_raw_text_file(self) -> None:
         asset_name = "vocab_raw_text_test.txt"
         asset_path = get_asset_path(asset_name)

--- a/test/prototype/test_with_asset.py
+++ b/test/prototype/test_with_asset.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import unittest
 from functools import partial
 
 import torch
@@ -135,6 +136,8 @@ class TestTransformsWithAsset(TorchtextTestCase):
         self.assertEqual(v.get_itos(), expected_itos)
         self.assertEqual(dict(v.get_stoi()), expected_stoi)
 
+    # TODO(Nayef211): remove decorator once https://github.com/pytorch/text/issues/1900 is closed
+    @unittest.skipIf(platform.system() == "Linux", "Test is known to fail on Linux.")
     def test_vocab_from_raw_text_file(self) -> None:
         asset_name = "vocab_raw_text_test.txt"
         asset_path = get_asset_path(asset_name)

--- a/test/prototype/test_with_asset.py
+++ b/test/prototype/test_with_asset.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import shutil
 import tempfile
 import unittest


### PR DESCRIPTION
- The `test_vocab_from_raw_text_file` test is failing on CI for linux platforms due to segmantation faults (see [sample CI job](https://app.circleci.com/pipelines/github/pytorch/text/6713/workflows/016984af-210f-4ec1-ac23-e7b31ea6f465/jobs/231623)).
- Will revert once https://github.com/pytorch/text/issues/1900 is resolved