### PR TITLE
update multi30k test dataset hash

### DIFF
--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -20,7 +20,7 @@ URL = {
 MD5 = {
     "train": "20140d013d05dd9a72dfde46478663ba05737ce983f478f960c1123c6671be5e",
     "valid": "a7aa20e9ebd5ba5adce7909498b94410996040857154dab029851af3a866da8c",
-    "test": "6d1ca1dba99e2c5dd54cae1226ff11c2551e6ce63527ebb072a1f70f72a5cd36",
+    "test": "0681be16a532912288a91ddd573594fbdd57c0fbb81486eff7c55247e35326c2",
 }
 
 _PREFIX = {


### PR DESCRIPTION
**Description**
- This diff changes the expected hash of the test data set back to what it was before https://github.com/pytorch/text/pull/1816 as that hash seems to be expected now. 
- fixes the bug reported here https://github.com/pytorch/text/issues/2001

**Testing**
```
import torchtext

def _main():
    train, val, test = torchtext.datasets.Multi30k(language_pair=("de", "en"))
    for thing in test:
        print(thing)
        break

if __name__ == "__main__":
    _main()
```

Above script now works