### PR TITLE
[Nova] Pass the smoke test scripts to Reusable Workflow

### DIFF
--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -39,6 +39,7 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
       # Using "development" as trigger event so these binaries are not uploaded
       # to official channels yet
       trigger-event: development

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -37,6 +37,7 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
       # Using "development" as trigger event so these binaries are not uploaded
       # to official channels yet
       trigger-event: development

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -37,6 +37,7 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
       runner-type: macos-12
       # Using "development" as trigger event so these binaries are not uploaded
       # to official channels yet


### PR DESCRIPTION
If the smoke-test script is not passed to the reusable workflow, it will just use the naive smoke test implemented in the reusable workflow. Passing it (as we do here) will ensure the smoke test script that exists in this repo gets run after the build is complete.