### PR TITLE
[Cherry Pick] move PATH_MANAGER to OSS

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - pip
   - pip:
       - dataclasses
+      - iopath
       - nltk
       - requests
       - revtok

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - spacy
   - pip:
       - dataclasses
+      - iopath
       - nltk
       - requests
       - revtok

--- a/packaging/torchtext/meta.yaml
+++ b/packaging/torchtext/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python
     - requests
     - tqdm
+    - iopath
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
 
 build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ tqdm
 
 # Downloading data and other files
 requests
+iopath
 
 # Optional NLP tools
 nltk

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup_info = dict(
     description="Text utilities and datasets for PyTorch",
     long_description=read("README.rst"),
     license="BSD",
-    install_requires=["tqdm", "requests", pytorch_package_dep, "numpy"],
+    install_requires=["tqdm", "requests", pytorch_package_dep, "numpy", "iopath"],
     python_requires=">=3.7",
     classifiers=[
         "Programming Language :: Python :: 3.7",

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -6,6 +6,7 @@ import tarfile
 import zipfile
 
 import torch
+from iopath.common.file_io import PathManager
 from torchtext import _CACHE_DIR
 
 from ._download_hooks import _DATASET_DOWNLOAD_MANAGER
@@ -228,3 +229,16 @@ def get_asset_local_path(asset_path: str, overwite=False) -> str:
     else:
         local_path = download_from_url(url=asset_path, root=_CACHE_DIR, overwrite=overwite)
     return local_path
+
+
+PATH_MANAGER = PathManager()
+'''
+We use iopath to handle local files, remote files with http/https urls, etc.
+This global instance is registered with all the required handlers with the best
+defaults. Learn more about iopath: https://github.com/facebookresearch/iopath
+
+Examples:
+    >>> from torchtext.utils import PATH_MANAGER
+    >>> with PATH_MANAGER.open(FILE_PATH) as f:
+    >>>     f.read()
+'''

--- a/torchtext/utils.py
+++ b/torchtext/utils.py
@@ -232,7 +232,7 @@ def get_asset_local_path(asset_path: str, overwite=False) -> str:
 
 
 PATH_MANAGER = PathManager()
-'''
+"""
 We use iopath to handle local files, remote files with http/https urls, etc.
 This global instance is registered with all the required handlers with the best
 defaults. Learn more about iopath: https://github.com/facebookresearch/iopath
@@ -241,4 +241,4 @@ Examples:
     >>> from torchtext.utils import PATH_MANAGER
     >>> with PATH_MANAGER.open(FILE_PATH) as f:
     >>>     f.read()
-'''
+"""


### PR DESCRIPTION
Summary:
## Problem:
pytext got "No module named 'pytorch'" in issue https://github.com/facebookresearch/pytext/issues/1706

It's due to `from pytorch.text.fb.utils import PATH_MANAGER` is internal only but imported in pytext. Actually, `pytorch/text/fb/utils/__init__.py` should be open sourced.

## Solution:
This diff moved it to OSS as `from torchtext.utils import PATH_MANAGER` and updated all the references

Reviewed By: Nayef211

Differential Revision: D39292896

fbshipit-source-id: c0046d62e64145b60ad9a5298b366f0f1a348369