### PR TITLE
Fix device setting for T5 model

### DIFF
--- a/torchtext/prototype/models/t5/model.py
+++ b/torchtext/prototype/models/t5/model.py
@@ -183,7 +183,10 @@ class T5Model(nn.Module):
 
             # decoder_tokens is None means at start of inference, in which case decoder sequence should begin with padding idx.
             if decoder_tokens is None:
-                decoder_tokens = torch.ones((encoder_tokens.size(0), 1), device=encoder_tokens.device, dtype=torch.long) * self.padding_idx
+                decoder_tokens = (
+                    torch.ones((encoder_tokens.size(0), 1), device=encoder_tokens.device, dtype=torch.long)
+                    * self.padding_idx
+                )
 
             if decoder_mask is None:
                 assert decoder_tokens is not None and decoder_tokens.dim() == 2

--- a/torchtext/prototype/models/t5/model.py
+++ b/torchtext/prototype/models/t5/model.py
@@ -85,7 +85,6 @@ class T5Model(nn.Module):
         self.padding_idx = config.padding_idx
         self.training = config.training
         self.dropout = config.dropout if config.training else 0.0
-        self.device = device
         self.dtype = dtype
 
         self.token_embeddings = nn.Embedding(config.vocab_size, config.embedding_dim, config.padding_idx)
@@ -184,13 +183,13 @@ class T5Model(nn.Module):
 
             # decoder_tokens is None means at start of inference, in which case decoder sequence should begin with padding idx.
             if decoder_tokens is None:
-                decoder_tokens = torch.ones((encoder_tokens.size(0), 1), dtype=torch.long) * self.padding_idx
+                decoder_tokens = torch.ones((encoder_tokens.size(0), 1), device=encoder_tokens.device, dtype=torch.long) * self.padding_idx
 
             if decoder_mask is None:
                 assert decoder_tokens is not None and decoder_tokens.dim() == 2
                 tgt_len = decoder_tokens.shape[1]
                 decoder_mask = torch.triu(torch.ones((tgt_len, tgt_len), dtype=torch.float64), diagonal=1)
-                decoder_mask = decoder_mask.to(self.device, dtype=torch.bool)
+                decoder_mask = decoder_mask.to(decoder_tokens.device, dtype=torch.bool)
 
             decoder_padding_mask = decoder_tokens.eq(self.padding_idx)
             # T5 implemention uses padding idx to start sequence. Want to ignore this when masking

--- a/torchtext/prototype/models/t5/modules.py
+++ b/torchtext/prototype/models/t5/modules.py
@@ -255,10 +255,7 @@ class T5MultiheadAttention(nn.MultiheadAttention):
                 ).unsqueeze(0)
             else:
                 position_bias = self._compute_bias(
-                    tgt_len,
-                    src_len,
-                    bidirectional=(not self.is_decoder),
-                    device=k.device
+                    tgt_len, src_len, bidirectional=(not self.is_decoder), device=k.device
                 )
 
         # Calculate attention and out projection
@@ -404,11 +401,7 @@ class T5MultiheadAttention(nn.MultiheadAttention):
 
     # NOTE: Modified from https://github.com/huggingface/transformers/blob/8581a798c0a48fca07b29ce2ca2ef55adcae8c7e/src/transformers/models/t5/modeling_t5.py#L421
     def _compute_bias(
-        self,
-        query_length: int,
-        key_length: int,
-        bidirectional: bool = True,
-        device: Optional[torch.device] = None
+        self, query_length: int, key_length: int, bidirectional: bool = True, device: Optional[torch.device] = None
     ) -> Tensor:
         """Compute binned relative position bias"""
         assert self.relative_attention_bias is not None

--- a/torchtext/prototype/models/t5/modules.py
+++ b/torchtext/prototype/models/t5/modules.py
@@ -74,8 +74,6 @@ class T5MultiheadAttention(nn.MultiheadAttention):
         else:
             self.relative_attention_bias = None
 
-        self.device = device
-
     def forward(
         self,
         query: Tensor,
@@ -260,6 +258,7 @@ class T5MultiheadAttention(nn.MultiheadAttention):
                     tgt_len,
                     src_len,
                     bidirectional=(not self.is_decoder),
+                    device=k.device
                 )
 
         # Calculate attention and out projection
@@ -409,11 +408,12 @@ class T5MultiheadAttention(nn.MultiheadAttention):
         query_length: int,
         key_length: int,
         bidirectional: bool = True,
+        device: Optional[torch.device] = None
     ) -> Tensor:
         """Compute binned relative position bias"""
         assert self.relative_attention_bias is not None
-        context_position = torch.arange(query_length, dtype=torch.long, device=self.device)[:, None]
-        memory_position = torch.arange(key_length, dtype=torch.long, device=self.device)[None, :]
+        context_position = torch.arange(query_length, dtype=torch.long, device=device)[:, None]
+        memory_position = torch.arange(key_length, dtype=torch.long, device=device)[None, :]
         relative_position = memory_position - context_position  # shape (query_length, key_length)
         relative_position_bucket = self._relative_position_bucket(
             relative_position,  # shape (query_length, key_length)
@@ -446,7 +446,7 @@ class T5MultiheadAttention(nn.MultiheadAttention):
         Returns:
             a Tensor with the same shape as relative_position, containing int32 values in the range [0, num_buckets)
         """
-        relative_buckets = torch.zeros(relative_position.shape, dtype=torch.long, device=self.device)
+        relative_buckets = torch.zeros(relative_position.shape, dtype=torch.long, device=relative_position.device)
         if bidirectional:
             num_buckets = num_buckets // 2
             relative_buckets += (relative_position > 0).to(torch.long) * num_buckets


### PR DESCRIPTION
Fixing 🐛 in T5Model when putting both model and input on GPUs.

Trace:
```
Traceback (most recent call last):
  File "<string>", line 38, in <module>
  File "<string>", line 36, in __run
  File "/usr/local/fbcode/platform010/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/fbcode/platform010/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/scripts/fni/d2go_scripts/torchtext_t5_tutorial.py", line 25, in <module>
    output = model(model_input)["decoder_output"]
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torch/nn/modules/module.py", line 1480, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torchtext/prototype/models/t5/model.py", line 173, in forward
    encoder_output, encoder_hidden_states, encoder_position_bias, encoder_sa = self.encoder(
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torch/nn/modules/module.py", line 1480, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torchtext/prototype/models/t5/modules.py", line 863, in forward
    output, position_bias, sa_score = mod(
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torch/nn/modules/module.py", line 1480, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torchtext/prototype/models/t5/modules.py", line 614, in forward
    sa_out, position_bias, sa_scores = self._sa_block(self.norm1(x), tgt_mask, tgt_key_padding_mask, position_bias)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torchtext/prototype/models/t5/modules.py", line 628, in _sa_block
    attn = self.self_attn(
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torch/nn/modules/module.py", line 1480, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torchtext/prototype/models/t5/modules.py", line 134, in forward
    attn_output, position_bias, attn_output_weights = self._t5_multi_head_attention_forward(
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torchtext/prototype/models/t5/modules.py", line 259, in _t5_multi_head_attention_forward
    position_bias = self._compute_bias(
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torchtext/prototype/models/t5/modules.py", line 424, in _compute_bias
    values = self.relative_attention_bias(relative_position_bucket)  # shape (query_length, key_length, num_heads)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torch/nn/modules/module.py", line 1480, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torch/nn/modules/sparse.py", line 162, in forward
    return F.embedding(
  File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/104a4d5c3a690252/scripts/fni/d2go_scripts/__torchtext_t5_tutorial__/torchtext_t5_tutorial#link-tree/torch/nn/functional.py", line 2210, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper__index_select)
```

Fix was to remove the `.device` attribute from the model, as it misleadingly made it seem that the entire model would be guaranteed to be on the same device, when in fact, the model could be sharded across different GPUs. Without this attribute, any new tensors created will be placed on the device of the already created or passed-in tensors.

GPU test will be added in a follow-up diff as we want this to land ASAP.