### PR TITLE
[NovaX] Windows CPU Unittests

### DIFF
--- a/.github/workflows/test-windows-cpu.yml
+++ b/.github/workflows/test-windows-cpu.yml
@@ -42,7 +42,7 @@ jobs:
         # Create Conda Env
         conda create -y --name ci_env python="${PYTHON_VERSION}"
         conda activate ci_env
-        python3 -m pip --quiet install cmake>=3.18.0 ninja
+        python -m pip --quiet install cmake>=3.18.0 ninja
         conda env update --file ".circleci/unittest/windows/scripts/environment.yml" --prune
 
         # TorchText-specific Setup
@@ -58,17 +58,17 @@ jobs:
           pytorch \
           cpuonly
         printf "Installing torchdata nightly\n"
-        python3 -m pip install "portalocker>=2.0.0"
-        python3 -m pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+        python -m pip install "portalocker>=2.0.0"
+        python -m pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         printf "* Installing pywin32_postinstall script\n"
         curl --output pywin32_postinstall.py https://raw.githubusercontent.com/mhammond/pywin32/main/pywin32_postinstall.py
         python pywin32_postinstall.py -install
 
-        "packaging/vc_env_helper.bat" python3 setup.py develop
-        python3 -m pip install parameterized
+        "packaging/vc_env_helper.bat" python setup.py develop
+        python -m pip install parameterized
 
         # Run Tests
-        python3 -m torch.utils.collect_env
+        python -m torch.utils.collect_env
         cd test
-        python3 -m pytest --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 torchtext_unittest
+        python -m pytest --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 torchtext_unittest

--- a/.github/workflows/test-windows-cpu.yml
+++ b/.github/workflows/test-windows-cpu.yml
@@ -1,0 +1,74 @@
+name: Unit-tests on Windows CPU
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+  workflow_dispatch:
+
+env:
+  CHANNEL: "nightly"
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        python_version: ["3.8", "3.9", "3.10"]
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    with:
+      runner: windows.4xlarge
+      repository: pytorch/text
+      script: |
+        set -euxo pipefail
+
+        # Mark Build Directory Safe
+        git config --global --add safe.directory /__w/text/text
+
+        # Set up Environment Variables
+        export PYTHON_VERSION="${{ matrix.python_version }}"
+        export VERSION="cpu"
+
+        # Set CHANNEL
+        if [[ (${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
+          export CHANNEL=test
+        else
+          export CHANNEL=nightly
+        fi
+
+        # Create Conda Env
+        conda create -yp ci_env python="${PYTHON_VERSION}"
+        conda activate /work/ci_env
+        python3 -m pip --quiet install cmake>=3.18.0 ninja
+        conda env update --file ".circleci/unittest/windows/scripts/environment.yml" --prune
+
+        # TorchText-specific Setup
+        printf "* Downloading SpaCy English models\n"
+        python -m spacy download en_core_web_sm
+        printf "* Downloading SpaCy German models\n"
+        python -m spacy download de_core_news_sm
+
+        # Install PyTorch, Torchvision, and TorchData
+        conda install \
+          --yes \
+          -c "pytorch-${CHANNEL}" \
+          pytorch \
+          cpuonly
+        printf "Installing torchdata nightly\n"
+        python3 -m pip install "portalocker>=2.0.0"
+        python3 -m pip install --pre torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+
+        printf "* Installing pywin32_postinstall script\n"
+        curl --output pywin32_postinstall.py https://raw.githubusercontent.com/mhammond/pywin32/main/pywin32_postinstall.py
+        python pywin32_postinstall.py -install
+
+        "packaging/vc_env_helper.bat" python3 setup.py develop
+        python3 -m pip install parameterized
+
+        # Run Tests
+        python3 -m torch.utils.collect_env
+        cd test
+        python3 -m pytest --cov=torchtext --junitxml=test-results/junit.xml -v --durations 20 torchtext_unittest

--- a/.github/workflows/test-windows-cpu.yml
+++ b/.github/workflows/test-windows-cpu.yml
@@ -40,8 +40,8 @@ jobs:
         fi
 
         # Create Conda Env
-        conda create -yp ci_env python="${PYTHON_VERSION}"
-        conda activate /work/ci_env
+        conda create -y --name ci_env python="${PYTHON_VERSION}"
+        conda activate ci_env
         python3 -m pip --quiet install cmake>=3.18.0 ninja
         conda env update --file ".circleci/unittest/windows/scripts/environment.yml" --prune
 


### PR DESCRIPTION
Adds Windows CPU Unittests as a GHA Nova Workflow. Supports Python 3.8-3.10 like the current CircleCI job. If these work well for a week or so, we can deprecate the old CircleCI jobs.