### PR TITLE
Add shift-right method to T5 model

### DIFF
--- a/test/torchtext_unittest/models/t5_models_test_impl.py
+++ b/test/torchtext_unittest/models/t5_models_test_impl.py
@@ -184,3 +184,25 @@ class T5BaseTestModels(TestBaseMixin):
 
         _train(model)
         self.assertNotEqual(model.state_dict(), current_state_dict)
+
+    def test_shift_right(self) -> None:
+        from torchtext.models import T5Conf, T5Model
+
+        dummy_encoder_conf = T5Conf()
+        dummy_t5_encoder = T5Model(dummy_encoder_conf)
+        padding_idx = dummy_t5_encoder.padding_idx
+
+        valid_cases_input = [[[1, 2], [3, 4]], [[1]]]
+        valid_cases_expected = [[[padding_idx, 1], [padding_idx, 3]], [[padding_idx]]]
+
+        invalid_cases_input = [[0], [], [[]]]
+
+        for input_ids, expected in zip(valid_cases_input, valid_cases_expected):
+            input_ids = torch.Tensor(input_ids)
+            expected = torch.Tensor(expected)
+            self.assertEqual(dummy_t5_encoder._shift_right(input_ids), expected)
+
+        for input_ids in invalid_cases_input:
+            input_ids = torch.Tensor(input_ids)
+            with self.assertRaises(IndexError):
+                dummy_t5_encoder._shift_right(input_ids)

--- a/torchtext/models/t5/model.py
+++ b/torchtext/models/t5/model.py
@@ -194,6 +194,17 @@ class T5Model(nn.Module):
         return reordered_decoder_past
 
     @torch.jit.export
+    def _shift_right(self, input_ids: Tensor) -> Tensor:
+        """Shift all input sequences to the right"""
+        shifted_input_ids = torch.zeros_like(input_ids)
+        shifted_input_ids[:, 1:] = input_ids[:, :-1].clone()
+
+        # T5 implemention uses padding idx to start sequence.
+        shifted_input_ids[:, 0] = self.padding_idx
+
+        return shifted_input_ids
+
+    @torch.jit.export
     def prepare_inputs_for_generation(
         self,
         input_ids: Tensor,


### PR DESCRIPTION
We add a `_shift_right` method to the T5 Model. This is used for training (see [Issue 2127](https://github.com/pytorch/text/issues/2127)).

It shifts an input batch of sequences of token-indices, one index to the right.
Their first token is replaced with the start-of-sequence token, which is the padding-token index for T5 models