### PR TITLE
fix codeql workflow failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
           sudo ln -s /usr/bin/ninja /usr/bin/ninja-build
 
       - name: Build TorchText
-        run: python setup.py develop --user
+        run: python setup.py develop
 
       # If any code scanning alerts are found, they will be under Security -> CodeQL
       # Link: https://github.com/pytorch/text/security/code-scanning

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,9 @@ jobs:
           sudo ln -s /usr/bin/ninja /usr/bin/ninja-build
 
       - name: Build TorchText
-        run: python setup.py develop
+        run: |
+          python -m pip install setuptools==65.7.0
+          python setup.py develop --user
 
       # If any code scanning alerts are found, they will be under Security -> CodeQL
       # Link: https://github.com/pytorch/text/security/code-scanning


### PR DESCRIPTION
The CodeQL workflow has started failing 3 weeks ago. I traced the issue to a change in how setuptools handles warnings in virtualenvs https://github.com/pypa/setuptools/issues/3772 Reverting to an older setuptools package fixes the issue, but I am not sure how to address properly