### PR TITLE
Fix Smoke Tests for Windows Conda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
               export CONDA_CHANNEL_FLAGS=" -c malfet"
             fi
             conda install -v -y ${CONDA_CHANNEL_FLAGS} -c pytorch-"${UPLOAD_CHANNEL}" pytorch
-            conda install -v -y ${CONDA_CHANNEL_FLAGS} -c ~/workspace/conda-bld torchtext
+            conda install -v -y ${CONDA_CHANNEL_FLAGS} -c pytorch-"${UPLOAD_CHANNEL}" -c ~/workspace/conda-bld torchtext
       - run:
           name: smoke test
           command: |

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -369,7 +369,7 @@ jobs:
               export CONDA_CHANNEL_FLAGS=" -c malfet"
             fi
             conda install -v -y ${CONDA_CHANNEL_FLAGS} -c pytorch-"${UPLOAD_CHANNEL}" pytorch
-            conda install -v -y ${CONDA_CHANNEL_FLAGS} -c ~/workspace/conda-bld torchtext
+            conda install -v -y ${CONDA_CHANNEL_FLAGS} -c pytorch-"${UPLOAD_CHANNEL}" -c ~/workspace/conda-bld torchtext
       - run:
           name: smoke test
           command: |


### PR DESCRIPTION
Possible fix for when torchtext is not found during the conda windows smoke tests.