### PR TITLE
Add missing CMakeLists.txt file in `tokenizer` dir

### DIFF
--- a/examples/libtorchtext/.gitignore
+++ b/examples/libtorchtext/.gitignore
@@ -1,2 +1,4 @@
 build
 **/*.pt
+**/*.bpe
+**/*.json

--- a/examples/libtorchtext/tokenizer/CMakeLists.txt
+++ b/examples/libtorchtext/tokenizer/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(tokenize main.cpp)
+target_link_libraries(tokenize "${TORCH_LIBRARIES}" "${TORCHTEXT_LIBRARY}")
+set_property(TARGET tokenize PROPERTY CXX_STANDARD 14)


### PR DESCRIPTION
## Description
- https://github.com/pytorch/text/pull/1817 missed checking in the `CMakeLists.txt` file within the `examples/libtorchtext/tokenizer` directory
- This led to users such as not being able to build and run the example (https://github.com/pytorch/text/pull/1817#issuecomment-1250224844)