### PR TITLE
facebook-unused-include-check in fbcode/pytorch

### DIFF
--- a/torchtext/csrc/vocab.cpp
+++ b/torchtext/csrc/vocab.cpp
@@ -4,7 +4,6 @@
 #include <torchtext/csrc/vocab.h> // @manual
 
 #include <iostream>
-#include <stdexcept>
 #include <string>
 namespace torchtext {
 

--- a/torchtext/csrc/vocab_factory.cpp
+++ b/torchtext/csrc/vocab_factory.cpp
@@ -6,7 +6,6 @@
 #include <torchtext/csrc/vocab_factory.h> // @manual
 
 #include <fstream>
-#include <stdexcept>
 #include <string>
 
 namespace torchtext {


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/vision/pull/8919

Remove headers flagged by facebook-unused-include-check over fbcode.pytorch.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uip
Autodiff partition: fbcode.pytorch
Autodiff bookmark: ad.uip.fbcode.pytorch

Reviewed By: dtolnay

Differential Revision: D69621180


