### PR TITLE
Use re instead of regex

### DIFF
--- a/packaging/torchtext/meta.yaml
+++ b/packaging/torchtext/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - python
     - requests
     - tqdm
-    - regex
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
 
 build:

--- a/torchtext/transforms.py
+++ b/torchtext/transforms.py
@@ -1,9 +1,9 @@
 import json
+import re
 from copy import deepcopy
 from functools import lru_cache
 from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
-import regex as re
 import torch
 import torchtext  # noqa: F401
 from torch import Tensor


### PR DESCRIPTION
Replaces https://github.com/pytorch/text/pull/1952

Fixes https://github.com/pytorch/text/issues/1951

Fixes issues introduced in https://github.com/pytorch/text/pull/1946

Uses the built-in `re` module instead of relying on [`regex`](https://pypi.org/project/regex)

Verified internally using:
```
$ buck2 test @mode/dev pytorch/text/test/torchtext_unittest:test_transforms
```

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>