### PR TITLE
Torchscriptable T5 generation

### DIFF
--- a/test/integration_tests/test_generate.py
+++ b/test/integration_tests/test_generate.py
@@ -21,7 +21,7 @@ class TestGenerationUtil(TorchtextTestCase):
         ]
         self.transformed_inputs = self.transform(self.inputs)
         torch.manual_seed(0)
-    
+
     def test_torchscriptable_t5_generate(self) -> None:
         generation_model = self.t5_base.get_model(with_generation_utils=True)
         assert isinstance(generation_model, GenerationUtils)
@@ -46,7 +46,6 @@ class TestGenerationUtil(TorchtextTestCase):
         generated_text_for_single_example = self.transform.decode(tokens_for_single_example.tolist())
 
         self.assertEqual(generated_text[0], generated_text_for_single_example[-1])
-
 
     def test_greedy_generate_with_t5(self) -> None:
         generation_model = GenerationUtils(self.model)

--- a/test/integration_tests/test_generate.py
+++ b/test/integration_tests/test_generate.py
@@ -1,17 +1,15 @@
-from unittest.mock import patch
-
 import torch
 from torchtext.models import T5_BASE_GENERATION
-from torchtext.prototype.generate import DEFAULT_MAX_SEQ_LEN, GenerationUtils
+from torchtext.prototype.generate import GenerationUtils
 from torchtext_unittest.common.torchtext_test_case import TorchtextTestCase
 
 
 class TestGenerationUtil(TorchtextTestCase):
     def setUp(self) -> None:
         super().setUp()
-        t5_base = T5_BASE_GENERATION
-        self.transform = t5_base.transform()
-        self.model = t5_base.get_model()
+        self.t5_base = T5_BASE_GENERATION
+        self.transform = self.t5_base.transform()
+        self.model = self.t5_base.get_model()
         self.model.eval()
         # Examples taken from T5 Paper and Huggingface
         self.inputs = [
@@ -23,6 +21,32 @@ class TestGenerationUtil(TorchtextTestCase):
         ]
         self.transformed_inputs = self.transform(self.inputs)
         torch.manual_seed(0)
+    
+    def test_torchscriptable_t5_generate(self) -> None:
+        generation_model = self.t5_base.get_model(with_generation_utils=True)
+        assert isinstance(generation_model, GenerationUtils)
+        scripted_model = torch.jit.script(generation_model)
+
+        tokens = scripted_model.generate(self.transformed_inputs, num_beams=1, max_length=30)
+        generated_text = self.transform.decode(tokens.tolist())
+
+        expected_generated_text = [
+            "owning a dog is good for you, according to studies . a dog is a good companion for a variety of reasons",
+            "Das ist gut so.",
+            "acceptable",
+            "4.0",
+            "mississippi authorities dispatch emergency crews to survey damage . severe weather in mississippi has caused extensive damage",
+        ]
+
+        self.assertEqual(generated_text, expected_generated_text)
+
+        inputs = self.transform([self.inputs[0]])
+
+        tokens_for_single_example = scripted_model.generate(inputs, num_beams=1, max_length=30)
+        generated_text_for_single_example = self.transform.decode(tokens_for_single_example.tolist())
+
+        self.assertEqual(generated_text[0], generated_text_for_single_example[-1])
+
 
     def test_greedy_generate_with_t5(self) -> None:
         generation_model = GenerationUtils(self.model)
@@ -52,12 +76,6 @@ class TestGenerationUtil(TorchtextTestCase):
 
         with self.assertRaises(ValueError):
             generation_model.generate(self.transformed_inputs, num_beams=0)
-
-    @patch("logging.Logger.warning")
-    def test_warns_when_no_max_len_provided(self, mock) -> None:
-        generation_model = GenerationUtils(self.model)
-        generation_model.generate(self.transformed_inputs)
-        mock.assert_called_with(f"`max_length` was not specified. Defaulting to {DEFAULT_MAX_SEQ_LEN} tokens.")
 
     def test_get_top_k_restriction(self) -> None:
         generation_model = GenerationUtils(self.model)

--- a/torchtext/models/t5/bundler.py
+++ b/torchtext/models/t5/bundler.py
@@ -318,6 +318,7 @@ class T5Bundle:
 
 class GenerationUtilsForT5(GenerationUtils):
     """In order to make GenerationUtils torchscriptable, we provide the exact typing for the underlying model forward call."""
+
     def __init__(self, model: torch.nn.Module, **kwargs) -> None:
         super().__init__(model, **kwargs)
 
@@ -373,6 +374,7 @@ class GenerationUtilsForT5(GenerationUtils):
             past_key_values=past_key_values,
             return_past_key_values=return_past_key_values,
         )
+
 
 ENCODER_DOC = """
     T5_{}_ENCODER is an encoder-only model from a pre-trained T5 model with the {} configuration.
@@ -497,6 +499,7 @@ FLAN_GENERATION_DOC = """
 
     Please refer to :func:`torchtext.models.T5Bundle` for the usage.
 """
+
 
 def t5_transform() -> T5Transform:
     return T5Transform(

--- a/torchtext/models/t5/bundler.py
+++ b/torchtext/models/t5/bundler.py
@@ -89,9 +89,14 @@ class T5Bundle:
         r"""get_model(load_weights: bool = True, freeze_model: bool = False, *, dl_kwargs=None) -> torctext.prototype.models.T5Model
 
         Args:
+            with_generation_utils (bool): Indicates whether to wrap model w/ `GenerationUtils` wrapper. (Default: `False`)
             load_weights (bool): Indicates whether or not to load weights if available. (Default: `True`)
             freeze_model (bool): Indicates whether or not to freeze the model weights. (Default: `False`)
             dl_kwargs (dictionary of keyword arguments): Passed to :func:`torch.hub.load_state_dict_from_url`. (Default: `None`)
+            gen_kwargs (dictionary of kwargs): Passed to :func:`GenerationUtilsForT5`. (Default: `None`)
+
+        Returns:
+            Either a T5Model or a T5Model wrapped with GenerationUtils.
         """
 
         if load_weights:
@@ -322,7 +327,7 @@ class GenerationUtilsForT5(GenerationUtils):
     def __init__(self, model: torch.nn.Module, **kwargs) -> None:
         super().__init__(model, **kwargs)
 
-    def scriptable_model_forward_call(
+    def _scripted_model_forward_call(
         self,
         kwargs: Dict[
             str,

--- a/torchtext/models/t5/modules.py
+++ b/torchtext/models/t5/modules.py
@@ -30,9 +30,14 @@ PAST_KEY_VALUE_TYPE = Tuple[Tensor, Tensor]
 PAST_KEY_VALUES_UNFILLED_TYPE = Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]
 
 # Define reusable types for encoder/decoder outputs
-ENCODER_OUTPUTS_TYPE = Dict[str, Union[Optional[Tensor], List[Tensor], List[Optional[Tensor]]]]
-DECODER_OUTPUTS_TYPE = Dict[
-    str, Union[Optional[Tensor], List[Tensor], List[Optional[Tensor]], List[PAST_KEY_VALUES_UNFILLED_TYPE]]
+SEQ_2_SEQ_OUTPUTS_TYPE = Dict[
+    str, 
+    Union[
+        Optional[Tensor],
+        List[Tensor],
+        List[Optional[Tensor]],
+        Optional[List[PAST_KEY_VALUES_UNFILLED_TYPE]]
+    ]
 ]
 
 
@@ -961,7 +966,7 @@ class T5Encoder(nn.Module):
         mask: Optional[Tensor] = None,
         src_key_padding_mask: Optional[Tensor] = None,
         embedded_src: Optional[Tensor] = None,
-    ) -> ENCODER_OUTPUTS_TYPE:
+    ) -> SEQ_2_SEQ_OUTPUTS_TYPE:
         r"""Pass the input (and masks) through the stack of encoder layers.
 
         Args:
@@ -1098,7 +1103,7 @@ class T5Decoder(nn.Module):
         memory_key_padding_mask: Optional[Tensor] = None,
         past_key_values: Optional[List[PAST_KEY_VALUES_TYPE]] = None,
         return_past_key_values: bool = False,
-    ) -> DECODER_OUTPUTS_TYPE:
+    ) -> SEQ_2_SEQ_OUTPUTS_TYPE:
         r"""Pass the inputs (and masks) through the stack of decoder layers.
 
         Args:

--- a/torchtext/models/t5/modules.py
+++ b/torchtext/models/t5/modules.py
@@ -31,13 +31,7 @@ PAST_KEY_VALUES_UNFILLED_TYPE = Tuple[Tensor, Tensor, Optional[Tensor], Optional
 
 # Define reusable types for encoder/decoder outputs
 SEQ_2_SEQ_OUTPUTS_TYPE = Dict[
-    str, 
-    Union[
-        Optional[Tensor],
-        List[Tensor],
-        List[Optional[Tensor]],
-        Optional[List[PAST_KEY_VALUES_UNFILLED_TYPE]]
-    ]
+    str, Union[Optional[Tensor], List[Tensor], List[Optional[Tensor]], Optional[List[PAST_KEY_VALUES_UNFILLED_TYPE]]]
 ]
 
 

--- a/torchtext/prototype/generate.py
+++ b/torchtext/prototype/generate.py
@@ -1,16 +1,25 @@
-import logging
-from typing import Optional
+import warnings
+from typing import Dict, Final, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
 from torch import nn
-
-logger = logging.getLogger(__name__)
-
-DEFAULT_MAX_SEQ_LEN = 256
+from torchtext.models.t5.modules import SEQ_2_SEQ_OUTPUTS_TYPE
 
 
-class GenerationUtils:
+DEFAULT_MAX_SEQ_LEN: Final[int] = 256
+MODEL_KWARGS_TYPE = Dict[
+    str,
+    Union[
+        bool,
+        torch.Tensor,
+        Optional[List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]]],
+        SEQ_2_SEQ_OUTPUTS_TYPE,
+    ],
+]
+
+
+class GenerationUtils(nn.Module):
     """Wrapper to provide generation utils for encoder/decoder models and decoder models.
 
     Example:
@@ -35,34 +44,75 @@ class GenerationUtils:
     """
 
     def __init__(self, model: nn.Module, **kwargs) -> None:
+        super().__init__()
         self.model = model
         self.is_encoder_decoder = kwargs.pop("is_encoder_decoder", True)
         self.is_huggingface_model = kwargs.pop("is_huggingface_model", False)
 
     def _prepare_decoder_ids_for_generation(
-        self, batch_size: int, pad_idx: int = 0, device: Optional[torch.device] = None, **model_kwargs
+        self,
+        batch_size: int,
+        pad_idx: int = 0,
+        device: Optional[torch.device] = None,
+        model_kwargs: Optional[MODEL_KWARGS_TYPE] = None,
     ):
         if model_kwargs is not None and "decoder_input_ids" in model_kwargs:
-            return model_kwargs.pop("decoder_input_ids")
+            decoder_input_ids = model_kwargs.pop("decoder_input_ids")
+            assert torch.jit.isinstance(decoder_input_ids, torch.Tensor)
+            return decoder_input_ids
         else:
             return torch.ones((batch_size, 1), dtype=torch.long, device=device) * pad_idx
 
+    def scriptable_model_forward_call(self, kwargs):
+        warnings.warn("`scriptable_model_forward_call` has not been overriden and will not produce correct output.")
+        pass
+
+    @torch.jit.unused
+    def _call_to_encoder_with_kwargs(self, inputs, kwargs):
+        if self.is_huggingface_model:
+            kwargs["return_dict"] = True
+        encoder = self.model.get_encoder()
+        return encoder(inputs, **kwargs)
+
+    @torch.jit.unused
+    def _call_to_prepare_inputs_for_generation_with_kwargs(self, inputs, kwargs):
+        return self.model.prepare_inputs_for_generation(inputs, **kwargs)
+
+    @torch.jit.unused
+    def _call_to_model_forward_with_kwargs(self, model_inputs):
+        return self.model(**model_inputs)
+
+    def _prepare_encoder_decoder_kwargs_for_generation(
+        self, input_ids: torch.Tensor, encoder_kwargs: MODEL_KWARGS_TYPE
+    ):
+        """Runs encoder and adds to model_kwargs for decoding. Modified from https://github.com/huggingface/transformers/blob/67d074874d285e616393c65a0e670088e1b6b74a/src/transformers/generation/utils.py#L592.
+
+        Args:
+            inputs: (Tensor): Tokenized startings sequence(s).
+            model_kwargs (Dict[str, Any]): Model keyword arguments to be modified for decoding.
+
+        Returns:
+            Modified model_kwargs with addition of encoded input sequence(s).
+        """
+        # Forward pass
+        if torch.jit.is_scripting():
+            encoder_kwargs["encoder_tokens"] = input_ids
+            encoder_output = self.scriptable_model_forward_call(encoder_kwargs)
+            assert torch.jit.isinstance(encoder_output, SEQ_2_SEQ_OUTPUTS_TYPE)
+            return encoder_output
+        return self._call_to_encoder_with_kwargs(input_ids, encoder_kwargs)
+
     def greedy_search(
-        self,
-        input_ids: torch.Tensor,
-        max_length: int,
-        eos_idx: int,
-        pad_idx: int,
-        **model_kwargs,
+        self, input_ids: torch.Tensor, max_length: int, eos_idx: int, pad_idx: int, model_kwargs: MODEL_KWARGS_TYPE
     ) -> torch.Tensor:
         """Greedy search decoding for text generation. Takes the most likely next token every time.
 
-        Inputs:
+        Args:
             input_ids (Tensor): Text prompt(s) for greedy generation.
             max_length (int): Max length to generate responses.
             eos_idx (int): End of sequence index.
             pad_idx (int): Padding index.
-            **model_kwargs
+            model_kwargs
 
         Returns:
             Batch of sequences decoded by greedy search.
@@ -70,19 +120,28 @@ class GenerationUtils:
         unfinished_sequences = torch.ones((input_ids.shape[0]), device=input_ids.device, dtype=torch.long)
 
         while True:
-            model_inputs = self.model.prepare_inputs_for_generation(input_ids, **model_kwargs)
+            model_inputs = (
+                self.model.prepare_inputs_for_generation(input_ids, model_kwargs=model_kwargs)
+                if torch.jit.is_scripting()
+                else self._call_to_prepare_inputs_for_generation_with_kwargs(input_ids, model_kwargs)
+            )
 
             if self.is_huggingface_model:
                 model_inputs["return_dict"] = True
                 model_inputs["output_hidden_states"] = True
 
             # Get model output
-            outputs = self.model(**model_inputs)
+            if torch.jit.is_scripting():
+                outputs = self.scriptable_model_forward_call(model_inputs)
+                assert torch.jit.isinstance(outputs, SEQ_2_SEQ_OUTPUTS_TYPE)
+            else:
+                outputs = self._call_to_model_forward_with_kwargs(model_inputs)
             output_key = "logits" if self.is_huggingface_model else "decoder_output"
-            decoder_output = outputs[output_key]
+            logits = outputs.get(output_key)
 
+            assert torch.jit.isinstance(logits, torch.Tensor)
             # Calculate probabilities and take the most likely next token
-            probs = F.log_softmax(decoder_output[:, -1], dim=-1)
+            probs = F.log_softmax(logits[:, -1], dim=-1)
             next_tokens = torch.argmax(probs, dim=-1)
 
             # For any finished sequences, padding idx should be the last token
@@ -103,11 +162,12 @@ class GenerationUtils:
     def beam_search(self, input_ids: torch.Tensor, num_beams: int, max_length: Optional[int]) -> torch.Tensor:
         raise NotImplementedError()
 
+    @torch.jit.export
     def generate(
         self,
-        inputs: Optional[torch.Tensor] = None,
+        inputs: torch.Tensor,
         num_beams: Optional[int] = None,
-        max_length: Optional[int] = None,
+        max_length: int = DEFAULT_MAX_SEQ_LEN,
         pad_idx: int = 0,
         eos_idx: int = 1,
     ) -> torch.Tensor:
@@ -127,28 +187,19 @@ class GenerationUtils:
 
         `Note`: If one beam is provided or no beams are specified, the generation method will default to greedy search.
         """
-        model_kwargs = {}
+        model_kwargs = torch.jit.annotate(MODEL_KWARGS_TYPE, {})
+        encoder_model_kwargs = torch.jit.annotate(MODEL_KWARGS_TYPE, {})
 
         if self.is_encoder_decoder:
-            encoder = self.model.get_encoder()
-            encoder_model_kwargs = {"src_key_padding_mask": inputs.eq(pad_idx)}
-            model_kwargs["encoder_outputs"] = encoder(inputs, **encoder_model_kwargs)
-            inputs = self._prepare_decoder_ids_for_generation(len(inputs), device=inputs.device, **model_kwargs)
+            encoder_model_kwargs["src_key_padding_mask"] = inputs.eq(pad_idx)
+            encoder_outputs = self._prepare_encoder_decoder_kwargs_for_generation(inputs, encoder_model_kwargs)
+            model_kwargs["encoder_outputs"] = encoder_outputs
             model_kwargs["encoder_padding_mask"] = encoder_model_kwargs.pop("src_key_padding_mask")
 
-        if max_length is None:
-            # Too hard to try to figure out the exact max_seq_length for each model
-            logger.warning(f"`max_length` was not specified. Defaulting to {DEFAULT_MAX_SEQ_LEN} tokens.")
-            max_length = DEFAULT_MAX_SEQ_LEN
+        inputs = self._prepare_decoder_ids_for_generation(len(inputs), device=inputs.device)
 
-        if num_beams == 1 or num_beams is None:
-            return self.greedy_search(
-                inputs,
-                max_length,
-                eos_idx,
-                pad_idx=pad_idx,
-                **model_kwargs,
-            )
+        if num_beams is None or num_beams == 1:
+            return self.greedy_search(inputs, max_length, eos_idx, pad_idx=pad_idx, model_kwargs=model_kwargs)
         elif num_beams > 1:
             return self.beam_search(inputs, num_beams, max_length)
         else:


### PR DESCRIPTION
Makes `GenerationUtils` TorchScript-compatible w/ T5 model.

This PR makes the following changes:
* Makes `GenerationUtils` an `nn.Module` and TorchScript-compatible
* Modifes the output type of T5 (and variants) and has a simpler update function from encoder and decoder
* Adds parameter `with_generation_utils` to `T5Bundle.get_model()` that returns a T5 model wrapped in a TorchScript-compatible `GenerationUtils` class

Testing:
* Passing all old tests for T5 and `GenerationUtils`
* Adds a new test for calling `get_model` with `with_generation_utils=True` and confirming that it is Torchscriptable and provides the correct results.