### PR TITLE
Fix torchdata import error

### DIFF
--- a/torchtext/datasets/ag_news.py
+++ b/torchtext/datasets/ag_news.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -65,6 +65,7 @@ def AG_NEWS(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL[split]])
     cache_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/ag_news.py
+++ b/torchtext/datasets/ag_news.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/ag_news.py
+++ b/torchtext/datasets/ag_news.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/amazonreviewfull.py
+++ b/torchtext/datasets/amazonreviewfull.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -79,6 +79,7 @@ def AmazonReviewFull(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/amazonreviewfull.py
+++ b/torchtext/datasets/amazonreviewfull.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/amazonreviewfull.py
+++ b/torchtext/datasets/amazonreviewfull.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/amazonreviewpolarity.py
+++ b/torchtext/datasets/amazonreviewpolarity.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -76,6 +76,7 @@ def AmazonReviewPolarity(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/amazonreviewpolarity.py
+++ b/torchtext/datasets/amazonreviewpolarity.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/amazonreviewpolarity.py
+++ b/torchtext/datasets/amazonreviewpolarity.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/cc100.py
+++ b/torchtext/datasets/cc100.py
@@ -1,7 +1,7 @@
 import os.path
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,

--- a/torchtext/datasets/cc100.py
+++ b/torchtext/datasets/cc100.py
@@ -2,7 +2,8 @@ import os.path
 from functools import partial
 
 
-from torchtext._download_hooks import HttpReader
+
+from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,
 )
@@ -167,6 +168,11 @@ def CC100(root: str, language_code: str = "en"):
     """
     if language_code not in VALID_CODES:
         raise ValueError(f"Invalid language code {language_code}")
+    if not is_module_available("torchdata"):
+        raise ModuleNotFoundError(
+            "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
+        )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url = URL % language_code
     url_dp = IterableWrapper([url])

--- a/torchtext/datasets/cc100.py
+++ b/torchtext/datasets/cc100.py
@@ -1,8 +1,6 @@
 import os.path
 from functools import partial
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,

--- a/torchtext/datasets/cnndm.py
+++ b/torchtext/datasets/cnndm.py
@@ -3,12 +3,6 @@ import os
 from functools import partial
 from typing import Union, Set, Tuple
 
-from torchdata.datapipes.iter import (
-    FileOpener,
-    IterableWrapper,
-    OnlineReader,
-    GDriveReader,
-)
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -141,6 +135,12 @@ def CNNDM(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import (
+        FileOpener,
+        IterableWrapper,
+        OnlineReader,
+        GDriveReader,
+    )
 
     cnn_dp = _load_stories(root, "cnn", split)
     dailymail_dp = _load_stories(root, "dailymail", split)

--- a/torchtext/datasets/cnndm.py
+++ b/torchtext/datasets/cnndm.py
@@ -135,7 +135,7 @@ def CNNDM(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
-    from torchdata.datapipes.iter import (
+    from torchdata.datapipes.iter import (  # noqa
         FileOpener,
         IterableWrapper,
         OnlineReader,

--- a/torchtext/datasets/cola.py
+++ b/torchtext/datasets/cola.py
@@ -3,7 +3,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory, _wrap_split_argument

--- a/torchtext/datasets/cola.py
+++ b/torchtext/datasets/cola.py
@@ -3,8 +3,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory, _wrap_split_argument
 

--- a/torchtext/datasets/cola.py
+++ b/torchtext/datasets/cola.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory, _wrap_split_argument
 
@@ -76,6 +76,7 @@ def CoLA(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/conll2000chunking.py
+++ b/torchtext/datasets/conll2000chunking.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/conll2000chunking.py
+++ b/torchtext/datasets/conll2000chunking.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -68,6 +68,7 @@ def CoNLL2000Chunking(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL[split]])
 

--- a/torchtext/datasets/conll2000chunking.py
+++ b/torchtext/datasets/conll2000chunking.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/dbpedia.py
+++ b/torchtext/datasets/dbpedia.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/dbpedia.py
+++ b/torchtext/datasets/dbpedia.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/dbpedia.py
+++ b/torchtext/datasets/dbpedia.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -75,6 +75,7 @@ def DBpedia(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/enwik9.py
+++ b/torchtext/datasets/enwik9.py
@@ -1,7 +1,7 @@
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory

--- a/torchtext/datasets/enwik9.py
+++ b/torchtext/datasets/enwik9.py
@@ -1,8 +1,6 @@
 import os
 from functools import partial
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory
 

--- a/torchtext/datasets/enwik9.py
+++ b/torchtext/datasets/enwik9.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory
 
@@ -50,6 +50,7 @@ def EnWik9(root: str):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Tuple, Union
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory
 from torchtext.data.datasets_utils import _wrap_split_argument
@@ -89,6 +89,7 @@ def IMDB(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
 

--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -3,7 +3,7 @@ from functools import partial
 from pathlib import Path
 from typing import Tuple, Union
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory

--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -3,8 +3,6 @@ from functools import partial
 from pathlib import Path
 from typing import Tuple, Union
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory
 from torchtext.data.datasets_utils import _wrap_split_argument

--- a/torchtext/datasets/iwslt2016.py
+++ b/torchtext/datasets/iwslt2016.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _clean_files,
@@ -219,6 +219,7 @@ def IWSLT2016(
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     if not isinstance(language_pair, list) and not isinstance(language_pair, tuple):
         raise ValueError("language_pair must be list or tuple but got {} instead".format(type(language_pair)))

--- a/torchtext/datasets/iwslt2016.py
+++ b/torchtext/datasets/iwslt2016.py
@@ -1,8 +1,6 @@
 import os
 from functools import partial
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _clean_files,

--- a/torchtext/datasets/iwslt2016.py
+++ b/torchtext/datasets/iwslt2016.py
@@ -1,7 +1,7 @@
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/iwslt2017.py
+++ b/torchtext/datasets/iwslt2017.py
@@ -1,8 +1,6 @@
 import os
 from functools import partial
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _clean_files,

--- a/torchtext/datasets/iwslt2017.py
+++ b/torchtext/datasets/iwslt2017.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _clean_files,
@@ -184,6 +184,7 @@ def IWSLT2017(root=".data", split=("train", "valid", "test"), language_pair=("de
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     valid_set = "dev2010"
     test_set = "tst2010"

--- a/torchtext/datasets/iwslt2017.py
+++ b/torchtext/datasets/iwslt2017.py
@@ -1,7 +1,7 @@
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/mnli.py
+++ b/torchtext/datasets/mnli.py
@@ -3,7 +3,7 @@ import csv
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook

--- a/torchtext/datasets/mnli.py
+++ b/torchtext/datasets/mnli.py
@@ -3,8 +3,6 @@ import csv
 import os
 from functools import partial
 
-
-
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
 

--- a/torchtext/datasets/mnli.py
+++ b/torchtext/datasets/mnli.py
@@ -7,7 +7,7 @@ from functools import partial
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,
@@ -89,6 +89,7 @@ def MNLI(root, split):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/mrpc.py
+++ b/torchtext/datasets/mrpc.py
@@ -3,7 +3,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, HttpReader, IterableWrapper
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -67,6 +66,7 @@ def MRPC(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL[split]])
     # cache data on-disk with sanity check

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader  # noqa
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -2,8 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-  # noqa
+# noqa
 
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/multi30k.py
+++ b/torchtext/datasets/multi30k.py
@@ -3,8 +3,8 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader  # noqa
-from torchtext._download_hooks import HttpReader
+  # noqa
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -89,6 +89,7 @@ def Multi30k(root: str, split: Union[Tuple[str], str], language_pair: Tuple[str]
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL[split]])
 

--- a/torchtext/datasets/penntreebank.py
+++ b/torchtext/datasets/penntreebank.py
@@ -3,8 +3,8 @@ from functools import partial
 from typing import Tuple, Union
 
 
-from torchtext._download_hooks import GDriveReader  # noqa
-from torchtext._download_hooks import HttpReader
+  # noqa
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -70,6 +70,7 @@ def PennTreebank(root, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL[split]])
     cache_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/penntreebank.py
+++ b/torchtext/datasets/penntreebank.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Tuple, Union
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader  # noqa
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available

--- a/torchtext/datasets/penntreebank.py
+++ b/torchtext/datasets/penntreebank.py
@@ -2,8 +2,7 @@ import os
 from functools import partial
 from typing import Tuple, Union
 
-
-  # noqa
+# noqa
 
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/qnli.py
+++ b/torchtext/datasets/qnli.py
@@ -3,7 +3,7 @@ import csv
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook

--- a/torchtext/datasets/qnli.py
+++ b/torchtext/datasets/qnli.py
@@ -3,8 +3,6 @@ import csv
 import os
 from functools import partial
 
-
-
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
 

--- a/torchtext/datasets/qnli.py
+++ b/torchtext/datasets/qnli.py
@@ -7,7 +7,7 @@ from functools import partial
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,
@@ -81,6 +81,7 @@ def QNLI(root, split):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at `https://github.com/pytorch/data`"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/qqp.py
+++ b/torchtext/datasets/qqp.py
@@ -1,7 +1,7 @@
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory

--- a/torchtext/datasets/qqp.py
+++ b/torchtext/datasets/qqp.py
@@ -1,8 +1,6 @@
 import os
 from functools import partial
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory
 

--- a/torchtext/datasets/qqp.py
+++ b/torchtext/datasets/qqp.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import _create_dataset_directory
 
@@ -48,6 +48,7 @@ def QQP(root: str):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/rte.py
+++ b/torchtext/datasets/rte.py
@@ -3,7 +3,7 @@ import csv
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook

--- a/torchtext/datasets/rte.py
+++ b/torchtext/datasets/rte.py
@@ -7,7 +7,7 @@ from functools import partial
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,
@@ -81,6 +81,7 @@ def RTE(root, split):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at `https://github.com/pytorch/data`"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/rte.py
+++ b/torchtext/datasets/rte.py
@@ -3,8 +3,6 @@ import csv
 import os
 from functools import partial
 
-
-
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
 

--- a/torchtext/datasets/sogounews.py
+++ b/torchtext/datasets/sogounews.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/sogounews.py
+++ b/torchtext/datasets/sogounews.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/sogounews.py
+++ b/torchtext/datasets/sogounews.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -79,6 +79,7 @@ def SogouNews(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/squad1.py
+++ b/torchtext/datasets/squad1.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -62,6 +62,8 @@ def SQuAD1(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
+
 
     url_dp = IterableWrapper([URL[split]])
     # cache data on-disk with sanity check

--- a/torchtext/datasets/squad1.py
+++ b/torchtext/datasets/squad1.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/squad1.py
+++ b/torchtext/datasets/squad1.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -63,7 +61,6 @@ def SQuAD1(root: str, split: Union[Tuple[str], str]):
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
     from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
-
 
     url_dp = IterableWrapper([URL[split]])
     # cache data on-disk with sanity check

--- a/torchtext/datasets/squad2.py
+++ b/torchtext/datasets/squad2.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/squad2.py
+++ b/torchtext/datasets/squad2.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/squad2.py
+++ b/torchtext/datasets/squad2.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -63,6 +63,7 @@ def SQuAD2(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL[split]])
     # cache data on-disk with sanity check

--- a/torchtext/datasets/sst2.py
+++ b/torchtext/datasets/sst2.py
@@ -2,7 +2,7 @@
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook

--- a/torchtext/datasets/sst2.py
+++ b/torchtext/datasets/sst2.py
@@ -2,8 +2,6 @@
 import os
 from functools import partial
 
-
-
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
 

--- a/torchtext/datasets/sst2.py
+++ b/torchtext/datasets/sst2.py
@@ -6,7 +6,7 @@ from functools import partial
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,
@@ -86,6 +86,7 @@ def SST2(root, split):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/stsb.py
+++ b/torchtext/datasets/stsb.py
@@ -2,8 +2,6 @@ import csv
 import os
 from functools import partial
 
-
-
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
 
@@ -83,7 +81,6 @@ def STSB(root, split):
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
     from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
-
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/stsb.py
+++ b/torchtext/datasets/stsb.py
@@ -2,7 +2,7 @@ import csv
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook

--- a/torchtext/datasets/stsb.py
+++ b/torchtext/datasets/stsb.py
@@ -6,7 +6,7 @@ from functools import partial
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,
@@ -82,6 +82,8 @@ def STSB(root, split):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
+
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/udpos.py
+++ b/torchtext/datasets/udpos.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/udpos.py
+++ b/torchtext/datasets/udpos.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -66,6 +66,7 @@ def UDPOS(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/udpos.py
+++ b/torchtext/datasets/udpos.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/wikitext103.py
+++ b/torchtext/datasets/wikitext103.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -72,7 +70,6 @@ def WikiText103(root: str, split: Union[Tuple[str], str]):
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
     from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
-
 
     url_dp = IterableWrapper([URL])
     # cache data on-disk

--- a/torchtext/datasets/wikitext103.py
+++ b/torchtext/datasets/wikitext103.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/wikitext103.py
+++ b/torchtext/datasets/wikitext103.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -71,6 +71,8 @@ def WikiText103(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
+
 
     url_dp = IterableWrapper([URL])
     # cache data on-disk

--- a/torchtext/datasets/wikitext2.py
+++ b/torchtext/datasets/wikitext2.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/wikitext2.py
+++ b/torchtext/datasets/wikitext2.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import HttpReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/wikitext2.py
+++ b/torchtext/datasets/wikitext2.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -71,6 +71,7 @@ def WikiText2(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     # cache data on-disk

--- a/torchtext/datasets/wnli.py
+++ b/torchtext/datasets/wnli.py
@@ -6,7 +6,7 @@ from functools import partial
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
-from torchtext._download_hooks import HttpReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _create_dataset_directory,
@@ -78,6 +78,7 @@ def WNLI(root, split):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at `https://github.com/pytorch/data`"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
     cache_compressed_dp = url_dp.on_disk_cache(

--- a/torchtext/datasets/wnli.py
+++ b/torchtext/datasets/wnli.py
@@ -2,7 +2,7 @@
 import os
 from functools import partial
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook

--- a/torchtext/datasets/wnli.py
+++ b/torchtext/datasets/wnli.py
@@ -2,8 +2,6 @@
 import os
 from functools import partial
 
-
-
 # we import HttpReader from _download_hooks so we can swap out public URLs
 # with interal URLs when the dataset is used within Facebook
 

--- a/torchtext/datasets/yahooanswers.py
+++ b/torchtext/datasets/yahooanswers.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/yahooanswers.py
+++ b/torchtext/datasets/yahooanswers.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/yahooanswers.py
+++ b/torchtext/datasets/yahooanswers.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -75,6 +75,7 @@ def YahooAnswers(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
 

--- a/torchtext/datasets/yelpreviewfull.py
+++ b/torchtext/datasets/yelpreviewfull.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/yelpreviewfull.py
+++ b/torchtext/datasets/yelpreviewfull.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/yelpreviewfull.py
+++ b/torchtext/datasets/yelpreviewfull.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -74,6 +74,7 @@ def YelpReviewFull(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
 

--- a/torchtext/datasets/yelpreviewpolarity.py
+++ b/torchtext/datasets/yelpreviewpolarity.py
@@ -2,8 +2,6 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-
-
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,

--- a/torchtext/datasets/yelpreviewpolarity.py
+++ b/torchtext/datasets/yelpreviewpolarity.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Union, Tuple
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper
+
 from torchtext._download_hooks import GDriveReader
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (

--- a/torchtext/datasets/yelpreviewpolarity.py
+++ b/torchtext/datasets/yelpreviewpolarity.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Union, Tuple
 
 
-from torchtext._download_hooks import GDriveReader
+
 from torchtext._internal.module_utils import is_module_available
 from torchtext.data.datasets_utils import (
     _wrap_split_argument,
@@ -74,6 +74,7 @@ def YelpReviewPolarity(root: str, split: Union[Tuple[str], str]):
         raise ModuleNotFoundError(
             "Package `torchdata` not found. Please install following instructions at https://github.com/pytorch/data"
         )
+    from torchdata.datapipes.iter import FileOpener, GDriveReader, HttpReader, IterableWrapper  # noqa
 
     url_dp = IterableWrapper([URL])
 


### PR DESCRIPTION
This PR moves all the torchdata imports as lazy imports to avoid import error when torchdata is not present.


Smoke test is passing when torchdata is not present:

```
(text) ➜  text git:(lajenflajenfljanefljanefljajnef) ✗ python -c "import torchdata"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'torchdata'


(text) ➜  text git:(lajenflajenfljanefljanefljajnef) ✗ python test/smoke_tests/smoke_tests.py
torchtext version is  0.17.0a0+51f373d
```