### PR TITLE
Rename variable to avoid conflict with PIP system variable PIP_PREFIX

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -14,7 +14,7 @@ export PIP_DOWNLOAD_URL="https://download.pytorch.org/whl/cpu"
 export PIP_PREFIX=""
 
 if [[ ${CHANNEL} = 'nightly' ]]; then
-    export PIP_PREFIX="--pre "
+    export TEXT_PIP_PREFIX="--pre "
     export PIP_DOWNLOAD_URL="https://download.pytorch.org/whl/nightly/cpu"
     export CONDA_CHANNEL="pytorch-nightly"
 elif [[ ${CHANNEL} = 'test' ]]; then
@@ -25,7 +25,7 @@ fi
 if [[ ${PACKAGE_TYPE} = 'conda' ]]; then
     conda install -y torchtext pytorch -c ${CONDA_CHANNEL}
 else
-    pip install ${PIP_PREFIX} torchtext torch --extra-index-url ${PIP_DOWNLOAD_URL}
+    pip install ${TEXT_PIP_PREFIX} torchtext torch --extra-index-url ${PIP_DOWNLOAD_URL}
 fi
 
 python  ./test/smoke_tests/smoke_tests.py


### PR DESCRIPTION
Fix failures in  https://github.com/pytorch/text/actions/runs/3742919848/jobs/6354468925
The failure was because the script defined "PIP_PREFIX = --pre " then pip install --pre torch torchtext command would install into the PIP_PREFIX directory, in this case '--pre ' directory. 

Solution: rename the PIP_PREFIX to TEXT_PIP_PREFIX to avoid this conflict. 