### PR TITLE
[Nova] Remove Linux and Mac Unittests from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,18 +666,6 @@ workflows:
           - build_docs
   unittest:
     jobs:
-      - unittest_linux:
-          name: unittest_linux_py3.7
-          python_version: '3.7'
-      - unittest_linux:
-          name: unittest_linux_py3.8
-          python_version: '3.8'
-      - unittest_linux:
-          name: unittest_linux_py3.9
-          python_version: '3.9'
-      - unittest_linux:
-          name: unittest_linux_py3.10
-          python_version: '3.10'
       - unittest_windows:
           name: unittest_windows_py3.7
           python_version: '3.7'
@@ -689,18 +677,6 @@ workflows:
           python_version: '3.9'
       - unittest_windows:
           name: unittest_windows_py3.10
-          python_version: '3.10'
-      - unittest_macos:
-          name: unittest_macos_py3.7
-          python_version: '3.7'
-      - unittest_macos:
-          name: unittest_macos_py3.8
-          python_version: '3.8'
-      - unittest_macos:
-          name: unittest_macos_py3.9
-          python_version: '3.9'
-      - unittest_macos:
-          name: unittest_macos_py3.10
           python_version: '3.10'
   nightly:
     jobs:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -159,7 +159,7 @@ def indent(indentation, data_list):
 
 def unittest_workflows(indentation=6):
     w = []
-    for os_type in ["linux", "windows", "macos"]:
+    for os_type in ["windows"]:
         for python_version in PYTHON_VERSIONS:
             w.append(
                 {


### PR DESCRIPTION
Linux and Mac Unittests are running via Nova/GHA for some time now. Deprecating the CircleCI ones.