### PR TITLE
[Nova] Migrate Mac Wheels and Conda Binaries off of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,18 +614,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_linux_wheel_py3.8
           python_version: '3.8'
-      - binary_macos_wheel:
-          name: binary_macos_wheel_py3.7
-          python_version: '3.7'
-      - binary_macos_wheel:
-          name: binary_macos_wheel_py3.8
-          python_version: '3.8'
-      - binary_macos_wheel:
-          name: binary_macos_wheel_py3.9
-          python_version: '3.9'
-      - binary_macos_wheel:
-          name: binary_macos_wheel_py3.10
-          python_version: '3.10'
       - binary_windows_wheel:
           name: binary_windows_wheel_py3.7
           python_version: '3.7'
@@ -637,18 +625,6 @@ workflows:
           python_version: '3.9'
       - binary_windows_wheel:
           name: binary_windows_wheel_py3.10
-          python_version: '3.10'
-      - binary_macos_conda:
-          name: binary_macos_conda_py3.7
-          python_version: '3.7'
-      - binary_macos_conda:
-          name: binary_macos_conda_py3.8
-          python_version: '3.8'
-      - binary_macos_conda:
-          name: binary_macos_conda_py3.9
-          python_version: '3.9'
-      - binary_macos_conda:
-          name: binary_macos_conda_py3.10
           python_version: '3.10'
       - binary_windows_conda:
           name: binary_windows_conda_py3.7
@@ -735,78 +711,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: nightly_binary_linux_wheel_py3.8
           python_version: '3.8'
-      - binary_macos_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.7
-          python_version: '3.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.7_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.7
-      - binary_macos_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.8
-          python_version: '3.8'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.8_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.8
-      - binary_macos_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.9
-          python_version: '3.9'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.9_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.9
-      - binary_macos_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.10
-          python_version: '3.10'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.10_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.10
       - binary_windows_wheel:
           filters:
             branches:
@@ -919,78 +823,6 @@ workflows:
           python_version: '3.10'
           requires:
           - nightly_binary_windows_wheel_py3.10_upload
-      - binary_macos_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.7
-          python_version: '3.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.7_upload
-          requires:
-          - nightly_binary_macos_conda_py3.7
-      - binary_macos_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.8
-          python_version: '3.8'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.8_upload
-          requires:
-          - nightly_binary_macos_conda_py3.8
-      - binary_macos_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.9
-          python_version: '3.9'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.9_upload
-          requires:
-          - nightly_binary_macos_conda_py3.9
-      - binary_macos_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.10
-          python_version: '3.10'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.10_upload
-          requires:
-          - nightly_binary_macos_conda_py3.10
       - binary_windows_conda:
           filters:
             branches:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -42,6 +42,8 @@ def build_workflows(prefix="", upload=False, filter_branch=None, indentation=6):
                     continue
                 if os_type == "linux" and btype == "conda":
                     continue
+                if os_type == "macos":
+                    continue
                 w += build_workflow_pair(btype, os_type, python_version, fb, prefix, upload)
 
     if not filter_branch:

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -43,6 +43,6 @@ jobs:
       runner-type: macos-m1-12
       # Using "development" as trigger event so these binaries are not uploaded
       # to official channels yet
-      trigger-event: development
+      trigger-event: ${{ github.event_name }}
     secrets:
       CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/build-conda-macos.yml
+++ b/.github/workflows/build-conda-macos.yml
@@ -43,6 +43,6 @@ jobs:
       runner-type: macos-12
       # Using "development" as trigger event so these binaries are not uploaded
       # to official channels yet
-      trigger-event: development
+      trigger-event: ${{ github.event_name }}
     secrets:
       CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -41,7 +41,7 @@ jobs:
       runner-type: macos-m1-12
       # Using "development" as trigger event so these binaries are not uploaded
       # to official channels yet
-      trigger-event: development
+      trigger-event: ${{ github.event_name }}
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
       AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -41,7 +41,7 @@ jobs:
       runner-type: macos-12
       # Using "development" as trigger event so these binaries are not uploaded
       # to official channels yet
-      trigger-event: development
+      trigger-event: ${{ github.event_name }}
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
       AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Disabling CircleCI Mac Wheels and Conda binary builds. Need to merge https://github.com/pytorch/text/pull/1990 after to remove the old M1 build workflow.