### PR TITLE
Add NPU test case

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ testpaths = test/
 python_paths = ./
 markers =
     gpu_test: marks cuda tests
+    npu_test: marks ascend npu tests

--- a/test/torchtext_unittest/models/npu_tests/models_npu_test.py
+++ b/test/torchtext_unittest/models/npu_tests/models_npu_test.py
@@ -1,0 +1,33 @@
+import importlib
+import unittest
+
+import pytest
+import torch
+from torchtext_unittest.common.torchtext_test_case import TorchtextTestCase
+from torchtext_unittest.models.roberta_models_test_impl import RobertaBaseTestModels
+from torchtext_unittest.models.t5_models_test_impl import T5BaseTestModels
+
+
+def is_npu_available(check_device=False):
+    "Checks if `torch_npu` is installed and potentially if a NPU is in the environment"
+    if importlib.util.find_spec("torch") is None or importlib.util.find_spec("torch_npu") is None:
+        return False
+
+    import torch
+    import torch_npu  # noqa: F401
+
+    if check_device:
+        try:
+            # Will raise a RuntimeError if no NPU is found
+            _ = torch.npu.device_count()
+            return torch.npu.is_available()
+        except RuntimeError:
+            return False
+    return hasattr(torch, "npu") and torch.npu.is_available()
+ 
+
+@pytest.mark.npu_test
+@unittest.skipIf(not is_npu_available(), reason="Ascend NPU is not available")
+class TestModels32NPU(RobertaBaseTestModels, T5BaseTestModels, TorchtextTestCase):
+    dtype = torch.float32
+    device = torch.device("npu")


### PR DESCRIPTION
In order to use torchtext with `NPU` backend, i've run example and unit test cases. All test cases can be work fine but gpu tests are skipped.
This PR adds `npu model tests` following the #2025, which could help us test the availability of NPU.

Results of unit testing and text_classfication example, verified on NPU,

<img width="522" alt="image" src="https://github.com/pytorch/text/assets/25071151/504e31fc-3c15-4b81-90ed-51938c03e638">
<img width="522" alt="image" src=https://github.com/pytorch/text/assets/25071151/612c0063-2886-4333-a0f6-e5c498b6099b">
<img width="583" alt="image" src="https://github.com/pytorch/text/assets/25071151/d9156399-9797-4e6f-aafe-ebdd9d240a28">

![image](https://github.com/pytorch/text/assets/25071151/0100e194-b165-4af0-a8a7-643648d582fb)

