### PR TITLE
[Nova] Increase Mac x86 CI Timeout

### DIFF
--- a/.github/workflows/test-macos-cpu.yml
+++ b/.github/workflows/test-macos-cpu.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       runner: macos-12
       repository: pytorch/text
+      timeout: 60
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/text/text


### PR DESCRIPTION
As mentioned in https://github.com/pytorch/text/pull/1969, the Unittests for Python3.10 on Mac x86 machines take ~40 minutes, both on GHA and CircleCI. Increasing the timeout for these jobs so they don't timeout.