### PR TITLE
Update integration-test.yml

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-18.04
+    with:
+      runner: linux.2xlarge
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Closes #2018 

`linux.2xlarge` should have enough memory to run the integration tests. 

Should only affect the Integration Tests (3.8) CPU CI workflow.