### PR TITLE
Add decoding capability to GPT2BPE tokenizer

### DIFF
--- a/test/torchtext_unittest/test_transforms.py
+++ b/test/torchtext_unittest/test_transforms.py
@@ -364,10 +364,32 @@ class TestGPT2BPETokenizer(TorchtextTestCase):
             else:
                 self.assertEqual(tokenizer(txt), expected_token_ids[idx])
 
+    def _gpt2_bpe_decoder(self, tokenizer):
+        sample_ids = [
+            ["15496", "2159", "28265", "703", "389", "345", "30"],
+            ["39", "2634", "297", "10205", "220", "22173", "129", "243", "75", "41585", "232", "126", "123"],
+            ["4965", "11377", "64", "2208", "72", "29625"],
+            ["7355", "67", "34655", "569", "81", "32790", "1228", "1990", "72", "38325", "6184", "106", "77"],
+        ]
+
+        expected_texts = [
+            "Hello World!, how are you?",
+            "Hélló  WoŕlḊ¿",
+            "Respublica superiorem",
+            "Avdija Vršajević în",
+        ]
+
+        for idx, ids in enumerate(sample_ids):
+            self.assertEqual(tokenizer.decode(ids), expected_texts[idx])
+
     @nested_params([True, False], [True, False])
     def test_gpt2_bpe_tokenizer(self, test_scripting, return_tokens):
         """test tokenization on single sentence input as well as batch on sentences"""
         self._gpt2_bpe_tokenizer(self._load_tokenizer(test_scripting=test_scripting, return_tokens=return_tokens))
+
+    def test_gpt2_bpe_decoder(self):
+        """test string output returned by decoder given the token ids"""
+        self._gpt2_bpe_decoder(self._load_tokenizer(test_scripting=False, return_tokens=False))
 
     def test_gpt2_bpe_tokenizer_save_load_pybind(self) -> None:
         tokenizer = self._load_tokenizer(test_scripting=False, return_tokens=False)

--- a/torchtext/csrc/gpt2_bpe_tokenizer.h
+++ b/torchtext/csrc/gpt2_bpe_tokenizer.h
@@ -69,8 +69,10 @@ struct GPT2BPEEncoder : torch::CustomClassHolder {
 
  public:
   const c10::Dict<std::string, int64_t> bpe_encoder_;
+  const c10::Dict<int64_t, std::string> bpe_decoder_;
   const c10::Dict<std::string, int64_t> bpe_merge_ranks_;
   const c10::Dict<int64_t, std::string> byte_encoder_;
+  const c10::Dict<std::string, int64_t> byte_decoder_;
   const std::string seperator_;
   const bool caching_enabled_;
   explicit GPT2BPEEncoder(
@@ -99,6 +101,7 @@ struct GPT2BPEEncoder : torch::CustomClassHolder {
   //  --> result --> [707, 5927, 11, 707, 68]
   //
   TORCHTEXT_API std::vector<int64_t> Encode(const std::string& text);
+  TORCHTEXT_API std::string Decode(const std::vector<int64_t>& tokens);
   TORCHTEXT_API std::vector<std::string> Tokenize(const std::string& text);
 
   TORCHTEXT_API std::unordered_map<std::string, int64_t> GetBPEEncoder() const;

--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -179,6 +179,7 @@ PYBIND11_MODULE(_torchtext, m) {
       .def_property_readonly("byte_encoder_", &GPT2BPEEncoder::GetByteEncoder)
       .def("encode", &GPT2BPEEncoder::Encode)
       .def("tokenize", &GPT2BPEEncoder::Tokenize)
+      .def("decode", &GPT2BPEEncoder::Decode)
       .def(py::pickle(
           // __getstate__
           [](const c10::intrusive_ptr<GPT2BPEEncoder>& self)

--- a/torchtext/csrc/register_torchbindings.cpp
+++ b/torchtext/csrc/register_torchbindings.cpp
@@ -139,6 +139,7 @@ TORCH_LIBRARY_FRAGMENT(torchtext, m) {
            c10::Dict<int64_t, std::string>,
            bool>())
       .def("encode", &GPT2BPEEncoder::Encode)
+      .def("decode", &GPT2BPEEncoder::Decode)
       .def("tokenize", &GPT2BPEEncoder::Tokenize)
       .def_pickle(
           // __getstate__

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -383,6 +383,16 @@ class GPT2BPETokenizer(Module):
             return tokenizer_copy
         return self
 
+    def decode(self, tokens: List[str]) -> str:
+        """Return a decoded string given a list of string token ids.
+
+        :param input: A list of strings, each string corresponds to token ids.
+        :type input: List[str]
+        :return: decoded text
+        :rtype: str
+        """
+        return self.bpe.decode([int(token) for token in tokens])
+
 
 class CLIPTokenizer(Module):
     """


### PR DESCRIPTION
## Description

Add add_special_tokens feature to GPT2BPETokenizer

This change is targeted towards a requirement posted internally. It adds a new function `add_special_tokens` to `GPT2BPETokenizer` in order to enable the user to specify a dictionary of token that should not be changed during tokenization. Any newly specified token shall also be added to the vocabulary.

The change adds the capability to decode tokens ids back to text. This change is required following the internal discussion.

## Types of changes
[x ] New feature (non-breaking change which adds core functionality)

## Changes made
* Made changes to C++ code (`GPT2BPEEncoder` class) to support the `decode` functionality.
* Updated torch bindings and py bindings as required.
* Added `decode` function to Python interface (`GPT2BPETokenizer` class).
* Added unit test to test the decoding process.

## Testing
* No issue identified in `pre-commit`
* No issue identified with any of the unit tests.