### PR TITLE
Update runner type to macos-14 in workflow

### DIFF
--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -48,5 +48,5 @@ jobs:
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
-      runner-type: macos-m1-stable
+      runner-type: macos-14
       trigger-event: ${{ github.event_name }}


### PR DESCRIPTION
Removing dependency on self-hosted macOS runners, in prep for migration to meta-pytorch org

Note: As per the readme, this repo has officially ceased development and the job has been failing for many months already.  I'll merge this PR as is but then disable all the nightly build workflows since it doesn't make sense to pay for all that CI for a unmaintained repo