### PR TITLE
[Nova] Updated Smoke Tests that Account for Recursive Import

### DIFF
--- a/test/smoke_tests/smoke_tests.py
+++ b/test/smoke_tests/smoke_tests.py
@@ -1,5 +1,6 @@
 """Run smoke tests"""
 
 import torchtext
+import torchtext.version  # noqa: F401
 
 print("torchtext version is ", torchtext.__version__)

--- a/test/smoke_tests/smoke_tests.py
+++ b/test/smoke_tests/smoke_tests.py
@@ -1,32 +1,5 @@
 """Run smoke tests"""
 
 import torchtext
-import torchtext.data  # noqa: F401
-import torchtext.data.batch  # noqa: F401
-import torchtext.data.dataset  # noqa: F401
-import torchtext.data.example  # noqa: F401
-import torchtext.data.field  # noqa: F401
-import torchtext.data.functional  # noqa: F401
-import torchtext.data.iterator  # noqa: F401
-import torchtext.data.metrics  # noqa: F401
-import torchtext.data.pipeline  # noqa: F401
-import torchtext.data.utils  # noqa: F401
-import torchtext.datasets  # noqa: F401
-import torchtext.datasets.babi  # noqa: F401
-import torchtext.datasets.imdb  # noqa: F401
-import torchtext.datasets.language_modeling  # noqa: F401
-import torchtext.datasets.nli  # noqa: F401
-import torchtext.datasets.sequence_tagging  # noqa: F401
-import torchtext.datasets.sst  # noqa: F401
-import torchtext.datasets.text_classification  # noqa: F401
-import torchtext.datasets.translation  # noqa: F401
-import torchtext.datasets.trec  # noqa: F401
-import torchtext.datasets.unsupervised_learning  # noqa: F401
-import torchtext.experimental  # noqa: F401
-import torchtext.experimental.datasets  # noqa: F401
-import torchtext.experimental.datasets.language_modeling  # noqa: F401
-import torchtext.experimental.datasets.text_classification  # noqa: F401
-import torchtext.utils  # noqa: F401
-import torchtext.vocab  # noqa: F401
 
 print("torchtext version is ", torchtext.__version__)


### PR DESCRIPTION
All the other modules are imported when we `import torchtext`, so no need to manually import them all. The recursive import can be seen here: https://github.com/pytorch/text/blob/main/torchtext/__init__.py#L12. There seem to be no lazily imported modules that we need to explicitly check for according to @abhinavarora. So these smoke tests should suffice.