### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
 
   lint_python_and_config:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run:
@@ -107,7 +107,7 @@ jobs:
 
   lint_c:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - run:
           name: Install additional system libraries
@@ -620,9 +620,6 @@ workflows:
           name: binary_linux_wheel_py3.8
           python_version: '3.8'
       - binary_windows_wheel:
-          name: binary_windows_wheel_py3.7
-          python_version: '3.7'
-      - binary_windows_wheel:
           name: binary_windows_wheel_py3.8
           python_version: '3.8'
       - binary_windows_wheel:
@@ -631,9 +628,6 @@ workflows:
       - binary_windows_wheel:
           name: binary_windows_wheel_py3.10
           python_version: '3.10'
-      - binary_windows_conda:
-          name: binary_windows_conda_py3.7
-          python_version: '3.7'
       - binary_windows_conda:
           name: binary_windows_conda_py3.8
           python_version: '3.8'
@@ -667,9 +661,6 @@ workflows:
   unittest:
     jobs:
       - unittest_windows:
-          name: unittest_windows_py3.7
-          python_version: '3.7'
-      - unittest_windows:
           name: unittest_windows_py3.8
           python_version: '3.8'
       - unittest_windows:
@@ -692,34 +683,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: nightly_binary_linux_wheel_py3.8
           python_version: '3.8'
-      - binary_windows_wheel:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.7
-          python_version: '3.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.7_upload
-          requires:
-          - nightly_binary_windows_wheel_py3.7
-      - smoke_test_windows_pip:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.7_smoke_test_pip
-          python_version: '3.7'
-          requires:
-          - nightly_binary_windows_wheel_py3.7_upload
       - binary_windows_wheel:
           filters:
             branches:
@@ -804,34 +767,6 @@ workflows:
           python_version: '3.10'
           requires:
           - nightly_binary_windows_wheel_py3.10_upload
-      - binary_windows_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.7
-          python_version: '3.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.7_upload
-          requires:
-          - nightly_binary_windows_conda_py3.7
-      - smoke_test_windows_conda:
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.7_smoke_test_conda
-          python_version: '3.7'
-          requires:
-          - nightly_binary_windows_conda_py3.7_upload
       - binary_windows_conda:
           filters:
             branches:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -88,7 +88,7 @@ jobs:
 
   lint_python_and_config:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run:
@@ -107,7 +107,7 @@ jobs:
 
   lint_c:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - run:
           name: Install additional system libraries

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,7 +21,7 @@ import yaml
 from jinja2 import select_autoescape
 
 
-PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
 
 DOC_VERSION = ("linux", "3.8")
 

--- a/.circleci/smoke_test/docker/Dockerfile
+++ b/.circleci/smoke_test/docker/Dockerfile
@@ -21,14 +21,12 @@ RUN apt-get -qq update && apt-get -qq -y install curl bzip2 sox libsox-dev libso
 ENV PATH /opt/conda/bin:$PATH
 
 
-RUN conda create -y --name python3.7 python=3.7
 RUN conda create -y --name python3.8 python=3.8
 RUN conda create -y --name python3.9 python=3.9
 RUN conda create -y --name python3.10 python=3.10
 
 SHELL [ "/bin/bash", "-c" ]
 RUN echo "source /usr/local/etc/profile.d/conda.sh" >> ~/.bashrc
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.9 && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.10 && conda install -y numpy

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -16,7 +16,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/.github/workflows/test-macos-cpu.yml
+++ b/.github/workflows/test-macos-cpu.yml
@@ -16,7 +16,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ We recommend Anaconda as a Python package management system. Please refer to `py
    :header: "PyTorch version", "torchtext version", "Supported Python version"
    :widths: 10, 10, 10
 
-   nightly build, main, ">=3.7, <=3.10"
+   nightly build, main, ">=3.8, <=3.10"
    1.13.0, 0.14.0, ">=3.7, <=3.10"
    1.12.0, 0.13.0, ">=3.7, <=3.10"
    1.11.0, 0.12.0, ">=3.6, <=3.9"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -136,7 +136,7 @@ retry () {
 }
 
 # Inputs:
-#   PYTHON_VERSION (2.7, 3.5, 3.6, 3.7)
+#   PYTHON_VERSION (2.7, 3.8, 3.9, 3.10)
 #   UNICODE_ABI (bool)
 #
 # Outputs:
@@ -158,7 +158,6 @@ setup_wheel_python() {
           python_abi=cp27-cp27m
         fi
         ;;
-      3.7) python_abi=cp37-cp37m ;;
       3.8) python_abi=cp38-cp38 ;;
       3.9) python_abi=cp39-cp39 ;;
       3.10) python_abi=cp310-cp310 ;;

--- a/setup.py
+++ b/setup.py
@@ -105,11 +105,11 @@ setup_info = dict(
     long_description=read("README.rst"),
     license="BSD",
     install_requires=["tqdm", "requests", pytorch_package_dep, "numpy", torchdata_package_dep],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     # Package info
     packages=find_packages(exclude=("test*", "tools*")),


### PR DESCRIPTION
According to https://github.com/pytorch/pytorch/issues/80513, PyTorch Core will drop support for 3.7 with the upcoming `torch==2.0.0` release. We should do the same.

Closes https://github.com/pytorch/text/issues/2036