### PR TITLE
Install portalocker for testing

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -30,7 +30,8 @@ printf "* Installing PyTorch\n"
 )
 
 
-printf "Installing torchdata nightly\n"
+printf "Installing torchdata nightly with portalocker\n"
+pip install "portalocker>=2.0.0"
 pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 printf "* Installing torchtext\n"

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -19,7 +19,8 @@ conda activate ./env
 printf "* Installing PyTorch\n"
 conda install -y -c "pytorch-${UPLOAD_CHANNEL}" ${CONDA_CHANNEL_FLAGS} pytorch cpuonly
 
-printf "* Installing torchdata nightly\n"
+printf "* Installing torchdata nightly with portalocker\n"
+pip install "portalocker>=2.0.0"
 pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 printf "* Installing pywin32_postinstall script\n"

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -58,6 +58,7 @@ jobs:
           -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
           "${CUDATOOLKIT}"
         printf "Installing torchdata nightly\n"
+        python3 -m pip install "portalocker>=2.0.0"
         python3 -m pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
         python3 setup.py develop
         python3 -m pip install parameterized

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -63,6 +63,7 @@ jobs:
           -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
           "${CUDATOOLKIT}"
         printf "Installing torchdata nightly\n"
+        python3 -m pip install "portalocker>=2.0.0"
         python3 -m pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu --quiet
         python3 setup.py develop
         python3 -m pip install parameterized --quiet

--- a/.github/workflows/test-macos-cpu.yml
+++ b/.github/workflows/test-macos-cpu.yml
@@ -65,6 +65,7 @@ jobs:
           pytorch \
           "${CUDATOOLKIT}"
         printf "Installing torchdata nightly\n"
+        python3 -m pip install "portalocker>=2.0.0"
         python3 -m pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
         python3 setup.py develop
         python3 -m pip install parameterized


### PR DESCRIPTION
We are adding this [patch](https://github.com/pytorch/data/pull/1007) to minimize the hard dependency for TorchData. So, `portalocker` won't be automatically installed when installing with `torchdata`.

This PR would add `portalocker` to ensure CI green