### PR TITLE
Allow overwriting of local SPM model path

### DIFF
--- a/torchtext/models/t5/t5_transform.py
+++ b/torchtext/models/t5/t5_transform.py
@@ -39,9 +39,16 @@ class T5Transform(nn.Module):
         >>> transform(["hello world", "attention is all you need!"])
     """
 
-    def __init__(self, sp_model_path: str, max_seq_len: int, eos_idx: int, padding_idx: int):
+    def __init__(
+        self,
+        sp_model_path: str,
+        max_seq_len: int,
+        eos_idx: int,
+        padding_idx: int,
+        overwrite_local_model_path: bool = True,
+    ):
         super().__init__()
-        self.sp_model = load_sp_model(get_asset_local_path(sp_model_path))
+        self.sp_model = load_sp_model(get_asset_local_path(sp_model_path, overwrite=overwrite_local_model_path))
         self.max_seq_len = max_seq_len
         self.eos_idx = eos_idx
         self.padding_idx = padding_idx


### PR DESCRIPTION
Fixes issue in which some download managers (Manifold) do not successfully download the SPM model; however, because the file has been created, the model does not attempt another redownload and instead tries to load an empty file.

Bug was found and fix authored by @debowin