### PR TITLE
Disable `test_download_charngram_vectors` on Linux CI

### DIFF
--- a/test/torchtext_unittest/test_build.py
+++ b/test/torchtext_unittest/test_build.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Tests that requires external resources (Network access to fetch dataset)"""
 import os
+import platform
+import unittest
 
 import torch
 import torchtext.data
@@ -64,6 +66,8 @@ class TestVocab(TorchtextTestCase):
         self.assertEqual(token_one_vec.shape[0], vec.dim)
         self.assertEqual(vec[tokens[0].lower()], token_one_vec)
 
+    # TODO(Nayef211): remove decorator once https://github.com/pytorch/text/issues/1900 is closed
+    @unittest.skipIf("CI" in os.environ and platform.system() == "Linux", "Test is known to fail on Linux.")
     @third_party_download
     def test_download_charngram_vectors(self) -> None:
         # Build a vocab and get vectors twice to test caching.


### PR DESCRIPTION
- The `test_vocab_from_raw_text_file` test is failing on CI for linux platforms due to the following error `urllib.error.HTTPError: HTTP Error 404: Not Found` (see [sample CI job](https://github.com/pytorch/text/actions/runs/4755755079/jobs/8520868662))
- Will revert once https://github.com/pytorch/text/issues/2160 is resolved