### PR TITLE
Add repository double-conversion support for loongarch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,6 +9,7 @@
 [submodule "third_party/double-conversion"]
 	path = third_party/double-conversion
 	url = https://github.com/google/double-conversion
+	branch = main
 	ignore = dirty
 [submodule "third_party/utf8proc"]
 	path = third_party/utf8proc

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "third_party/double-conversion"]
 	path = third_party/double-conversion
 	url = https://github.com/google/double-conversion
-	branch = main
+	branch = master
 	ignore = dirty
 [submodule "third_party/utf8proc"]
 	path = third_party/utf8proc


### PR DESCRIPTION
Add warehouse double-conversion to support loongarch, which has been tested on loongarch and can be passed