### PR TITLE
Add padding_masks and tests for T5Model

### DIFF
--- a/test/torchtext_unittest/prototype/models/test_models.py
+++ b/test/torchtext_unittest/prototype/models/test_models.py
@@ -3,13 +3,12 @@ from unittest.mock import patch
 
 import torch
 from torch.nn import functional as F
+from torchtext.prototype.models import T5Bundle, T5Conf, T5Model
 from torchtext_unittest.common.torchtext_test_case import TorchtextTestCase
 
 
 class TestModels(TorchtextTestCase):
     def test_t5_bundler_build_model(self) -> None:
-        from torchtext.prototype.models import T5Conf, T5Model, T5Bundle
-
         # case: user provides encoder checkpoint state dict
         dummy_encoder_conf = T5Conf(
             encoder_only=True,
@@ -21,7 +20,9 @@ class TestModels(TorchtextTestCase):
             num_decoder_layers=2,
         )
         dummy_t5_encoder = T5Model(dummy_encoder_conf)
-        t5_encoder_model = T5Bundle.build_model(config=dummy_encoder_conf, checkpoint=dummy_t5_encoder.state_dict())
+        t5_encoder_model = T5Bundle.build_model(
+            config=dummy_encoder_conf, checkpoint=dummy_t5_encoder.state_dict()
+        )
         self.assertEqual(t5_encoder_model.state_dict(), dummy_t5_encoder.state_dict())
 
         # case: user provides encoder-decoder checkpoint state dict
@@ -35,7 +36,9 @@ class TestModels(TorchtextTestCase):
             num_decoder_layers=2,
         )
         dummy_t5 = T5Model(dummy_t5_conf)
-        t5_model = T5Bundle.build_model(config=dummy_t5_conf, checkpoint=dummy_t5.state_dict())
+        t5_model = T5Bundle.build_model(
+            config=dummy_t5_conf, checkpoint=dummy_t5.state_dict()
+        )
         self.assertEqual(t5_model.state_dict(), dummy_t5.state_dict())
 
         # case: user provides checkpoint state dict for encoder-decoder with generation
@@ -53,12 +56,12 @@ class TestModels(TorchtextTestCase):
         t5_generation_model = T5Bundle.build_model(
             config=dummy_t5_generation_conf, checkpoint=dummy_t5_generation.state_dict()
         )
-        self.assertEqual(t5_generation_model.state_dict(), dummy_t5_generation.state_dict())
+        self.assertEqual(
+            t5_generation_model.state_dict(), dummy_t5_generation.state_dict()
+        )
 
     @patch("logging.Logger.warning")
     def test_t5_bundler_get_model(self, mock):
-        from torchtext.prototype.models import T5Conf, T5Bundle
-
         # encoder-decoder with generation
         dummy_t5_generation_conf = T5Conf(
             encoder_only=False,
@@ -77,8 +80,6 @@ class TestModels(TorchtextTestCase):
         )
 
     def test_t5_bundler_raise_checkpoint(self) -> None:
-        from torchtext.prototype.models import T5Conf, T5Bundle
-
         # encoder-only
         with self.assertRaises(TypeError):
             dummy_encoder_conf = T5Conf(
@@ -132,8 +133,6 @@ class TestModels(TorchtextTestCase):
             )
 
     def test_t5_bundler_conf_property(self) -> None:
-        from torchtext.prototype.models import T5Conf, T5Bundle
-
         dummy_t5_conf = T5Conf(
             encoder_only=False,
             vocab_size=10,
@@ -148,7 +147,6 @@ class TestModels(TorchtextTestCase):
 
     def test_t5_bundler_train(self) -> None:
         from torch.optim import SGD
-        from torchtext.prototype.models import T5Conf, T5Model, T5Bundle
 
         def _train(model):
             optim = SGD(model.parameters(), lr=1)
@@ -181,3 +179,68 @@ class TestModels(TorchtextTestCase):
 
         _train(model)
         self.assertNotEqual(model.state_dict(), current_state_dict)
+
+    def test_t5_model_forward_with_encoder_mask_encoder_only(self) -> None:
+        dummy_conf = T5Conf(
+            encoder_only=True,
+            linear_head=True,
+            vocab_size=100,
+            embedding_dim=16,
+            ffn_dimension=64,
+            num_attention_heads=2,
+            num_encoder_layers=2,
+            num_decoder_layers=2,
+            training=False,
+        )
+        dummy_model = T5Model(dummy_conf)
+        tokens = torch.tensor([[1, 2, 3, 4, 5, 0, 0, 0, 0, 0]])
+        mask = tokens.eq(0)
+
+        with torch.no_grad():
+            output_with_mask = dummy_model(
+                encoder_tokens=tokens, encoder_padding_mask=mask
+            )
+            output_no_mask = dummy_model(tokens)
+
+        torch.testing.assert_close(
+            output_with_mask["encoder_output"],
+            output_no_mask["encoder_output"],
+            atol=1e-04,
+            rtol=2.5e-06,
+        )
+
+    def test_t5_model_forward_with_encoder_mask_encoder_decoder(self) -> None:
+        dummy_conf = T5Conf(
+            encoder_only=False,
+            linear_head=True,
+            vocab_size=100,
+            embedding_dim=16,
+            ffn_dimension=64,
+            num_attention_heads=2,
+            num_encoder_layers=2,
+            num_decoder_layers=2,
+            training=False,
+        )
+        dummy_model = T5Model(dummy_conf)
+        enc_tokens = torch.tensor([[1, 2, 3, 4, 5, 0, 0, 0, 0, 0]])
+        dec_tokens = torch.tensor([[6, 7, 8, 9, 10, 11, 0, 0, 0, 0]])
+        enc_mask = enc_tokens.eq(0)
+        dec_mask = dec_tokens.eq(0)
+
+        with torch.no_grad():
+            output_with_mask = dummy_model(
+                encoder_tokens=enc_tokens,
+                encoder_padding_mask=enc_mask,
+                decoder_tokens=dec_tokens,
+                decoder_padding_mask=dec_mask,
+            )
+            output_no_mask = dummy_model(
+                encoder_tokens=enc_tokens, decoder_tokens=dec_tokens
+            )
+
+        torch.testing.assert_close(
+            output_with_mask["decoder_output"],
+            output_no_mask["decoder_output"],
+            atol=1e-04,
+            rtol=2.5e-06,
+        )


### PR DESCRIPTION
Summary:
Added the following parameters to the `forward` method of the T5Model:
* `encoder_padding_mask`
* `decoder_padding_mask`

These allow users to specifically mask out the padding of input sequences. This matches the implementation of Transformers in PyTorch core.

Differential Revision: D40252794

