### PR TITLE
Move read_from_tar to load_from_tar

### DIFF
--- a/torchtext/datasets/stsb.py
+++ b/torchtext/datasets/stsb.py
@@ -93,7 +93,7 @@ def STSB(root, split):
 
     cache_decompressed_dp = cache_compressed_dp.on_disk_cache(filepath_fn=partial(_extracted_filepath_fn, root, split))
     cache_decompressed_dp = (
-        FileOpener(cache_decompressed_dp, mode="b").read_from_tar().filter(partial(_filter_fn, split))
+        FileOpener(cache_decompressed_dp, mode="b").load_from_tar().filter(partial(_filter_fn, split))
     )
     cache_decompressed_dp = cache_decompressed_dp.end_caching(mode="wb", same_filepath_fn=True)
 


### PR DESCRIPTION
Forward fix caused by deprecating PRs: https://github.com/pytorch/pytorch/pull/89794 and https://github.com/pytorch/data/pull/909
