### PR TITLE
[Nova] Remove CUDA binary builds

### DIFF
--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -15,6 +15,7 @@ jobs:
       os: linux
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
+      with-cuda: disable
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -15,6 +15,7 @@ jobs:
       os: linux
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
+      with-cuda: disable
   build:
     needs: generate-matrix
     strategy:


### PR DESCRIPTION
TorchText only has CPU binary builds, but our build matrix was including cuda builds as well. This should remove these unnecessary builds.