### PR TITLE
Add TorchFix linter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,13 @@
 [flake8]
 ignore =
     E401,E402,E501,E722,W503,W504,F821,B006,B007,B008,B009,
-    E203 # https://github.com/PyCQA/pycodestyle/issues/373
+    # https://github.com/PyCQA/pycodestyle/issues/373
+    E203
 select =
     B,C,E,F,P,T4,W,B9,
-    D417, # Missing argument descriptions in the docstring
-    TOR # TorchFix
+    # Missing argument descriptions in the docstring
+    D417,
+    # TorchFix
+    TOR
 max-line-length = 120
 exclude = docs/source,third_party

--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@ ignore =
     E203 # https://github.com/PyCQA/pycodestyle/issues/373
 select =
     B,C,E,F,P,T4,W,B9,
-    D417 # Missing argument descriptions in the docstring
+    D417, # Missing argument descriptions in the docstring
+    TOR # TorchFix
 max-line-length = 120
 exclude = docs/source,third_party

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,6 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings == 1.6.0
+          - torchfix == 0.0.1
         args:
           - --config=.flake8

--- a/test/torchtext_unittest/data/test_jit.py
+++ b/test/torchtext_unittest/data/test_jit.py
@@ -1,5 +1,5 @@
 import torch
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 from torchtext.nn import InProjContainer, MultiheadAttentionContainer, ScaledDotProduct
 
 from ..common.torchtext_test_case import TorchtextTestCase
@@ -26,5 +26,5 @@ class TestJIT(TorchtextTestCase):
 
         ts_MHA = torch.jit.script(MHA)
         ts_mha_output, ts_attn_weights = ts_MHA(query, key, value, attn_mask=attn_mask)
-        assert_allclose(mha_output, ts_mha_output)
-        assert_allclose(attn_weights, ts_attn_weights)
+        assert_close(mha_output, ts_mha_output)
+        assert_close(attn_weights, ts_attn_weights)


### PR DESCRIPTION
Add TorchFix linter and fix deprecated usages of `assert_allclose` to make it pass.

Also move the comments in the flake8 config to separate lines, as more modern flake8 versions do not support inline comments for any of the keys - https://flake8.pycqa.org/en/latest/user/configuration.html

The bandit failure and M1 failures are pre-existing.