### PR TITLE
Avoid using std::regex and fix lint errors

### DIFF
--- a/torchtext/csrc/gpt2_bpe_tokenizer.h
+++ b/torchtext/csrc/gpt2_bpe_tokenizer.h
@@ -111,7 +111,7 @@ struct GPT2BPEEncoder : torch::CustomClassHolder {
   TORCHTEXT_API std::vector<std::string> Tokenize(const std::string& text);
   TORCHTEXT_API int64_t AddSpecialTokens(
       const c10::Dict<std::string, std::string>& standard_special_tokens_dict,
-      const std::vector<std::string> additional_special_tokens);
+      const std::vector<std::string>& additional_special_tokens);
 
   TORCHTEXT_API std::unordered_map<std::string, int64_t> GetBPEEncoder() const;
   TORCHTEXT_API std::unordered_map<std::string, int64_t> GetBPEMergeRanks()

--- a/torchtext/csrc/register_pybindings.cpp
+++ b/torchtext/csrc/register_pybindings.cpp
@@ -186,8 +186,9 @@ PYBIND11_MODULE(_torchtext, m) {
              const std::unordered_map<std::string, std::string>& items,
              const std::vector<std::string>& additional) {
             c10::Dict<std::string, std::string> d;
-            for (const auto& item : items)
+            for (const auto& item : items) {
               d.insert(item.first, item.second);
+            }
             return (self->AddSpecialTokens(d, additional));
           })
       .def(py::pickle(


### PR DESCRIPTION
## Description

Avoid using std::regex and fix lint errors

This change fixes the lint errors raised from merging #1916 into fbcode.

## Types of changes
[x ] Fixes

## Changes made
* Removed `std::regex` usage and opted to use `re2`
* Fixed indexing in pre-tokenization step
* Addressed additional linter issue identified internally

## Testing
* No issue identified in `pre-commit`
* No issue identified with any of the unit tests.