### PR TITLE
Simplify torchdata version extraction in packaging script

### DIFF
--- a/packaging/install_torchdata.sh
+++ b/packaging/install_torchdata.sh
@@ -33,7 +33,7 @@ $install_cmd torchdata $install_channel
 if [ "$package_type" = "wheel" ]; then
   TORCHDATA_VERSION="$(pip show torchdata | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
 else
-  TORCHDATA_VERSION="$(conda list -fe torchdata | grep torchdata | sed -e 's/torchdata=\(.*\)=py/\1/')"
+  TORCHDATA_VERSION="$(conda list -fe torchdata | grep torchdata | sed -e 's/torchdata=\(.*\)=py.*/\1/')"
   echo "export CONDA_TORCHDATA_CONSTRAINT='- torchdata==${TORCHDATA_VERSION}'" >> "${BUILD_ENV_FILE}"
 fi
 

--- a/packaging/install_torchdata.sh
+++ b/packaging/install_torchdata.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 package_type="$PACKAGE_TYPE"
-channel="$CHANNEl"
+channel="$CHANNEL"
 if [ -z "$package_type" ]; then
   package_type="wheel"
 fi
@@ -33,14 +33,7 @@ $install_cmd torchdata $install_channel
 if [ "$package_type" = "wheel" ]; then
   TORCHDATA_VERSION="$(pip show torchdata | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
 else
-  TORCHDATA_VERSION="$(conda search --json 'torchdata[channel=pytorch-'"${channel}"] | \
-    python -c "import json, os, re, sys; \
-      cuver = 'cpu'; \
-      pyver = os.environ.get('PYTHON_VERSION').replace('.', ''); \
-      print(re.sub(r'\\+.*$', '',
-        [x['version'] for x in json.load(sys.stdin)['torchdata'] \
-          if 'py' + pyver in x['fn']][-1]))"
-      )"
+  TORCHDATA_VERSION="$(conda list -fe torchdata | grep torchdata | sed -e 's/torchdata=\(.*\)=py/\1/')"
   echo "export CONDA_TORCHDATA_CONSTRAINT='- torchdata==${TORCHDATA_VERSION}'" >> "${BUILD_ENV_FILE}"
 fi
 


### PR DESCRIPTION
Simplify torchdata version extraction in packaging script
test:
```
conda list -fe torchdata 
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: linux-64
torchdata=0.7.0.dev20230328=py310

conda list -fe torchdata | grep torchdata | sed -e 's/torchdata=\(.*\)=py.*/\1/'
0.7.0.dev202303283
```