### PR TITLE
Migrate Validation Workflows to test-infra. Simplify setup logic

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -1,22 +1,8 @@
-conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION} numpy
-conda activate ${ENV_NAME}
-export CONDA_CHANNEL="pytorch"
-export PIP_DOWNLOAD_URL="https://download.pytorch.org/whl/cpu"
-export TEXT_PIP_PREFIX=""
-
-if [[ ${MATRIX_CHANNEL} = "nightly" ]]; then
-    export TEXT_PIP_PREFIX="--pre"
-    export PIP_DOWNLOAD_URL="https://download.pytorch.org/whl/nightly/cpu"
-    export CONDA_CHANNEL="pytorch-nightly"
-elif [[ ${MATRIX_CHANNEL} = "test" ]]; then
-    export PIP_DOWNLOAD_URL="https://download.pytorch.org/whl/test/cpu"
-    export CONDA_CHANNEL="pytorch-test"
-fi
 
 if [[ ${MATRIX_PACKAGE_TYPE} = "conda" ]]; then
-    conda install -y torchtext pytorch -c ${CONDA_CHANNEL}
+    conda install -y torchtext -c ${PYTORCH_CONDA_CHANNEL}
 else
-    pip install ${TEXT_PIP_PREFIX} torchtext torch --extra-index-url ${PIP_DOWNLOAD_URL}
+    pip install ${PYTORCH_PIP_PREFIX} torchtext --extra-index-url ${PYTORCH_PIP_DOWNLOAD_URL}
 fi
 
 python  ./test/smoke_tests/smoke_tests.py

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -45,10 +45,11 @@ on:
         type: string
 jobs:
   validate-binaries:
-    uses: pytorch/builder/.github/workflows/validate-domain-library.yml@main
+    uses: pytorch/test-infra/.github/workflows/validate-domain-library.yml@main
     with:
       package_type: "conda,wheel"
       os: ${{ inputs.os }}
       channel: ${{ inputs.channel }}
       repository: "pytorch/text"
       smoke_test: "source ./.github/scripts/validate_binaries.sh"
+      install_torch: true


### PR DESCRIPTION
Migrated DL validation to test-infra. Added torch pre-install. This simplifies logic needed to be added to Domain Library side.