### PR TITLE
[Nova] Simplify Caller Workflows

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -18,29 +18,18 @@ jobs:
       with-cuda: disable
   build:
     needs: generate-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - repository: pytorch/text
-            pre-script: packaging/install_torchdata.sh
-            post-script: ""
-            smoke-test-script: test/smoke_tests/smoke_tests.py
-            package-name: torchtext
-    name: ${{ matrix.repository }}
+    name: pytorch/text
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
-      repository: ${{ matrix.repository }}
+      repository: pytorch/text
       ref: ""
+      pre-script: packaging/install_torchdata.sh
+      post-script: ""
+      package-name: torchtext
+      smoke-test-script: test/smoke_tests/smoke_tests.py
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
-      package-name: ${{ matrix.package-name }}
-      smoke-test-script: ${{ matrix.smoke-test-script }}
-      # Using "development" as trigger event so these binaries are not uploaded
-      # to official channels yet
       trigger-event: ${{ github.event_name }}
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}


### PR DESCRIPTION
There's no need to have a matrix in the caller workflow. Let's just pass these inputs directly.