### PR TITLE
Include padding mask in generation

### DIFF
--- a/test/integration_tests/test_generate.py
+++ b/test/integration_tests/test_generate.py
@@ -14,26 +14,25 @@ class TestGenerationUtil(TorchtextTestCase):
         self.model = t5_base.get_model()
         self.model.eval()
         # Examples taken from T5 Paper and Huggingface
-        self.inputs = self.transform(
-            [
-                "summarize: studies have shown that owning a dog is good for you",
-                "translate English to German: That is good.",
-                "cola sentence: The course is jumping well.",
-                "stsb sentence1: The rhino grazed on the grass. sentence2: A rhino is grazing in a field.",
-                "summarize: state authorities dispatched emergency crews tuesday to survey the damage after an onslaught of severe weather in mississippi...",
-            ]
-        )
+        self.inputs = [
+            "summarize: studies have shown that owning a dog is good for you",
+            "translate English to German: That is good.",
+            "cola sentence: The course is jumping well.",
+            "stsb sentence1: The rhino grazed on the grass. sentence2: A rhino is grazing in a field.",
+            "summarize: state authorities dispatched emergency crews tuesday to survey the damage after an onslaught of severe weather in mississippi...",
+        ]
+        self.transformed_inputs = self.transform(self.inputs)
         torch.manual_seed(0)
 
     def test_greedy_generate_with_t5(self) -> None:
         generation_model = GenerationUtils(self.model)
 
-        tokens = generation_model.generate(self.inputs, num_beams=1, max_length=30)
+        tokens = generation_model.generate(self.transformed_inputs, num_beams=1, max_length=30)
         generated_text = self.transform.decode(tokens.tolist())
 
         expected_generated_text = [
-            "a dog is good for you, according to studies . owning a dog is good for you, according to studies .",
-            "Das ist gut.",
+            "owning a dog is good for you, according to studies . a dog is a good companion for a variety of reasons",
+            "Das ist gut so.",
             "acceptable",
             "4.0",
             "mississippi authorities dispatch emergency crews to survey damage . severe weather in mississippi has caused extensive damage",
@@ -41,14 +40,21 @@ class TestGenerationUtil(TorchtextTestCase):
 
         self.assertEqual(generated_text, expected_generated_text)
 
+        inputs = self.transform([self.inputs[0]])
+
+        tokens_for_single_example = generation_model.generate(inputs, num_beams=1, max_length=30)
+        generated_text_for_single_example = self.transform.decode(tokens_for_single_example.tolist())
+
+        self.assertEqual(generated_text[0], generated_text_for_single_example[-1])
+
     def test_generate_errors_with_incorrect_beams(self) -> None:
         generation_model = GenerationUtils(self.model, is_encoder_decoder=True)
 
         with self.assertRaises(ValueError):
-            generation_model.generate(self.inputs, num_beams=0)
+            generation_model.generate(self.transformed_inputs, num_beams=0)
 
     @patch("logging.Logger.warning")
     def test_warns_when_no_max_len_provided(self, mock) -> None:
         generation_model = GenerationUtils(self.model)
-        generation_model.generate(self.inputs)
+        generation_model.generate(self.transformed_inputs)
         mock.assert_called_with(f"`max_length` was not specified. Defaulting to {DEFAULT_MAX_SEQ_LEN} tokens.")

--- a/torchtext/models/t5/model.py
+++ b/torchtext/models/t5/model.py
@@ -198,6 +198,7 @@ class T5Model(nn.Module):
         self,
         input_ids: Tensor,
         encoder_outputs: ENCODER_OUTPUTS_TYPE,
+        encoder_padding_mask: Optional[Tensor] = None,
         past: Optional[List[PAST_KEY_VALUES_TYPE]] = None,
         return_past_key_values: bool = True,
     ) -> Dict[str, Union[Tensor, ENCODER_OUTPUTS_TYPE, Optional[List[PAST_KEY_VALUES_TYPE]], bool]]:
@@ -209,6 +210,7 @@ class T5Model(nn.Module):
             "decoder_tokens": input_ids,
             "encoder_outputs": encoder_outputs,
             "past_key_values": past,
+            "encoder_padding_mask": encoder_padding_mask,
             "return_past_key_values": return_past_key_values,
         }
 


### PR DESCRIPTION
### Bug

Expect batched input to match single input e.g.

1. [seq1, ... seq_m] -> generate -> [output1, ...., output_m]
2. [seq1] -> generate -> [output1]

Before this would not create the same output1. The issue was that the src_key_padding_mask was not being propagated forward. 

### Fix

Create padding mask and add it to `model_kwargs` and pass it to the forward function.