### PR TITLE
[Cherry Pick]  Turn off mask checking for torchtext which is known to have a legal mask (#1896)

### DIFF
--- a/torchtext/models/roberta/modules.py
+++ b/torchtext/models/roberta/modules.py
@@ -120,7 +120,12 @@ class TransformerEncoder(Module):
             batch_first=True,
             norm_first=normalize_before,
         )
-        self.layers = torch.nn.TransformerEncoder(encoder_layer=layer, num_layers=num_encoder_layers)
+        self.layers = torch.nn.TransformerEncoder(
+            encoder_layer=layer,
+            num_layers=num_encoder_layers,
+            enable_nested_tensor=True,
+            mask_check=False,
+        )
         self.positional_embedding = PositionalEmbedding(max_seq_len, embedding_dim, padding_idx)
         self.embedding_layer_norm = nn.LayerNorm(embedding_dim)
         self.dropout = nn.Dropout(dropout)


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/text/pull/1896

Turn off mask checking for torchtext which is known to have a legal mask

Reviewed By: zrphercule

Differential Revision: D39445703

fbshipit-source-id: 3f0cacfd39ea11a16c7a06f339872554333b5e97