### PR TITLE
[CHERRY PICK] flan t5 torchtext (#2027)

### DIFF
--- a/test/integration_tests/prototype/test_models.py
+++ b/test/integration_tests/prototype/test_models.py
@@ -4,15 +4,15 @@ import pytest  # noqa: F401
 import torch
 from parameterized import parameterized, parameterized_class
 from torchtext.prototype.models import (
-    T5_BASE_ENCODER,
     T5_BASE,
+    T5_BASE_ENCODER,
     T5_BASE_GENERATION,
-    T5_SMALL_ENCODER,
-    T5_SMALL,
-    T5_SMALL_GENERATION,
-    T5_LARGE_ENCODER,
     T5_LARGE,
+    T5_LARGE_ENCODER,
     T5_LARGE_GENERATION,
+    T5_SMALL,
+    T5_SMALL_ENCODER,
+    T5_SMALL_GENERATION,
     T5Conf,
     T5Transform,
 )
@@ -21,7 +21,7 @@ from torchtext.prototype.models.t5.wrapper import T5Wrapper
 from torchtext_unittest.common.assets import get_asset_path
 from torchtext_unittest.common.parameterized_utils import nested_params
 from torchtext_unittest.common.torchtext_test_case import TorchtextTestCase
-from transformers import T5Model, T5EncoderModel, T5ForConditionalGeneration
+from transformers import T5EncoderModel, T5ForConditionalGeneration, T5Model
 
 BUNDLERS = {
     "base_model": T5_BASE,
@@ -254,7 +254,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
             our_output = our_t5(self.encoder_input_ids, self.decoder_input_ids)
 
             self.check_outputs_of_models(our_output, hf_output, our_t5.config, False)
-    
+
     def test_flan_t5_bundler_load_hf_ckpt_pretrained_encoder_decoder(self) -> None:
-        #TODO(joecummings): Download FLAN-T5 chkpts and test here
+        # TODO(joecummings): Download FLAN-T5 chkpts and test here
         pass

--- a/test/integration_tests/prototype/test_models.py
+++ b/test/integration_tests/prototype/test_models.py
@@ -114,7 +114,7 @@ class TestT5Wrapper(TorchtextTestCase):
 
         beam_size = 3
         max_seq_len = 512
-        model = T5Wrapper(configuration=configuration)
+        model = T5Wrapper(configuration=configuration, strict=False)
         if name == "jit":
             model = torch.jit.script(model)
 
@@ -195,10 +195,10 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model_path = f"{tmp_dir}/hf_t5_small_enc"
 
-            t5_small_enc = T5EncoderModel.from_pretrained("t5-small", encoder_only=True)
+            t5_small_enc = T5EncoderModel.from_pretrained("t5-small")
             t5_small_enc.save_pretrained(model_path)
 
-            our_encoder = T5Bundle.build_model_from_huggingface_ckpt(model_path)
+            our_encoder = T5Bundle.build_model_from_huggingface_ckpt(model_path, encoder_only=True)
 
             hf_output = t5_small_enc(
                 input_ids=self.encoder_input_ids,
@@ -209,7 +209,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
 
             our_output = our_encoder(self.encoder_input_ids)
 
-            self.check_outputs_of_models(our_output, hf_output, our_encoder.config, encoder_only=True)
+            self.check_outputs_of_models(our_output, hf_output, our_encoder.config, True)
 
     def test_t5_bundler_load_hf_ckpt_pretrained_encoder_decoder(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -218,7 +218,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
             t5_small = T5Model.from_pretrained("t5-small")
             t5_small.save_pretrained(model_path)
 
-            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path, encoder_only=False)
+            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path)
 
             hf_output = t5_small(
                 input_ids=self.encoder_input_ids,
@@ -231,7 +231,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
 
             our_output = our_t5(self.encoder_input_ids, self.decoder_input_ids)
 
-            self.check_outputs_of_models(our_output, hf_output, our_t5.config, encoder_only=False)
+            self.check_outputs_of_models(our_output, hf_output, our_t5.config, False)
 
     def test_t5_bundler_load_hf_ckpt_pretrained_encoder_decoder_with_gen(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -240,7 +240,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
             t5_small_gen = T5ForConditionalGeneration.from_pretrained("t5-small")
             t5_small_gen.save_pretrained(model_path)
 
-            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path, encoder_only=False)
+            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path)
 
             hf_output = t5_small_gen(
                 input_ids=self.encoder_input_ids,
@@ -253,4 +253,8 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
 
             our_output = our_t5(self.encoder_input_ids, self.decoder_input_ids)
 
-            self.check_outputs_of_models(our_output, hf_output, our_t5.config, encoder_only=False)
+            self.check_outputs_of_models(our_output, hf_output, our_t5.config, False)
+    
+    def test_flan_t5_bundler_load_hf_ckpt_pretrained_encoder_decoder(self) -> None:
+        #TODO(joecummings): Download FLAN-T5 chkpts and test here
+        pass

--- a/test/integration_tests/prototype/test_models.py
+++ b/test/integration_tests/prototype/test_models.py
@@ -195,7 +195,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model_path = f"{tmp_dir}/hf_t5_small_enc"
 
-            t5_small_enc = T5EncoderModel.from_pretrained("t5-small")
+            t5_small_enc = T5EncoderModel.from_pretrained("t5-small", encoder_only=True)
             t5_small_enc.save_pretrained(model_path)
 
             our_encoder = T5Bundle.build_model_from_huggingface_ckpt(model_path)
@@ -218,7 +218,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
             t5_small = T5Model.from_pretrained("t5-small")
             t5_small.save_pretrained(model_path)
 
-            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path)
+            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path, encoder_only=False)
 
             hf_output = t5_small(
                 input_ids=self.encoder_input_ids,
@@ -240,7 +240,7 @@ class TestLoadFromHFCheckpoints(TorchtextTestCase):
             t5_small_gen = T5ForConditionalGeneration.from_pretrained("t5-small")
             t5_small_gen.save_pretrained(model_path)
 
-            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path)
+            our_t5 = T5Bundle.build_model_from_huggingface_ckpt(model_path, encoder_only=False)
 
             hf_output = t5_small_gen(
                 input_ids=self.encoder_input_ids,

--- a/torchtext/prototype/models/t5/bundler.py
+++ b/torchtext/prototype/models/t5/bundler.py
@@ -118,7 +118,6 @@ class T5Bundle:
             strict (bool): Passed to :func: `torch.nn.Module.load_state_dict` method. (Default: `False`)
             dl_kwargs (dictionary of keyword arguments): Passed to :func:`torch.hub.load_state_dict_from_url`. (Default: `None`)
         """
-
         model = T5Model(config, freeze_model)
         if checkpoint is not None:
             if torch.jit.isinstance(checkpoint, Dict[str, torch.Tensor]):
@@ -138,7 +137,7 @@ class T5Bundle:
     @staticmethod
     def build_model_from_huggingface_ckpt(
         ckpt_path: Union[str, os.PathLike],
-        encoder_only: bool,
+        encoder_only: bool = False,
         *,
         freeze_model: bool = False,
         strict: bool = True,
@@ -162,7 +161,6 @@ class T5Bundle:
             config_json = json.load(handle)
         hf_weights = torch.load(model_path)
 
-        # TODO(joecummings): find better way to determine `encoder_only` and `linear_head`
         config = T5Conf(
             encoder_only=encoder_only,
             linear_head="lm_head.weight" in hf_weights.keys(),
@@ -194,7 +192,6 @@ class T5Bundle:
                 t5_model_state_dict[f"encoder.layers.{i}.linear1_1.weight"] = hf_weights[
                     f"encoder.block.{i}.layer.1.DenseReluDense.wi_1.weight"
                 ]
-
             else:
                 t5_model_state_dict[f"encoder.layers.{i}.linear1.weight"] = hf_weights[
                     f"encoder.block.{i}.layer.1.DenseReluDense.wi.weight"
@@ -230,9 +227,20 @@ class T5Bundle:
             ]
 
             for i in range(config.num_decoder_layers):
-                t5_model_state_dict[f"decoder.layers.{i}.linear1.weight"] = hf_weights[
-                    f"decoder.block.{i}.layer.2.DenseReluDense.wi.weight"
-                ]
+
+                if config.is_gated_act:
+                    t5_model_state_dict[f"encoder.layers.{i}.linear1_0.weight"] = hf_weights[
+                        f"decoder.block.{i}.layer.1.DenseReluDense.wi_0.weight"
+                    ]
+
+                    t5_model_state_dict[f"encoder.layers.{i}.linear1_1.weight"] = hf_weights[
+                        f"decoder.block.{i}.layer.1.DenseReluDense.wi_1.weight"
+                    ]
+                else:
+                    t5_model_state_dict[f"decoder.layers.{i}.linear1.weight"] = hf_weights[
+                        f"decoder.block.{i}.layer.2.DenseReluDense.wi.weight"
+                    ]
+
                 t5_model_state_dict[f"decoder.layers.{i}.linear2.weight"] = hf_weights[
                     f"decoder.block.{i}.layer.2.DenseReluDense.wo.weight"
                 ]
@@ -277,7 +285,7 @@ class T5Bundle:
             t5_model_state_dict["lm_head.weight"] = hf_weights["lm_head.weight"]
 
         # Load state dict into our model
-        t5_model.load_state_dict(t5_model_state_dict, strict)
+        t5_model.load_state_dict(t5_model_state_dict, strict=False)
 
         return t5_model
 

--- a/torchtext/prototype/models/t5/bundler.py
+++ b/torchtext/prototype/models/t5/bundler.py
@@ -138,6 +138,7 @@ class T5Bundle:
     @staticmethod
     def build_model_from_huggingface_ckpt(
         ckpt_path: Union[str, os.PathLike],
+        encoder_only: bool,
         *,
         freeze_model: bool = False,
         strict: bool = True,
@@ -163,13 +164,14 @@ class T5Bundle:
 
         # TODO(joecummings): find better way to determine `encoder_only` and `linear_head`
         config = T5Conf(
-            encoder_only="decoder.final_layer_norm.weight" not in hf_weights.keys(),
+            encoder_only=encoder_only,
             linear_head="lm_head.weight" in hf_weights.keys(),
             embedding_dim=config_json["d_model"],
             num_attention_heads=config_json["num_heads"],
             num_encoder_layers=config_json["num_layers"],
             num_decoder_layers=config_json["num_decoder_layers"],
             ffn_dimension=config_json["d_ff"],
+            feed_forward_proj=config_json.get("feed_forward_proj"),
         )
 
         t5_model = T5Model(config, freeze_model)
@@ -184,9 +186,20 @@ class T5Bundle:
         }
         # Convert encoder layers
         for i in range(config.num_encoder_layers):
-            t5_model_state_dict[f"encoder.layers.{i}.linear1.weight"] = hf_weights[
-                f"encoder.block.{i}.layer.1.DenseReluDense.wi.weight"
-            ]
+            if config.is_gated_act:
+                t5_model_state_dict[f"encoder.layers.{i}.linear1_0.weight"] = hf_weights[
+                    f"encoder.block.{i}.layer.1.DenseReluDense.wi_0.weight"
+                ]
+
+                t5_model_state_dict[f"encoder.layers.{i}.linear1_1.weight"] = hf_weights[
+                    f"encoder.block.{i}.layer.1.DenseReluDense.wi_1.weight"
+                ]
+
+            else:
+                t5_model_state_dict[f"encoder.layers.{i}.linear1.weight"] = hf_weights[
+                    f"encoder.block.{i}.layer.1.DenseReluDense.wi.weight"
+                ]
+
             t5_model_state_dict[f"encoder.layers.{i}.linear2.weight"] = hf_weights[
                 f"encoder.block.{i}.layer.1.DenseReluDense.wo.weight"
             ]

--- a/torchtext/prototype/models/t5/model.py
+++ b/torchtext/prototype/models/t5/model.py
@@ -43,7 +43,7 @@ class T5Conf:
         if self.feed_forward_proj:
             act_info = self.feed_forward_proj.split("-")
             self.activation = act_info[-1]
-            self.is_gated_act = (act_info[0] == "gated")
+            self.is_gated_act = act_info[0] == "gated"
 
             if len(act_info) > 1 and act_info[0] != "gated" or len(act_info) > 2:
                 raise ValueError(

--- a/torchtext/prototype/models/t5/model.py
+++ b/torchtext/prototype/models/t5/model.py
@@ -33,7 +33,7 @@ class T5Conf:
     is_gated_act: bool = False
 
     def __post_init__(self):
-        """ The following is modified from:
+        """The following is modified from:
         https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/configuration_t5.py
 
         It's to support T5 1.1 and FLAN-T5.

--- a/torchtext/prototype/models/t5/model.py
+++ b/torchtext/prototype/models/t5/model.py
@@ -33,8 +33,7 @@ class T5Conf:
     is_gated_act: bool = False
 
     def __post_init__(self):
-        """
-        the following is modified from
+        """ The following is modified from:
         https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/configuration_t5.py
 
         It's to support T5 1.1 and FLAN-T5.
@@ -145,6 +144,7 @@ class T5Model(nn.Module):
                 layer_norm_eps=config.layer_norm_eps,
                 relative_attention_num_buckets=config.relative_attention_num_buckets,
                 relative_attention_max_distance=config.relative_attention_max_distance,
+                is_gated_act=config.is_gated_act,
                 device=device,
                 dtype=dtype,
             )

--- a/torchtext/prototype/models/t5/modules.py
+++ b/torchtext/prototype/models/t5/modules.py
@@ -542,7 +542,6 @@ class T5EncoderLayer(nn.Module):
         relative_attention_max_distance: int = 128,
         is_gated_act: bool = False,
         compute_relative_attention_bias: bool = False,
-
         device: Optional[torch.device] = None,
         dtype=None,
     ) -> None:
@@ -593,7 +592,7 @@ class T5EncoderLayer(nn.Module):
                 self.activation = F.gelu
             elif activation == "gelu_new":
                 # the following should match the math of https://github.com/huggingface/transformers/blob/main/src/transformers/activations.py
-                self.activation = nn.GELU(approximate='tanh')
+                self.activation = nn.GELU(approximate="tanh")
         else:
             self.activation = activation
 

--- a/torchtext/prototype/models/t5/modules.py
+++ b/torchtext/prototype/models/t5/modules.py
@@ -540,7 +540,9 @@ class T5EncoderLayer(nn.Module):
         layer_norm_eps: float = 1e-6,
         relative_attention_num_buckets: int = 32,
         relative_attention_max_distance: int = 128,
+        is_gated_act: bool = False,
         compute_relative_attention_bias: bool = False,
+
         device: Optional[torch.device] = None,
         dtype=None,
     ) -> None:
@@ -549,6 +551,7 @@ class T5EncoderLayer(nn.Module):
         self.compute_relative_attention_bias = compute_relative_attention_bias
         self.relative_attention_num_buckets = relative_attention_num_buckets
         self.relative_attention_max_distance = relative_attention_max_distance
+        self.is_gated_act = is_gated_act
 
         self.self_attn = T5MultiheadAttention(
             d_model,
@@ -562,7 +565,15 @@ class T5EncoderLayer(nn.Module):
             device=device,
             dtype=dtype,
         )
-        self.linear1 = nn.Linear(d_model, dim_feedforward, bias=False)
+
+        if self.is_gated_act:
+            self.linear1 = None
+            self.linear1_0 = nn.Linear(d_model, dim_feedforward, bias=False)
+            self.linear1_1 = nn.Linear(d_model, dim_feedforward, bias=False)
+        else:
+            self.linear1 = nn.Linear(d_model, dim_feedforward, bias=False)
+            self.linear1_0 = None
+            self.linear1_1 = None
         self.linear2 = nn.Linear(dim_feedforward, d_model, bias=False)
         self.norm1 = T5LayerNorm(d_model, eps=layer_norm_eps)
         self.norm2 = T5LayerNorm(d_model, eps=layer_norm_eps)
@@ -574,11 +585,15 @@ class T5EncoderLayer(nn.Module):
             assert activation in (
                 "relu",
                 "gelu",
-            ), f"Do not support '{activation}' activation. Use either 'relu' or 'gelu'"
+                "gelu_new",
+            ), f"Do not support '{activation}' activation. Use 'relu' or 'gelu' or 'gelu_new'"
             if activation == "relu":
                 self.activation = F.relu
             elif activation == "gelu":
                 self.activation = F.gelu
+            elif activation == "gelu_new":
+                # the following should match the math of https://github.com/huggingface/transformers/blob/main/src/transformers/activations.py
+                self.activation = nn.GELU(approximate='tanh')
         else:
             self.activation = activation
 
@@ -637,8 +652,19 @@ class T5EncoderLayer(nn.Module):
 
     # Feed forward block
     def _ff_block(self, x: Tensor) -> Tensor:
-        x = self.linear2(self.dropout2(self.activation(self.linear1(x))))
-        return self.dropout3(x)
+        if self.is_gated_act:
+            wi_0 = self.activation(self.linear1_0(x))
+            wi_1 = self.linear1_1(x)
+            hidden_states = wi_0 * wi_1
+            hidden_states = self.dropout2(hidden_states)
+            hidden_states = self.linear2(hidden_states)
+            hidden_states = self.dropout3(hidden_states)
+            return hidden_states
+
+        else:
+            assert self.linear1 is not None
+            x = self.linear2(self.dropout2(self.activation(self.linear1(x))))
+            return self.dropout3(x)
 
 
 # NOTE: Comparable HuggingFace implentation can be found at https://github.com/huggingface/transformers/blob/8581a798c0a48fca07b29ce2ca2ef55adcae8c7e/src/transformers/models/t5/modeling_t5.py#L622
@@ -810,6 +836,7 @@ class T5Encoder(nn.Module):
         relative_attention_num_buckets: int = 32,
         relative_attention_max_distance: int = 128,
         token_embeddings: Optional[nn.Module] = None,
+        is_gated_act: bool = False,
         device: Optional[torch.device] = None,
         dtype=None,
     ) -> None:
@@ -827,6 +854,7 @@ class T5Encoder(nn.Module):
                     layer_norm_eps,
                     relative_attention_num_buckets,
                     relative_attention_max_distance,
+                    is_gated_act,
                     compute_relative_attention_bias=True if i == 0 else False,
                     device=device,
                     dtype=dtype,

--- a/torchtext/prototype/models/t5/modules.py
+++ b/torchtext/prototype/models/t5/modules.py
@@ -652,18 +652,17 @@ class T5EncoderLayer(nn.Module):
     # Feed forward block
     def _ff_block(self, x: Tensor) -> Tensor:
         if self.is_gated_act:
+            assert self.linear1_0 is not None
+            assert self.linear1_1 is not None
             wi_0 = self.activation(self.linear1_0(x))
             wi_1 = self.linear1_1(x)
             hidden_states = wi_0 * wi_1
             hidden_states = self.dropout2(hidden_states)
             hidden_states = self.linear2(hidden_states)
-            hidden_states = self.dropout3(hidden_states)
-            return hidden_states
-
         else:
             assert self.linear1 is not None
-            x = self.linear2(self.dropout2(self.activation(self.linear1(x))))
-            return self.dropout3(x)
+            hidden_states = self.linear2(self.dropout2(self.activation(self.linear1(x))))
+        return self.dropout3(hidden_states)
 
 
 # NOTE: Comparable HuggingFace implentation can be found at https://github.com/huggingface/transformers/blob/8581a798c0a48fca07b29ce2ca2ef55adcae8c7e/src/transformers/models/t5/modeling_t5.py#L622
@@ -710,6 +709,7 @@ class T5DecoderLayer(T5EncoderLayer):
         relative_attention_num_buckets: int = 32,
         relative_attention_max_distance: int = 128,
         compute_relative_attention_bias: bool = False,
+        is_gated_act: bool = False,
         device: Optional[torch.device] = None,
         dtype=None,
     ) -> None:
@@ -723,6 +723,7 @@ class T5DecoderLayer(T5EncoderLayer):
             layer_norm_eps,
             relative_attention_num_buckets,
             relative_attention_max_distance,
+            is_gated_act,
             compute_relative_attention_bias,
             device,
             dtype,
@@ -961,6 +962,7 @@ class T5Decoder(nn.Module):
         layer_norm_eps: float = 1e-6,
         relative_attention_num_buckets: int = 32,
         relative_attention_max_distance: int = 128,
+        is_gated_act: bool = False,
         device: Optional[torch.device] = None,
         dtype=None,
     ) -> None:
@@ -979,6 +981,7 @@ class T5Decoder(nn.Module):
                     relative_attention_num_buckets,
                     relative_attention_max_distance,
                     compute_relative_attention_bias=True if i == 0 else False,
+                    is_gated_act=is_gated_act,
                     device=device,
                     dtype=dtype,
                 )


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/text/pull/2027

[d2go] flan t5 torchtext

This enables support for FLAN-T5 in Torchtext.

So far, we have only enabled FLAN-T5 encoder-only models. If we need to have an encoder-decoder model, it would be straightforward to add support for that.

Reviewed By: joecummings

Differential Revision: D42159825

fbshipit-source-id: 6c2a4430df890131e18d3ebe40bba35ecc6b25b8