### PR TITLE
3.11 Windows Wheels Support in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,6 +628,9 @@ workflows:
       - binary_windows_wheel:
           name: binary_windows_wheel_py3.10
           python_version: '3.10'
+      - binary_windows_wheel:
+          name: binary_windows_wheel_py3.11
+          python_version: '3.11'
       - binary_windows_conda:
           name: binary_windows_conda_py3.8
           python_version: '3.8'
@@ -669,6 +672,9 @@ workflows:
       - unittest_windows:
           name: unittest_windows_py3.10
           python_version: '3.10'
+      - unittest_windows:
+          name: unittest_windows_py3.11
+          python_version: '3.11'
   nightly:
     jobs:
       - circleci_consistency:
@@ -767,6 +773,34 @@ workflows:
           python_version: '3.10'
           requires:
           - nightly_binary_windows_wheel_py3.10_upload
+      - binary_windows_wheel:
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_windows_wheel_py3.11
+          python_version: '3.11'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_windows_wheel_py3.11_upload
+          requires:
+          - nightly_binary_windows_wheel_py3.11
+      - smoke_test_windows_pip:
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_windows_wheel_py3.11_smoke_test_pip
+          python_version: '3.11'
+          requires:
+          - nightly_binary_windows_wheel_py3.11_upload
       - binary_windows_conda:
           filters:
             branches:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,7 +21,7 @@ import yaml
 from jinja2 import select_autoescape
 
 
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 
 DOC_VERSION = ("linux", "3.8")
 
@@ -44,6 +44,13 @@ def build_workflows(prefix="", upload=False, filter_branch=None, indentation=6):
                     continue
                 if os_type == "macos":
                     continue
+                # Not supporting Python 3.11 conda packages at the
+                # moment since the necessary dependencies are not
+                # available. Windows 3.11 Wheels will be built from
+                # CircleCI here, however.
+                if python_version == "3.11" and btype == "conda":
+                    continue
+
                 w += build_workflow_pair(btype, os_type, python_version, fb, prefix, upload)
 
     if not filter_branch:


### PR DESCRIPTION
Adding Python 3.11 to the build matrix for Windows wheels (this is still done in circleCI for now).