### PR TITLE
[torchtext/csrc/bert_tokenizer.h] : fix compilation on Xcode 16.3

### DIFF
--- a/torchtext/csrc/bert_tokenizer.h
+++ b/torchtext/csrc/bert_tokenizer.h
@@ -5,7 +5,7 @@
 
 namespace torchtext {
 
-typedef std::basic_string<uint32_t> UString;
+typedef std::u32string UString;
 typedef ska_ordered::order_preserving_flat_hash_map<std::string, int64_t>
     IndexDict;
 


### PR DESCRIPTION
Recent version of xcode complaints with:
```
error: implicit instantiation of undefined template 'std::char_traits<unsigned int>'
```

std::u32string is c++11 and should be equivalent.